### PR TITLE
add optional configuration to facet charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/isomorphic-fetch": "^0.0.35",
+        "@types/plotly.js": "^1.54.14",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "@typescript-eslint/parser": "^4.28.3",
         "eslint": "^7.30.0",
@@ -627,6 +628,17 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@choojs/findup": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "dependencies": {
+        "commander": "^2.15.1"
+      },
+      "bin": {
+        "findup": "bin/findup.js"
+      }
     },
     "node_modules/@emotion/cache": {
       "version": "11.4.0",
@@ -2513,6 +2525,70 @@
         "node": ">= 10.18.0"
       }
     },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
+      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "peerDependencies": {
+        "mapbox-gl": ">=0.32.1 <2.0.0"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2849,6 +2925,57 @@
         "@octokit/openapi-types": "^9.0.0"
       }
     },
+    "node_modules/@plotly/d3": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.0.tgz",
+      "integrity": "sha512-L10iHgzvw3uSic/nQpYehlNzxUQvImwms5U7S95pJAEhrllzkrdQNy1Mc5DW9ab881Yr4fh300gJztKXWZDfkQ=="
+    },
+    "node_modules/@plotly/d3-sankey": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
+      "dependencies": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/@plotly/d3-sankey-circular": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "dependencies": {
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "node_modules/@plotly/point-cluster": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
+      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "binary-search-bounds": "^2.0.4",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
+      }
+    },
+    "node_modules/@plotly/point-cluster/node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.0.tgz",
@@ -2946,6 +3073,61 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
+      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
@@ -2992,6 +3174,12 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/d3": {
+      "version": "3.5.45",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.45.tgz",
+      "integrity": "sha512-wLICfMtjDEoAJie1MF6OuksAzOapRXgJy+l5HQVpyC1yMAlvHz2QKrrasUHru8xD6cbgQNGeO+CeyjOlKtly2A==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -3130,6 +3318,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "node_modules/@types/plotly.js": {
+      "version": "1.54.14",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-1.54.14.tgz",
+      "integrity": "sha512-vYevenBloZ3B4i831i+ccS9u782JSnkJpBG/c/qPRJNDW6s25udnrmoHkFhbBl7jkzBy8pO2lPNhpMrQJV7ETA==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3": "^3"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.3.1",
@@ -3447,6 +3644,26 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/3d-view": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
+      "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
+      "dependencies": {
+        "matrix-camera-controller": "^2.1.1",
+        "orbit-camera-controller": "^4.0.0",
+        "turntable-camera-controller": "^3.0.0"
+      }
+    },
+    "node_modules/a-big-triangle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
+      "integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
+      "dependencies": {
+        "gl-buffer": "^2.1.1",
+        "gl-vao": "^1.2.0",
+        "weak-map": "^1.0.5"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -3458,6 +3675,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha1-32Acjo0roQ1KdtYl4japo5wnI78="
     },
     "node_modules/acorn": {
       "version": "8.4.1",
@@ -3531,11 +3753,27 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/add-line-numbers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
+      "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
+      "dependencies": {
+        "pad-left": "^1.0.2"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
+    },
+    "node_modules/affine-hull": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
+      "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
+      "dependencies": {
+        "robust-orientation": "^1.1.3"
+      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -3590,6 +3828,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/almost-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
+      "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
+    },
+    "node_modules/alpha-complex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
+      "integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
+      "dependencies": {
+        "circumradius": "^1.0.0",
+        "delaunay-triangulate": "^1.1.6"
+      }
+    },
+    "node_modules/alpha-shape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
+      "integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
+      "dependencies": {
+        "alpha-complex": "^1.0.0",
+        "simplicial-complex-boundary": "^1.0.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -3718,6 +3979,19 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-bounds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
+      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
+    },
     "node_modules/array-differ": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
@@ -3725,6 +3999,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/array-ify": {
@@ -3751,6 +4033,24 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-normalize": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
+      "dependencies": {
+        "array-bounds": "^1.0.0"
+      }
+    },
+    "node_modules/array-range": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
+      "integrity": "sha1-9W5GWRhDYRxqVvd+8C7afFAIm/w="
+    },
+    "node_modules/array-rearrange": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
+      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -3873,6 +4173,11 @@
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/atob-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
+      "integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs="
     },
     "node_modules/autoprefixer": {
       "version": "10.3.1",
@@ -4038,6 +4343,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/barycentric": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
+      "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
+      "dependencies": {
+        "robust-linear-solve": "^1.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4072,6 +4385,21 @@
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
+    "node_modules/big-rat": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
+      "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
+      "dependencies": {
+        "bit-twiddle": "^1.0.2",
+        "bn.js": "^4.11.6",
+        "double-bits": "^1.1.1"
+      }
+    },
+    "node_modules/big-rat/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4080,10 +4408,73 @@
         "node": ">=8"
       }
     },
+    "node_modules/binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
+    },
+    "node_modules/bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+    },
+    "node_modules/bitmap-sdf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
+      "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
+      "dependencies": {
+        "clamp": "^1.0.1"
+      }
+    },
+    "node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+    },
+    "node_modules/boundary-cells": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.2.tgz",
+      "integrity": "sha512-/S48oUFYEgZMNvdqC87iYRbLBAPHYijPRNrNpm/sS8u7ijIViKm/hrV3YD4sx/W68AsG5zLMyBEditVHApHU5w=="
+    },
+    "node_modules/box-intersect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
+      "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4166,8 +4557,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
@@ -4306,11 +4696,34 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/canvas-fit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
+      "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
+      "dependencies": {
+        "element-size": "^1.1.1"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
+    },
+    "node_modules/cdt2d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
+      "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.3",
+        "robust-in-sphere": "^1.1.3",
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "node_modules/cell-orientation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cell-orientation/-/cell-orientation-1.0.1.tgz",
+      "integrity": "sha1-tQStlqZq0obZ7dmFoiU9A7gNKFA="
     },
     "node_modules/chalk": {
       "version": "4.1.1",
@@ -4377,16 +4790,52 @@
       "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
       "dev": true
     },
+    "node_modules/circumcenter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
+      "integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
+      "dependencies": {
+        "dup": "^1.0.0",
+        "robust-linear-solve": "^1.0.0"
+      }
+    },
+    "node_modules/circumradius": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
+      "integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
+      "dependencies": {
+        "circumcenter": "^1.0.0"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
       "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
       "dev": true
     },
+    "node_modules/clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+    },
     "node_modules/classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "node_modules/clean-pslg": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
+      "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
+      "dependencies": {
+        "big-rat": "^1.0.3",
+        "box-intersect": "^1.0.1",
+        "nextafter": "^1.0.0",
+        "rat-vec": "^1.1.1",
+        "robust-segment-intersect": "^1.0.1",
+        "union-find": "^1.0.2",
+        "uniq": "^1.0.1"
+      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -4515,6 +4964,14 @@
         "color-string": "^1.5.4"
       }
     },
+    "node_modules/color-alpha": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
+      "dependencies": {
+        "color-parse": "^1.3.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4526,10 +4983,57 @@
         "node": ">=7.0.0"
       }
     },
+    "node_modules/color-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
+      "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
+      "dependencies": {
+        "clamp": "^1.0.1"
+      }
+    },
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-normalize": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
+      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
+      "dependencies": {
+        "clamp": "^1.0.1",
+        "color-rgba": "^2.1.1",
+        "dtype": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "defined": "^1.0.0",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "node_modules/color-rgba": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
+      "dependencies": {
+        "clamp": "^1.0.1",
+        "color-parse": "^1.3.8",
+        "color-space": "^1.14.6"
+      }
+    },
+    "node_modules/color-space": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
+      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
+      "dependencies": {
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
+      }
     },
     "node_modules/color-string": {
       "version": "1.5.5",
@@ -4557,6 +5061,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+    },
+    "node_modules/colormap": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.2.tgz",
+      "integrity": "sha512-jDOjaoEEmA9AgA11B/jCSAvYE95r3wRoAyTf3LEHGiUVlNHJaL1mRkf5AyLSpQBVGfTEPwGEqCIzL+kgr2WgNA==",
+      "dependencies": {
+        "lerp": "^1.0.3"
+      }
     },
     "node_modules/columnify": {
       "version": "1.5.4",
@@ -4604,8 +5116,29 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/compare-angle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
+      "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
+      "dependencies": {
+        "robust-orientation": "^1.0.2",
+        "robust-product": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "signum": "^0.0.0",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "node_modules/compare-angle/node_modules/signum": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-0.0.0.tgz",
+      "integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY="
+    },
+    "node_modules/compare-cell": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/compare-cell/-/compare-cell-1.0.0.tgz",
+      "integrity": "sha1-qetwj24OQa73qlZrEw8ZaNyeGqo="
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -4627,6 +5160,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/compare-oriented-cell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
+      "integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
+      "dependencies": {
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0"
+      }
+    },
+    "node_modules/compute-dims": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
+      "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
+      "dependencies": {
+        "utils-copy": "^1.0.0",
+        "validate.io-array": "^1.0.6",
+        "validate.io-matrix-like": "^1.0.2",
+        "validate.io-ndarray-like": "^1.0.0",
+        "validate.io-positive-integer": "^1.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -4664,6 +5218,16 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
+    },
+    "node_modules/const-max-uint32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
+      "integrity": "sha1-8Am7YjDmeO2HTdLWqc2ePL+rtnY="
+    },
+    "node_modules/const-pinf-float64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
+      "integrity": "sha1-9u+w15+cCYbT558pI6v5twtj1yY="
     },
     "node_modules/conventional-changelog-angular": {
       "version": "5.0.12",
@@ -4799,6 +5363,16 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/convex-hull": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
+      "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
+      "dependencies": {
+        "affine-hull": "^1.0.0",
+        "incremental-convex-hull": "^1.0.1",
+        "monotone-convex-hull-2d": "^1.0.1"
+      }
+    },
     "node_modules/core-js-pure": {
       "version": "3.15.2",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.2.tgz",
@@ -4813,8 +5387,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.0",
@@ -4831,6 +5404,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/country-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
+      "integrity": "sha1-UcMz3N8Sknt+XuucEKyBEqYSCJY="
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4845,10 +5423,61 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-font": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
+      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+      "dependencies": {
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
+      }
+    },
+    "node_modules/css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss="
+    },
+    "node_modules/css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA="
+    },
+    "node_modules/css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ="
+    },
+    "node_modules/css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc="
+    },
+    "node_modules/css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk="
+    },
+    "node_modules/css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0="
+    },
     "node_modules/css-unit-converter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
       "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -4889,6 +5518,139 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+    },
+    "node_modules/cubic-hermite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cubic-hermite/-/cubic-hermite-1.0.0.tgz",
+      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU="
+    },
+    "node_modules/cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "node_modules/d3-force": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "dependencies": {
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/d3-geo": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
+      "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
+      "dependencies": {
+        "commander": "2",
+        "d3-array": "1",
+        "d3-geo": "^1.12.0",
+        "resolve": "^1.1.10"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg",
+        "geograticule": "bin/geograticule",
+        "geoproject": "bin/geoproject",
+        "geoquantize": "bin/geoquantize",
+        "geostitch": "bin/geostitch"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
+    "node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/d3-quadtree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.7",
@@ -5021,8 +5783,7 @@
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -5071,6 +5832,15 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
+    "node_modules/delaunay-triangulate": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
+      "integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
+      "dependencies": {
+        "incremental-convex-hull": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5109,6 +5879,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-kerning": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -5250,11 +6025,76 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/double-bits": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
+      "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
+    },
+    "node_modules/draw-svg-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
+      "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
+      "dependencies": {
+        "abs-svg-path": "~0.1.1",
+        "normalize-svg-path": "~0.1.0"
+      }
+    },
+    "node_modules/dtype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
+      "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
+    },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -5266,10 +6106,31 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/edges-to-adjacency-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
+      "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.766",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
       "integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w=="
+    },
+    "node_modules/element-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
+      "integrity": "sha1-ZOXxWdlxIWMYRby67K8nnDm1404="
+    },
+    "node_modules/elementary-circuits-directed-graph": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
+      "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
+      "dependencies": {
+        "strongly-connected-components": "^1.0.1"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -5310,6 +6171,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -5404,10 +6273,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dependencies": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/es6-object-assign": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5807,7 +6716,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -5862,6 +6770,14 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -5929,6 +6845,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dependencies": {
+        "type": "^2.0.0"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+      "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5974,6 +6903,11 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/extract-frustum-planes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extract-frustum-planes/-/extract-frustum-planes-1.0.0.tgz",
+      "integrity": "sha1-l9VwP/BWTIw8aDjKxF+ee8UsnvU="
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -5982,6 +6916,36 @@
       "engines": [
         "node >=0.6.0"
       ]
+    },
+    "node_modules/falafel": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
+      "integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "foreach": "^2.0.5",
+        "isarray": "^2.0.1",
+        "object-keys": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/falafel/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/falafel/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6004,6 +6968,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/fast-isnumeric": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
+      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
+      "dependencies": {
+        "is-string-blank": "^1.0.1"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6013,8 +6985,7 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fastq": {
       "version": "1.11.1",
@@ -6089,6 +7060,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/filtered-vector": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.5.tgz",
+      "integrity": "sha512-5Vu6wdtQJ1O2nRmz39dIr9m3hEDq1skYby5k1cJQdNWK4dMgvYcUEiA/9j7NcKfNZ5LGxn8w2LSLiigyH7pTAw==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0",
+        "cubic-hermite": "^1.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -6119,6 +7099,35 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
       "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
+    },
+    "node_modules/flatten-vertex-data": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
+      "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
+      "dependencies": {
+        "dtype": "^2.0.0"
+      }
+    },
+    "node_modules/flip-pixels": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flip-pixels/-/flip-pixels-1.0.2.tgz",
+      "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA=="
+    },
+    "node_modules/font-atlas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
+      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
+      "dependencies": {
+        "css-font": "^1.0.0"
+      }
+    },
+    "node_modules/font-measure": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
+      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
+      "dependencies": {
+        "css-font": "^1.2.0"
+      }
     },
     "node_modules/foreach": {
       "version": "2.0.5",
@@ -6158,6 +7167,37 @@
       "funding": {
         "type": "patreon",
         "url": "https://www.patreon.com/infusion"
+      }
+    },
+    "node_modules/from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "node_modules/from2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/from2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fs-extra": {
@@ -6219,8 +7259,12 @@
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "node_modules/gamma": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
+      "integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA="
     },
     "node_modules/gauge": {
       "version": "2.7.4",
@@ -6300,6 +7344,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6308,6 +7357,11 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/get-canvas-context": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
+      "integrity": "sha1-1ue1C8TkyGNXzTnyJkeoS3NgHpM="
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
@@ -6526,7 +7580,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6637,6 +7690,392 @@
         "ini": "^1.3.2"
       }
     },
+    "node_modules/gl-axes3d": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.5.3.tgz",
+      "integrity": "sha512-KRYbguKQcDQ6PcB9g1pgqB8Ly4TY1DQODpPKiDTasyWJ8PxQk0t2Q7XoQQijNqvsguITCpVVCzNb5GVtIWiVlQ==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.2",
+        "dup": "^1.0.0",
+        "extract-frustum-planes": "^1.0.0",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-state": "^1.0.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec4": "^1.0.1",
+        "glslify": "^7.0.0",
+        "robust-orientation": "^1.1.3",
+        "split-polygon": "^1.0.0",
+        "vectorize-text": "^3.2.1"
+      }
+    },
+    "node_modules/gl-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
+      "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
+      "dependencies": {
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.1.0",
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "node_modules/gl-cone3d": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/gl-cone3d/-/gl-cone3d-1.5.2.tgz",
+      "integrity": "sha512-1JNeHH4sUtUmDA4ZK7Om8/kShwb8IZVAsnxaaB7IPRJsNGciLj1sTpODrJGeMl41RNkex5kXD2SQFrzyEAR2Rw==",
+      "dependencies": {
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec3": "^1.1.3",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
+      }
+    },
+    "node_modules/gl-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-constants/-/gl-constants-1.0.0.tgz",
+      "integrity": "sha1-WXpQTjZHUP9QJTqjX43qevSl0jM="
+    },
+    "node_modules/gl-error3d": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.16.tgz",
+      "integrity": "sha512-TGJewnKSp7ZnqGgG3XCF9ldrDbxZrO+OWlx6oIet4OdOM//n8xJ5isArnIV/sdPJnFbhfoLxWrW9f5fxHFRQ1A==",
+      "dependencies": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0"
+      }
+    },
+    "node_modules/gl-fbo": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
+      "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
+      "dependencies": {
+        "gl-texture2d": "^2.0.0"
+      }
+    },
+    "node_modules/gl-format-compiler-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
+      "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
+      "dependencies": {
+        "add-line-numbers": "^1.0.1",
+        "gl-constants": "^1.0.0",
+        "glsl-shader-name": "^1.0.0",
+        "sprintf-js": "^1.0.3"
+      }
+    },
+    "node_modules/gl-heatmap2d": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.1.1.tgz",
+      "integrity": "sha512-6Vo1fPIB1vQFWBA/MR6JAA16XuQuhwvZRbSjYEq++m4QV33iqjGS2HcVIRfJGX+fomd5eiz6bwkVZcKm69zQPw==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "typedarray-pool": "^1.2.0"
+      }
+    },
+    "node_modules/gl-line3d": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.2.1.tgz",
+      "integrity": "sha512-eeb0+RI2ZBRqMYJK85SgsRiJK7c4aiOjcnirxv0830A3jmOc99snY3AbPcV8KvKmW0Yaf3KA4e+qNCbHiTOTnA==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
+      }
+    },
+    "node_modules/gl-mat3": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
+      "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+    },
+    "node_modules/gl-mat4": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
+      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
+    },
+    "node_modules/gl-mesh3d": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.3.1.tgz",
+      "integrity": "sha512-pXECamyGgu4/9HeAQSE5OEUuLBGS1aq9V4BCsTcxsND4fNLaajEkYKUz/WY2QSYElqKdsMBVsldGiKRKwlybqA==",
+      "dependencies": {
+        "barycentric": "^1.0.1",
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18",
+        "normals": "^1.1.0",
+        "polytope-closest-point": "^1.0.0",
+        "simplicial-complex-contour": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-plot2d": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.5.tgz",
+      "integrity": "sha512-6GmCN10SWtV+qHFQ1gjdnVubeHFVsm6P4zmo0HrPIl9TcdePCUHDlBKWAuE6XtFhiMKMj7R8rApOX8O8uXUYog==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-select-static": "^2.0.7",
+        "gl-shader": "^4.2.1",
+        "glsl-inverse": "^1.0.0",
+        "glslify": "^7.0.0",
+        "text-cache": "^4.2.2"
+      }
+    },
+    "node_modules/gl-plot3d": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.7.tgz",
+      "integrity": "sha512-mLDVWrl4Dj0O0druWyHUK5l7cBQrRIJRn2oROEgrRuOgbbrLAzsREKefwMO0bA0YqkiZMFMnV5VvPA9j57X5Xg==",
+      "dependencies": {
+        "3d-view": "^2.0.0",
+        "a-big-triangle": "^1.0.3",
+        "gl-axes3d": "^1.5.3",
+        "gl-fbo": "^2.0.5",
+        "gl-mat4": "^1.2.0",
+        "gl-select-static": "^2.0.7",
+        "gl-shader": "^4.2.1",
+        "gl-spikes3d": "^1.0.10",
+        "glslify": "^7.0.0",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.1",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.19",
+        "right-now": "^1.0.0"
+      }
+    },
+    "node_modules/gl-pointcloud2d": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.3.tgz",
+      "integrity": "sha512-OS2e1irvJXVRpg/GziXj10xrFJm9kkRfFoB6BLUvkjCQV7ZRNNcs2CD+YSK1r0gvMwTg2T3lfLM3UPwNtz+4Xw==",
+      "dependencies": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-quat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
+      "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
+      "dependencies": {
+        "gl-mat3": "^1.0.0",
+        "gl-vec3": "^1.0.3",
+        "gl-vec4": "^1.0.0"
+      }
+    },
+    "node_modules/gl-scatter3d": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.2.3.tgz",
+      "integrity": "sha512-nXqPlT1w5Qt51dTksj+DUqrZqwWAEWg0PocsKcoDnVNv0X8sGA+LBZ0Y+zrA+KNXUL0PPCX9WR9cF2uJAZl1Sw==",
+      "dependencies": {
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
+        "is-string-blank": "^1.0.1",
+        "typedarray-pool": "^1.1.0",
+        "vectorize-text": "^3.2.1"
+      }
+    },
+    "node_modules/gl-select-box": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.4.tgz",
+      "integrity": "sha512-mKsCnglraSKyBbQiGq0Ila0WF+m6Tr+EWT2yfaMn/Sh9aMHq5Wt0F/l6Cf/Ed3CdERq5jHWAY5yxLviZteYu2w==",
+      "dependencies": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0"
+      }
+    },
+    "node_modules/gl-select-static": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.7.tgz",
+      "integrity": "sha512-OvpYprd+ngl3liEatBTdXhSyNBjwvjMSvV2rN0KHpTU+BTi4viEETXNZXFgGXY37qARs0L28ybk3UQEW6C5Nnw==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.2",
+        "gl-fbo": "^2.0.5",
+        "ndarray": "^1.0.18",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-shader": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.3.1.tgz",
+      "integrity": "sha512-xLoN6XtRLlg97SEqtuzfKc+pVWpVkQ3YjDI1kuCale8tF7+zMhiKlMfmG4IMQPMdKJZQbIc/Ny8ZusEpfh5U+w==",
+      "dependencies": {
+        "gl-format-compiler-error": "^1.0.2",
+        "weakmap-shim": "^1.1.0"
+      }
+    },
+    "node_modules/gl-spikes2d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.2.tgz",
+      "integrity": "sha512-QVeOZsi9nQuJJl7NB3132CCv5KA10BWxAY2QgJNsKqbLsG53B/TrGJpjIAohnJftdZ4fT6b3ZojWgeaXk8bOOA=="
+    },
+    "node_modules/gl-spikes3d": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.10.tgz",
+      "integrity": "sha512-lT3xroowOFxMvlhT5Mof76B2TE02l5zt/NIWljhczV2FFHgIVhA4jMrd5dIv1so1RXMBDJIKu0uJI3QKliDVLg==",
+      "dependencies": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glslify": "^7.0.0"
+      }
+    },
+    "node_modules/gl-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
+      "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "node_modules/gl-streamtube3d": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/gl-streamtube3d/-/gl-streamtube3d-1.4.1.tgz",
+      "integrity": "sha512-rH02v00kgwgdpkXVo7KsSoPp38bIAYR9TE1iONjcQ4cQAlDhrGRauqT/P5sUaOIzs17A2DxWGcXM+EpNQs9pUA==",
+      "dependencies": {
+        "gl-cone3d": "^1.5.2",
+        "gl-vec3": "^1.1.3",
+        "gl-vec4": "^1.0.1",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0"
+      }
+    },
+    "node_modules/gl-surface3d": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.6.0.tgz",
+      "integrity": "sha512-x15+u4712ysnB85G55RLJEml6mOB4VaDn0VTlXCc9JcjRl5Es10Tk7lhGGyiPtkCfHwvhnkxzYA1/rHHYN7Y0A==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.4",
+        "bit-twiddle": "^1.0.2",
+        "colormap": "^2.3.1",
+        "dup": "^1.0.0",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-beckmann": "^1.1.2",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18",
+        "ndarray-gradient": "^1.0.0",
+        "ndarray-ops": "^1.2.2",
+        "ndarray-pack": "^1.2.1",
+        "ndarray-scratch": "^1.2.0",
+        "surface-nets": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-text": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.2.0.tgz",
+      "integrity": "sha512-1X5yL8wKjyVMPenPKe7UvDAgyAOstuQ9gRfDBI3OK7ZHqHEnatTT5NaHWoY+II2ZHE35DvePxnOuayukowF0Ow==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^2.0.0",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-text/node_modules/regl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.0.tgz",
+      "integrity": "sha512-oWUce/aVoEvW5l2V0LK7O5KJMzUSKeiOwFuJehzpSFd43dO5spP9r+sSUfhKtsky4u6MCqWJaRL+abzExynfTg=="
+    },
+    "node_modules/gl-texture2d": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
+      "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
+      "dependencies": {
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.2.2",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-util": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
+      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+      "dependencies": {
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
+      }
+    },
+    "node_modules/gl-vao": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gl-vao/-/gl-vao-1.3.0.tgz",
+      "integrity": "sha1-6ekqqVWIyrnVwvBLaTRAw99pGSM="
+    },
+    "node_modules/gl-vec3": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gl-vec3/-/gl-vec3-1.1.3.tgz",
+      "integrity": "sha512-jduKUqT0SGH02l8Yl+mV1yVsDfYgQAJyXGxkJQGyxPLHRiW25DwVIRPt6uvhrEMHftJfqhqKthRcyZqNEl9Xdw=="
+    },
+    "node_modules/gl-vec4": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gl-vec4/-/gl-vec4-1.0.1.tgz",
+      "integrity": "sha1-l9loeCgbFLUyy84QF4Xf0cs0CWQ="
+    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -6705,10 +8144,273 @@
         "node": ">= 4"
       }
     },
+    "node_modules/glsl-inject-defines": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
+      "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
+      "dependencies": {
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "node_modules/glsl-inverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-inverse/-/glsl-inverse-1.0.0.tgz",
+      "integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY="
+    },
+    "node_modules/glsl-out-of-range": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.4.tgz",
+      "integrity": "sha512-fCcDu2LCQ39VBvfe1FbhuazXEf0CqMZI9OYXrYlL6uUARG48CTAbL04+tZBtVM0zo1Ljx4OLu2AxNquq++lxWQ=="
+    },
+    "node_modules/glsl-resolve": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
+      "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
+      "dependencies": {
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
+      }
+    },
+    "node_modules/glsl-resolve/node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
+    },
+    "node_modules/glsl-resolve/node_modules/xtend": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
+      "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/glsl-shader-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
+      "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
+      "dependencies": {
+        "atob-lite": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "node_modules/glsl-specular-beckmann": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-specular-beckmann/-/glsl-specular-beckmann-1.1.2.tgz",
+      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE="
+    },
+    "node_modules/glsl-specular-cook-torrance": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
+      "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
+      "dependencies": {
+        "glsl-specular-beckmann": "^1.1.1"
+      }
+    },
+    "node_modules/glsl-token-assignments": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
+      "integrity": "sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8="
+    },
+    "node_modules/glsl-token-defines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
+      "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
+      "dependencies": {
+        "glsl-tokenizer": "^2.0.0"
+      }
+    },
+    "node_modules/glsl-token-depth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
+      "integrity": "sha1-I8XjDuK9JViEtKKLyFC495HpXYQ="
+    },
+    "node_modules/glsl-token-descope": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
+      "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
+      "dependencies": {
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
+      }
+    },
+    "node_modules/glsl-token-inject-block": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
+      "integrity": "sha1-4QFfWYDBCRgkraomJfHf3ovQADQ="
+    },
+    "node_modules/glsl-token-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
+      "integrity": "sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4="
+    },
+    "node_modules/glsl-token-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
+      "integrity": "sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E="
+    },
+    "node_modules/glsl-token-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
+      "integrity": "sha1-WUQdL4V958NEnJRWZgIezjWOSOw="
+    },
+    "node_modules/glsl-token-whitespace-trim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
+      "integrity": "sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA="
+    },
+    "node_modules/glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "dependencies": {
+        "through2": "^0.6.3"
+      }
+    },
+    "node_modules/glsl-tokenizer/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "node_modules/glsl-tokenizer/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/glsl-tokenizer/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "node_modules/glsl-tokenizer/node_modules/through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/glslify": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
+      "dependencies": {
+        "bl": "^2.2.1",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.5",
+        "resolve": "^1.1.5",
+        "stack-trace": "0.0.9",
+        "static-eval": "^2.0.5",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "glslify": "bin.js"
+      }
+    },
+    "node_modules/glslify-bundle": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
+      "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
+      "dependencies": {
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
+        "shallow-copy": "0.0.1"
+      }
+    },
+    "node_modules/glslify-deps": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
+      "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
+      "dependencies": {
+        "@choojs/findup": "^0.2.0",
+        "events": "^3.2.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
+        "map-limit": "0.0.1",
+        "resolve": "^1.0.0"
+      }
+    },
+    "node_modules/glslify/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/glslify/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/glslify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/glslify/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -6788,6 +8490,22 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-hover": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
+      "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
+      "dependencies": {
+        "is-browser": "^2.0.1"
+      }
+    },
+    "node_modules/has-passive-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
+      "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
+      "dependencies": {
+        "is-browser": "^2.0.1"
       }
     },
     "node_modules/has-symbols": {
@@ -6877,6 +8595,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/hsluv": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
+      "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -6974,7 +8697,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -7017,6 +8739,16 @@
       "dev": true,
       "dependencies": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/image-palette": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
+      "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
+      "dependencies": {
+        "color-id": "^1.1.0",
+        "pxls": "^2.0.0",
+        "quantize": "^1.0.2"
       }
     },
     "node_modules/immer": {
@@ -7096,6 +8828,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/incremental-convex-hull": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
+      "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
+      "dependencies": {
+        "robust-orientation": "^1.1.2",
+        "simplicial-complex": "^1.0.0"
       }
     },
     "node_modules/indent-string": {
@@ -7205,6 +8946,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interval-tree-1d": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.4.tgz",
+      "integrity": "sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0"
+      }
+    },
+    "node_modules/invert-permutation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-permutation/-/invert-permutation-1.0.0.tgz",
+      "integrity": "sha1-oKeAQurbNrwXVR54fv0UOa3VSTM="
+    },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+    },
     "node_modules/ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -7251,6 +9010,11 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "node_modules/is-base64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.1.0.tgz",
+      "integrity": "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg=="
+    },
     "node_modules/is-bigint": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
@@ -7270,6 +9034,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-boolean-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
@@ -7284,11 +9059,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
+      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
+    },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-callable": {
       "version": "1.2.3",
@@ -7399,6 +9178,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-firefox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
+      "integrity": "sha1-KioVZ3g6QX9uFYMjEI84YbCRhWI=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-float-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-float-array/-/is-float-array-1.0.0.tgz",
+      "integrity": "sha512-4ew1Sx6B6kEAl3T3NOM0yB94J3NZnBdNt4paw0e8nY73yHHTeTEhyQ3Lj7EQEnv5LD+GxNTaT4L46jcKjjpLiQ=="
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -7439,11 +9242,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-iexplorer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
+      "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
+    },
+    "node_modules/is-mobile": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
+      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
@@ -7503,7 +9319,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7570,6 +9385,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
+    "node_modules/is-svg-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
+      "integrity": "sha1-d6tZDBKz0gNI5cehPQBAyHeE3aA="
+    },
     "node_modules/is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -7623,8 +9448,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8660,6 +10484,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
     "node_modules/kind-of": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -8728,6 +10557,11 @@
         "node": ">= 10.18.0"
       }
     },
+    "node_modules/lerp": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
+      "integrity": "sha1-oYyJaPkXiW3hXM/MKNVaa3Med24="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8741,7 +10575,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -8958,8 +10791,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -9083,6 +10915,22 @@
         "tmpl": "1.0.x"
       }
     },
+    "node_modules/map-limit": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
+      "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
+      "dependencies": {
+        "once": "~1.3.0"
+      }
+    },
+    "node_modules/map-limit/node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/map-obj": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
@@ -9093,6 +10941,95 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mapbox-gl": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.0.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/marching-simplex-table": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
+      "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
+      "dependencies": {
+        "convex-hull": "^1.0.3"
+      }
+    },
+    "node_modules/mat4-decompose": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
+      "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
+      "dependencies": {
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2"
+      }
+    },
+    "node_modules/mat4-interpolate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
+      "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
+      "dependencies": {
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2",
+        "mat4-decompose": "^1.0.3",
+        "mat4-recompose": "^1.0.3",
+        "quat-slerp": "^1.0.0"
+      }
+    },
+    "node_modules/mat4-recompose": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
+      "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
+      "dependencies": {
+        "gl-mat4": "^1.0.1"
+      }
+    },
+    "node_modules/math-log2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
+      "integrity": "sha1-+4lBvl9evol55xjmJzsXjlhpRWU=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matrix-camera-controller": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.4.tgz",
+      "integrity": "sha512-zsPGPONclrKSImNpqqKDTcqFpWLAIwMXEJtCde4IFPOw1dA9udzFg4HOFytOTosOFanchrx7+Hqq6glLATIxBA==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0",
+        "gl-mat4": "^1.1.2",
+        "gl-vec3": "^1.0.3",
+        "mat4-interpolate": "^1.0.3"
       }
     },
     "node_modules/memoize-one": {
@@ -9471,11 +11408,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/monotone-convex-hull-2d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "dependencies": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "node_modules/mouse-change": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
+      "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
+      "dependencies": {
+        "mouse-event": "^1.0.0"
+      }
+    },
+    "node_modules/mouse-event": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
+      "integrity": "sha1-s3ie23EJmX1aky0dAdqhVDpQFzI="
+    },
+    "node_modules/mouse-event-offset": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+      "integrity": "sha1-39hqbiSMa6jK1TuQXVA3ogY+mYQ="
+    },
+    "node_modules/mouse-wheel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+      "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
+      "dependencies": {
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "devOptional": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -9505,6 +11477,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/mumath": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
+      "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
+      "deprecated": "Redundant dependency in your project.",
+      "dependencies": {
+        "almost-equal": "^1.1.0"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -9522,11 +11508,106 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "node_modules/ndarray-extract-contour": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
+      "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
+      "dependencies": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "node_modules/ndarray-gradient": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
+      "integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
+      "dependencies": {
+        "cwise-compiler": "^1.0.0",
+        "dup": "^1.0.0"
+      }
+    },
+    "node_modules/ndarray-linear-interpolate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ndarray-linear-interpolate/-/ndarray-linear-interpolate-1.0.0.tgz",
+      "integrity": "sha1-eLySuFuavBW25n7mWCj54hN65ys="
+    },
+    "node_modules/ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+      "dependencies": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
+    "node_modules/ndarray-pack": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
+      "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+      "dependencies": {
+        "cwise-compiler": "^1.1.2",
+        "ndarray": "^1.0.13"
+      }
+    },
+    "node_modules/ndarray-scratch": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
+      "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
+      "dependencies": {
+        "ndarray": "^1.0.14",
+        "ndarray-ops": "^1.2.1",
+        "typedarray-pool": "^1.0.2"
+      }
+    },
+    "node_modules/ndarray-sort": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
+      "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
+      "dependencies": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "node_modules/needle": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.8.0.tgz",
+      "integrity": "sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.2",
@@ -9542,6 +11623,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node_modules/nextafter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
+      "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
+      "dependencies": {
+        "double-bits": "^1.1.0"
+      }
     },
     "node_modules/node-emoji": {
       "version": "1.10.0",
@@ -9766,6 +11860,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
+      "integrity": "sha1-RWNg5g7Odfvve11+FgSA5//Rb+U="
+    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -9777,6 +11876,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/normals": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
+      "integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA="
     },
     "node_modules/npm-bundled": {
       "version": "1.1.2",
@@ -9974,6 +12078,17 @@
         "set-blocking": "~2.0.0"
       }
     },
+    "node_modules/number-is-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
+      "integrity": "sha1-5ZvKFy/+0nMY55x862y3LAlbIVI=",
+      "dependencies": {
+        "is-finite": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -9982,6 +12097,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/numeric": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
+      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
     },
     "node_modules/nwsapi": {
       "version": "2.2.0",
@@ -10155,7 +12275,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
       "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -10166,6 +12285,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/orbit-camera-controller": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
+      "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
+      "dependencies": {
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.3"
       }
     },
     "node_modules/os-homedir": {
@@ -10415,6 +12543,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/pad-left": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
+      "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
+      "dependencies": {
+        "repeat-string": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10425,6 +12564,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parenthesis": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.7.tgz",
+      "integrity": "sha512-iMtu+HCbLXVrpf6Ys/4YKhcFxbux3xK4ZVB9r+a2kMSqeeQWQoDNYlXIsOjwlT2ldYXZ3k5PVeBnYn7fbAo/Bg=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -10454,6 +12598,24 @@
         "qs": "^6.9.4",
         "query-string": "^6.13.8"
       }
+    },
+    "node_modules/parse-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
+      "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
+      "dependencies": {
+        "pick-by-alias": "^1.2.0"
+      }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha1-en7A0esG+lMlx9PgCbhZoJtdSes="
+    },
+    "node_modules/parse-unit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
     },
     "node_modules/parse-url": {
       "version": "6.0.0",
@@ -10516,11 +12678,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "node_modules/permutation-parity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
+      "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
+      "dependencies": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "node_modules/permutation-rank": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
+      "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
+      "dependencies": {
+        "invert-permutation": "^1.0.0",
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "node_modules/pick-by-alias": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
+      "integrity": "sha1-X3yysfIabh6ISgyHhVqko3NhEHs="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -10566,6 +12761,130 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/planar-dual": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
+      "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
+      "dependencies": {
+        "compare-angle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
+    },
+    "node_modules/planar-graph-to-polyline": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.6.tgz",
+      "integrity": "sha512-h8a9kdAjo7mRhC0X6HZ42xzFp7vKDZA+Hygyhsq/08Qi4vVAQYJaLLYLvKUUzRbVKvdYqq0reXHyV0EygyEBHA==",
+      "dependencies": {
+        "edges-to-adjacency-list": "^1.0.0",
+        "planar-dual": "^1.0.0",
+        "point-in-big-polygon": "^2.0.1",
+        "robust-orientation": "^1.0.1",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0",
+        "uniq": "^1.0.0"
+      }
+    },
+    "node_modules/plotly.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.3.1.tgz",
+      "integrity": "sha512-Vrm4ElvOoxN/PhWdMc/KsCLhsAsahgIGrJRQ3FgHUgBzM33joR2uQzlUyAFI2jR2kM95V7jG3Bq0qtNswAJNhg==",
+      "dependencies": {
+        "@plotly/d3": "3.8.0",
+        "@plotly/d3-sankey": "0.7.2",
+        "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/point-cluster": "^3.1.9",
+        "@turf/area": "^6.4.0",
+        "@turf/bbox": "^6.4.0",
+        "@turf/centroid": "^6.0.2",
+        "alpha-shape": "^1.0.0",
+        "canvas-fit": "^1.5.0",
+        "color-alpha": "1.0.4",
+        "color-normalize": "1.5.0",
+        "color-parse": "1.3.8",
+        "color-rgba": "2.1.1",
+        "convex-hull": "^1.0.3",
+        "country-regex": "^1.1.0",
+        "d3-force": "^1.2.1",
+        "d3-format": "^1.4.5",
+        "d3-geo": "^1.12.1",
+        "d3-geo-projection": "^2.9.0",
+        "d3-hierarchy": "^1.1.9",
+        "d3-interpolate": "^1.4.0",
+        "d3-time": "^1.1.0",
+        "d3-time-format": "^2.2.3",
+        "delaunay-triangulate": "^1.1.6",
+        "fast-isnumeric": "^1.1.4",
+        "gl-cone3d": "^1.5.2",
+        "gl-error3d": "^1.0.16",
+        "gl-heatmap2d": "^1.1.1",
+        "gl-line3d": "1.2.1",
+        "gl-mat4": "^1.2.0",
+        "gl-mesh3d": "^2.3.1",
+        "gl-plot2d": "^1.4.5",
+        "gl-plot3d": "^2.4.7",
+        "gl-pointcloud2d": "^1.0.3",
+        "gl-scatter3d": "^1.2.3",
+        "gl-select-box": "^1.0.4",
+        "gl-spikes2d": "^1.0.2",
+        "gl-streamtube3d": "^1.4.1",
+        "gl-surface3d": "^1.6.0",
+        "gl-text": "^1.1.8",
+        "glslify": "^7.1.1",
+        "has-hover": "^1.0.1",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.2",
+        "mapbox-gl": "1.10.1",
+        "matrix-camera-controller": "^2.1.4",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "native-promise-only": "^0.8.1",
+        "ndarray": "^1.0.19",
+        "ndarray-linear-interpolate": "^1.0.0",
+        "parse-svg-path": "^0.1.2",
+        "polybooljs": "^1.2.0",
+        "probe-image-size": "^7.2.1",
+        "regl": "^1.6.1",
+        "regl-error2d": "^2.0.12",
+        "regl-line2d": "^3.1.1",
+        "regl-scatter2d": "^3.2.6",
+        "regl-splom": "^1.0.14",
+        "right-now": "^1.0.0",
+        "robust-orientation": "^1.1.3",
+        "strongly-connected-components": "^1.0.1",
+        "superscript-text": "^1.0.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.2",
+        "to-px": "1.0.1",
+        "topojson-client": "^3.1.0",
+        "webgl-context": "^2.2.0",
+        "world-calendars": "^1.0.3"
+      }
+    },
+    "node_modules/point-in-big-polygon": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.1.tgz",
+      "integrity": "sha512-DtrN8pa2VfMlvmWlCcypTFeBE4+OYz1ojDNJLKCWa4doiVAD6PRBbxFYAT71tsp5oKaRXT5sxEiHCAQKb1zr2Q==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0",
+        "interval-tree-1d": "^1.0.1",
+        "robust-orientation": "^1.1.3",
+        "slab-decomposition": "^1.0.1"
+      }
+    },
+    "node_modules/polybooljs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
+      "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g="
+    },
+    "node_modules/polytope-closest-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
+      "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
+      "dependencies": {
+        "numeric": "^1.2.6"
       }
     },
     "node_modules/portal-proto": {
@@ -10665,11 +12984,15 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
+    "node_modules/potpack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
+      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -10727,11 +13050,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/probe-image-size": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.1.tgz",
+      "integrity": "sha512-d+6L3NvQBCNt4peRDoEfA7r9bPm6/qy18FnLKwg4NWBC5JrJm0pMLRg1kF4XNsPe1bUdt3WIMonPJzQWN2HXjQ==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -10799,6 +13131,11 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.1.tgz",
+      "integrity": "sha512-YVCvdhxWNDP8/nJDyXLuM+UFsuPk4+1PB7WGPVDzm3HTHbzFLxQYeW2iZpS4mmnXrQJGBzt230t/BbEb7PrQaw=="
+    },
     "node_modules/protocols": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
@@ -10842,6 +13179,41 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pxls": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
+      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "compute-dims": "^1.1.0",
+        "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
+        "is-buffer": "^2.0.3",
+        "to-uint8": "^1.4.1"
+      }
+    },
+    "node_modules/pxls/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -10865,6 +13237,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quantize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
+      "integrity": "sha1-0lrCAKd7bXD0ASfKFxoQ4zyFRt4=",
+      "engines": {
+        "node": ">=0.10.21"
+      }
+    },
+    "node_modules/quat-slerp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
+      "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
+      "dependencies": {
+        "gl-quat": "^1.0.0"
       }
     },
     "node_modules/query-string": {
@@ -10924,12 +13312,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rat-vec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
+      "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
+      "dependencies": {
+        "big-rat": "^1.0.3"
       }
     },
     "node_modules/react": {
@@ -10994,6 +13403,18 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
+      }
+    },
+    "node_modules/react-plotly.js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.5.1.tgz",
+      "integrity": "sha512-Oya14whSHvPsYXdI0nHOGs1pZhMzV2edV7HAW1xFHD58Y73m/LbG2Encvyz1tztL0vfjph0JNhiwO8cGBJnlhg==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "plotly.js": ">1.34.0",
+        "react": ">0.13.0"
       }
     },
     "node_modules/react-redux": {
@@ -11403,6 +13824,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
+    "node_modules/reduce-simplicial-complex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
+      "integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
+      "dependencies": {
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0",
+        "compare-oriented-cell": "^1.0.1"
+      }
+    },
     "node_modules/redux": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
@@ -11420,6 +13851,11 @@
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
+    "node_modules/regex-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-regex/-/regex-regex-1.0.0.tgz",
+      "integrity": "sha1-kEih6uuHD01IDavHb8Qs3MC8OnI="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
@@ -11447,6 +13883,90 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/regl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.7.0.tgz",
+      "integrity": "sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w=="
+    },
+    "node_modules/regl-error2d": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
+      "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "node_modules/regl-line2d": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.1.tgz",
+      "integrity": "sha512-oxtdSNv2daqwOi72EpaT9WRtvA/DOAq9D/icNBs1fZviPSnC/6O85UgPpAuTguj+ri0n/e9+FDbqauYg+l+uqA==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "array-find-index": "^1.0.2",
+        "array-normalize": "^1.1.4",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0"
+      }
+    },
+    "node_modules/regl-scatter2d": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.6.tgz",
+      "integrity": "sha512-ElPlu6jIx1Par4pG8OIhBuw5F5d+5qynYIlx4lMgikzkRtBgN5hjB3nfEp6jsMm4INPM367fs5vn6XcHD/s0Ow==",
+      "dependencies": {
+        "@plotly/point-cluster": "^3.1.9",
+        "array-range": "^1.0.1",
+        "array-rearrange": "^2.2.2",
+        "clamp": "^1.0.1",
+        "color-id": "^1.1.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "image-palette": "^2.1.0",
+        "is-iexplorer": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "node_modules/regl-splom": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
+      "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "array-range": "^1.0.1",
+        "color-alpha": "^1.0.4",
+        "flatten-vertex-data": "^1.0.2",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.2.3"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/request": {
@@ -11582,6 +14102,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -11613,6 +14141,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/right-now": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg="
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11626,6 +14159,97 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/robust-compress": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-compress/-/robust-compress-1.0.0.tgz",
+      "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs="
+    },
+    "node_modules/robust-determinant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
+      "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
+      "dependencies": {
+        "robust-compress": "^1.0.0",
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "node_modules/robust-dot-product": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
+      "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
+      "dependencies": {
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "node_modules/robust-in-sphere": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.2.1.tgz",
+      "integrity": "sha512-3zJdcMIOP1gdwux93MKTS0RiMYEGwQBoE5R1IW/9ZQmGeZzP7f7i4+xdcK8ujJvF/dEOS1WPuI9IB1WNFbj3Cg==",
+      "dependencies": {
+        "robust-scale": "^1.0.0",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "node_modules/robust-linear-solve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
+      "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
+      "dependencies": {
+        "robust-determinant": "^1.1.0"
+      }
+    },
+    "node_modules/robust-orientation": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.2.1.tgz",
+      "integrity": "sha512-FuTptgKwY6iNuU15nrIJDLjXzCChWB+T4AvksRtwPS/WZ3HuP1CElCm1t+OBfgQKfWbtZIawip+61k7+buRKAg==",
+      "dependencies": {
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
+      }
+    },
+    "node_modules/robust-product": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
+      "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
+      "dependencies": {
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0"
+      }
+    },
+    "node_modules/robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "dependencies": {
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "node_modules/robust-segment-intersect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
+      "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
+      "dependencies": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "node_modules/robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "node_modules/robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
     },
     "node_modules/rollup": {
       "version": "2.52.7",
@@ -11682,6 +14306,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
     "node_modules/rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -11703,6 +14332,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -11760,6 +14394,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -11801,6 +14440,11 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/signum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+      "integrity": "sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc="
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -11814,11 +14458,78 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
+    "node_modules/simplicial-complex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
+      "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
+      "dependencies": {
+        "bit-twiddle": "^1.0.0",
+        "union-find": "^1.0.0"
+      }
+    },
+    "node_modules/simplicial-complex-boundary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
+      "integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
+      "dependencies": {
+        "boundary-cells": "^2.0.0",
+        "reduce-simplicial-complex": "^1.0.0"
+      }
+    },
+    "node_modules/simplicial-complex-contour": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
+      "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
+      "dependencies": {
+        "marching-simplex-table": "^1.0.0",
+        "ndarray": "^1.0.15",
+        "ndarray-sort": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/simplify-planar-graph": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
+      "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
+      "dependencies": {
+        "robust-orientation": "^1.0.1",
+        "simplicial-complex": "^0.3.3"
+      }
+    },
+    "node_modules/simplify-planar-graph/node_modules/bit-twiddle": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-0.0.2.tgz",
+      "integrity": "sha1-wurruVKjuUrMFASX4c3NLxoz9Y4="
+    },
+    "node_modules/simplify-planar-graph/node_modules/simplicial-complex": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
+      "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
+      "dependencies": {
+        "bit-twiddle": "~0.0.1",
+        "union-find": "~0.0.3"
+      }
+    },
+    "node_modules/simplify-planar-graph/node_modules/union-find": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/union-find/-/union-find-0.0.4.tgz",
+      "integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY="
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
+    },
+    "node_modules/slab-decomposition": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.3.tgz",
+      "integrity": "sha512-1EfR304JHvX9vYQkUi4AKqN62mLsjk6W45xTk/TxwN8zd3HGwS7PVj9zj0I6fgCZqfGlimDEY+RzzASHn97ZmQ==",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0",
+        "functional-red-black-tree": "^1.0.0",
+        "robust-orientation": "^1.1.3"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -12006,6 +14717,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/split-polygon": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
+      "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
+      "dependencies": {
+        "robust-dot-product": "^1.0.0",
+        "robust-sum": "^1.0.0"
+      }
+    },
     "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -12018,8 +14738,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "node_modules/sshpk": {
       "version": "1.16.1",
@@ -12058,6 +14777,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -12068,6 +14795,43 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/static-eval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+      "dependencies": {
+        "escodegen": "^1.11.1"
+      }
+    },
+    "node_modules/static-eval/node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/static-eval/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/stream-browserify": {
@@ -12089,6 +14853,32 @@
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
       }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
@@ -12138,6 +14928,28 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/string-split-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
+      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+      "dependencies": {
+        "parenthesis": "^3.1.5"
+      }
+    },
+    "node_modules/string-to-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
+      "dependencies": {
+        "atob-lite": "^2.0.0",
+        "is-base64": "^0.1.0"
+      }
+    },
+    "node_modules/string-to-arraybuffer/node_modules/atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
     "node_modules/string-width": {
       "version": "4.2.2",
@@ -12266,10 +15078,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/strongly-connected-components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
+      "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
+    },
     "node_modules/stylis": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
       "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
+    },
+    "node_modules/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-7+bR4FbF5SYsmkHfDp61QiwCKtwNDyPsddk9TzfsDA5DQr5Goii5CVD2SXjglweFCxjrzVZf945ahqYfUIk8UA==",
+      "dependencies": {
+        "kdbush": "^3.0.0"
+      }
+    },
+    "node_modules/superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -12293,6 +15123,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/surface-nets": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
+      "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
+      "dependencies": {
+        "ndarray-extract-contour": "^1.0.0",
+        "triangulate-hypercube": "^1.0.0",
+        "zero-crossings": "^1.0.0"
+      }
+    },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
+    },
+    "node_modules/svg-path-bounds": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
+      "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
+      "dependencies": {
+        "abs-svg-path": "^0.1.1",
+        "is-svg-path": "^1.0.1",
+        "normalize-svg-path": "^1.0.0",
+        "parse-svg-path": "^0.1.2"
+      }
+    },
+    "node_modules/svg-path-bounds/node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/svg-path-sdf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
+      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
+      "dependencies": {
+        "bitmap-sdf": "^1.0.0",
+        "draw-svg-path": "^1.0.0",
+        "is-svg-path": "^1.0.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-path-bounds": "^1.0.1"
       }
     },
     "node_modules/symbol-tree": {
@@ -12529,6 +15405,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-cache": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.2.2.tgz",
+      "integrity": "sha512-zky+UDYiX0a/aPw/YTBD+EzKMlCTu1chFuCMZeAkgoRiceySdROu1V2kJXhCbtEdBhiOviYnAdGiSYl58HW0ZQ==",
+      "dependencies": {
+        "vectorize-text": "^3.2.1"
+      }
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -12565,6 +15449,19 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tinycolor2": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -12582,12 +15479,35 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
+    "node_modules/to-array-buffer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
+      "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
+      "dependencies": {
+        "flatten-vertex-data": "^1.0.2",
+        "is-blob": "^2.0.1",
+        "string-to-arraybuffer": "^1.0.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/to-float32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
+      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
+    },
+    "node_modules/to-px": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
+      "integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
+      "dependencies": {
+        "parse-unit": "^1.0.1"
       }
     },
     "node_modules/to-regex-range": {
@@ -12599,6 +15519,31 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-uint8": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
+      "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "clamp": "^1.0.1",
+        "is-base64": "^0.1.0",
+        "is-float-array": "^1.0.0",
+        "to-array-buffer": "^3.0.0"
+      }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
       }
     },
     "node_modules/tough-cookie": {
@@ -12625,6 +15570,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/triangulate-hypercube": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
+      "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
+      "dependencies": {
+        "gamma": "^0.1.0",
+        "permutation-parity": "^1.0.0",
+        "permutation-rank": "^1.0.0"
+      }
+    },
+    "node_modules/triangulate-polyline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
+      "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
+      "dependencies": {
+        "cdt2d": "^1.0.0"
       }
     },
     "node_modules/trim-newlines": {
@@ -12726,17 +15689,41 @@
         "node": "*"
       }
     },
+    "node_modules/turntable-camera-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
+      "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
+      "dependencies": {
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.2",
+        "gl-vec3": "^1.0.2"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "node_modules/two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "node_modules/two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+    },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -12765,11 +15752,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
+      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "node_modules/typedarray-pool": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -12835,6 +15835,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/union-find": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
+      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+    },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -12868,6 +15878,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+    },
     "node_modules/upath": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
@@ -12877,6 +15892,11 @@
         "node": ">=4",
         "yarn": "*"
       }
+    },
+    "node_modules/update-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
+      "integrity": "sha1-9RAYLYHugZ+4LDprIrYrve2ngI8="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -12912,6 +15932,49 @@
       "dev": true,
       "dependencies": {
         "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "node_modules/utils-copy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
+      "integrity": "sha1-biuXmCqozXPhGCo+b4vsPA9AWKc=",
+      "dependencies": {
+        "const-pinf-float64": "^1.0.0",
+        "object-keys": "^1.0.9",
+        "type-name": "^2.0.0",
+        "utils-copy-error": "^1.0.0",
+        "utils-indexof": "^1.0.0",
+        "utils-regex-from-string": "^1.0.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-buffer": "^1.0.1",
+        "validate.io-nonnegative-integer": "^1.0.0"
+      }
+    },
+    "node_modules/utils-copy-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
+      "integrity": "sha1-eR3jk8DwmJCv1Z88vqY18HmpT6U=",
+      "dependencies": {
+        "object-keys": "^1.0.9",
+        "utils-copy": "^1.1.0"
+      }
+    },
+    "node_modules/utils-indexof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
+      "integrity": "sha1-IP6r8J7xAYtSNkPoOA57yD7GG1w=",
+      "dependencies": {
+        "validate.io-array-like": "^1.0.1",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
+    "node_modules/utils-regex-from-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
+      "integrity": "sha1-/hopCfjeD/DVGCyA+8ZU1qaH0Yk=",
+      "dependencies": {
+        "regex-regex": "^1.0.0",
+        "validate.io-string-primitive": "^1.0.0"
       }
     },
     "node_modules/uuid": {
@@ -12970,6 +16033,96 @@
         "builtins": "^1.0.3"
       }
     },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "node_modules/validate.io-array-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
+      "integrity": "sha1-evn363tRcVvrIhVmjsXM5U+t21o=",
+      "dependencies": {
+        "const-max-uint32": "^1.0.2",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
+    "node_modules/validate.io-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-buffer/-/validate.io-buffer-1.0.2.tgz",
+      "integrity": "sha1-hS1nNAIZFNXROvwyUxdh43IO1E4="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
+      "integrity": "sha1-qaoBA1X+hoHA/qbBp0rSQZyt3cY=",
+      "dependencies": {
+        "validate.io-number-primitive": "^1.0.0"
+      }
+    },
+    "node_modules/validate.io-matrix-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-matrix-like/-/validate.io-matrix-like-1.0.2.tgz",
+      "integrity": "sha1-XsMqddCInaxzbepovdYUWxVe38M="
+    },
+    "node_modules/validate.io-ndarray-like": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-ndarray-like/-/validate.io-ndarray-like-1.0.0.tgz",
+      "integrity": "sha1-2KOw7RZbvx0vwNAHMnDPpVIpWRk="
+    },
+    "node_modules/validate.io-nonnegative-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
+      "integrity": "sha1-gGkkOgjF+Y6VQTySnf17GPP28p8=",
+      "dependencies": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+    },
+    "node_modules/validate.io-number-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-number-primitive/-/validate.io-number-primitive-1.0.0.tgz",
+      "integrity": "sha1-0uAfICmJNp3PEVVElWQgOv5YTlU="
+    },
+    "node_modules/validate.io-positive-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
+      "integrity": "sha1-ftLQO0wnVYzGagCqsPDpIYFKZYI=",
+      "dependencies": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "node_modules/validate.io-string-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate.io-string-primitive/-/validate.io-string-primitive-1.0.1.tgz",
+      "integrity": "sha1-uBNbn7E3K94C/dU60dDM1t55j+4="
+    },
+    "node_modules/vectorize-text": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.2.tgz",
+      "integrity": "sha512-34NVOCpMMQVXujU4vb/c6u98h6djI0jGdtC202H4Huvzn48B6ARsR7cmGh1xsAc0pHNQiUKGK/aHF05VtGv+eA==",
+      "dependencies": {
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.0",
+        "ndarray": "^1.0.11",
+        "planar-graph-to-polyline": "^1.0.6",
+        "simplify-planar-graph": "^2.0.1",
+        "surface-nets": "^1.0.0",
+        "triangulate-polyline": "^1.0.0"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -12982,6 +16135,16 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -13029,6 +16192,24 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/weak-map": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+    },
+    "node_modules/weakmap-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
+      "integrity": "sha1-1lr9eEEJshZuAP9XHDMVDsKkC0k="
+    },
+    "node_modules/webgl-context": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
+      "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
+      "dependencies": {
+        "get-canvas-context": "^1.0.1"
       }
     },
     "node_modules/webidl-conversions": {
@@ -13180,7 +16361,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13190,6 +16370,14 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "node_modules/world-calendars": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
+      "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
+      "dependencies": {
+        "object-assign": "^4.1.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -13446,6 +16634,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/zero-crossings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
+      "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
+      "dependencies": {
+        "cwise-compiler": "^1.0.0"
       }
     },
     "packages/core": {
@@ -13709,9 +16905,11 @@
         "@reduxjs/toolkit": "^1.6.0",
         "@tailwindcss/forms": "^0.3.3",
         "next": "^11.0.1",
+        "plotly.js": "^2.3.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-modal": "^3.14.3",
+        "react-plotly.js": "^2.5.1",
         "react-redux": "^7.2.0",
         "react-select": "^4.3.1",
         "react-tabs": "^3.2.2"
@@ -18147,6 +21345,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@choojs/findup": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "requires": {
+        "commander": "^2.15.1"
+      }
+    },
     "@emotion/cache": {
       "version": "11.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
@@ -19821,6 +23027,59 @@
         "write-file-atomic": "^3.0.3"
       }
     },
+    "@mapbox/geojson-rewind": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
+      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
+      "requires": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.5"
+      }
+    },
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+    },
+    "@mapbox/mapbox-gl-supported": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "requires": {}
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+    },
+    "@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+    },
+    "@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+    },
+    "@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "requires": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -20109,6 +23368,56 @@
         "@octokit/openapi-types": "^9.0.0"
       }
     },
+    "@plotly/d3": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.0.tgz",
+      "integrity": "sha512-L10iHgzvw3uSic/nQpYehlNzxUQvImwms5U7S95pJAEhrllzkrdQNy1Mc5DW9ab881Yr4fh300gJztKXWZDfkQ=="
+    },
+    "@plotly/d3-sankey": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
+      "requires": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "@plotly/d3-sankey-circular": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "requires": {
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "@plotly/point-cluster": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
+      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "binary-search-bounds": "^2.0.4",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
+      },
+      "dependencies": {
+        "is-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+        }
+      }
+    },
     "@reduxjs/toolkit": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.0.tgz",
@@ -20178,6 +23487,46 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/centroid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
+      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+    },
+    "@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
+    },
     "@types/aria-query": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
@@ -20224,6 +23573,12 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/d3": {
+      "version": "3.5.45",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.45.tgz",
+      "integrity": "sha512-wLICfMtjDEoAJie1MF6OuksAzOapRXgJy+l5HQVpyC1yMAlvHz2QKrrasUHru8xD6cbgQNGeO+CeyjOlKtly2A==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -20358,6 +23713,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "@types/plotly.js": {
+      "version": "1.54.14",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-1.54.14.tgz",
+      "integrity": "sha512-vYevenBloZ3B4i831i+ccS9u782JSnkJpBG/c/qPRJNDW6s25udnrmoHkFhbBl7jkzBy8pO2lPNhpMrQJV7ETA==",
+      "dev": true,
+      "requires": {
+        "@types/d3": "^3"
+      }
     },
     "@types/prettier": {
       "version": "2.3.1",
@@ -20586,6 +23950,26 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "3d-view": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
+      "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
+      "requires": {
+        "matrix-camera-controller": "^2.1.1",
+        "orbit-camera-controller": "^4.0.0",
+        "turntable-camera-controller": "^3.0.0"
+      }
+    },
+    "a-big-triangle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
+      "integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
+      "requires": {
+        "gl-buffer": "^2.1.1",
+        "gl-vao": "^1.2.0",
+        "weak-map": "^1.0.5"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -20597,6 +23981,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha1-32Acjo0roQ1KdtYl4japo5wnI78="
     },
     "acorn": {
       "version": "8.4.1",
@@ -20651,11 +24040,27 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
+    "add-line-numbers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
+      "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
+      "requires": {
+        "pad-left": "^1.0.2"
+      }
+    },
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
+    },
+    "affine-hull": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
+      "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
     },
     "agent-base": {
       "version": "6.0.2",
@@ -20697,6 +24102,29 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "almost-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
+      "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
+    },
+    "alpha-complex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
+      "integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
+      "requires": {
+        "circumradius": "^1.0.0",
+        "delaunay-triangulate": "^1.1.6"
+      }
+    },
+    "alpha-shape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
+      "integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
+      "requires": {
+        "alpha-complex": "^1.0.0",
+        "simplicial-complex-boundary": "^1.0.0"
       }
     },
     "ansi-colors": {
@@ -20803,11 +24231,26 @@
         "@babel/runtime-corejs3": "^7.10.2"
       }
     },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-bounds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
+      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
+    },
     "array-differ": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
       "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
       "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-ify": {
       "version": "1.0.0",
@@ -20827,6 +24270,24 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.5"
       }
+    },
+    "array-normalize": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
+      "requires": {
+        "array-bounds": "^1.0.0"
+      }
+    },
+    "array-range": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
+      "integrity": "sha1-9W5GWRhDYRxqVvd+8C7afFAIm/w="
+    },
+    "array-rearrange": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
+      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -20919,6 +24380,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "atob-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
+      "integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs="
     },
     "autoprefixer": {
       "version": "10.3.1",
@@ -21038,6 +24504,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "barycentric": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
+      "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
+      "requires": {
+        "robust-linear-solve": "^1.0.0"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -21058,15 +24532,97 @@
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
+    "big-rat": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
+      "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "bn.js": "^4.11.6",
+        "double-bits": "^1.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
+    },
+    "bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+    },
+    "bitmap-sdf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
+      "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
+      "requires": {
+        "clamp": "^1.0.1"
+      }
+    },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+    },
+    "boundary-cells": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.2.tgz",
+      "integrity": "sha512-/S48oUFYEgZMNvdqC87iYRbLBAPHYijPRNrNpm/sS8u7ijIViKm/hrV3YD4sx/W68AsG5zLMyBEditVHApHU5w=="
+    },
+    "box-intersect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
+      "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -21133,8 +24689,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -21238,11 +24793,34 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
       "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA=="
     },
+    "canvas-fit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
+      "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
+      "requires": {
+        "element-size": "^1.1.1"
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
+    },
+    "cdt2d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
+      "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
+      "requires": {
+        "binary-search-bounds": "^2.0.3",
+        "robust-in-sphere": "^1.1.3",
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "cell-orientation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cell-orientation/-/cell-orientation-1.0.1.tgz",
+      "integrity": "sha1-tQStlqZq0obZ7dmFoiU9A7gNKFA="
     },
     "chalk": {
       "version": "4.1.1",
@@ -21292,16 +24870,52 @@
       "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
       "dev": true
     },
+    "circumcenter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
+      "integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
+      "requires": {
+        "dup": "^1.0.0",
+        "robust-linear-solve": "^1.0.0"
+      }
+    },
+    "circumradius": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
+      "integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
+      "requires": {
+        "circumcenter": "^1.0.0"
+      }
+    },
     "cjs-module-lexer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
       "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
       "dev": true
     },
+    "clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+    },
     "classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "clean-pslg": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
+      "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
+      "requires": {
+        "big-rat": "^1.0.3",
+        "box-intersect": "^1.0.1",
+        "nextafter": "^1.0.0",
+        "rat-vec": "^1.1.1",
+        "robust-segment-intersect": "^1.0.1",
+        "union-find": "^1.0.2",
+        "uniq": "^1.0.1"
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -21416,6 +25030,14 @@
         }
       }
     },
+    "color-alpha": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
+      "requires": {
+        "color-parse": "^1.3.8"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -21424,10 +25046,57 @@
         "color-name": "~1.1.4"
       }
     },
+    "color-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
+      "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
+      "requires": {
+        "clamp": "^1.0.1"
+      }
+    },
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-normalize": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
+      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
+      "requires": {
+        "clamp": "^1.0.1",
+        "color-rgba": "^2.1.1",
+        "dtype": "^2.0.0"
+      }
+    },
+    "color-parse": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "defined": "^1.0.0",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "color-rgba": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
+      "requires": {
+        "clamp": "^1.0.1",
+        "color-parse": "^1.3.8",
+        "color-space": "^1.14.6"
+      }
+    },
+    "color-space": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
+      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
+      "requires": {
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
+      }
     },
     "color-string": {
       "version": "1.5.5",
@@ -21442,6 +25111,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+    },
+    "colormap": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.2.tgz",
+      "integrity": "sha512-jDOjaoEEmA9AgA11B/jCSAvYE95r3wRoAyTf3LEHGiUVlNHJaL1mRkf5AyLSpQBVGfTEPwGEqCIzL+kgr2WgNA==",
+      "requires": {
+        "lerp": "^1.0.3"
+      }
     },
     "columnify": {
       "version": "1.5.4",
@@ -21482,8 +25159,31 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "compare-angle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
+      "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
+      "requires": {
+        "robust-orientation": "^1.0.2",
+        "robust-product": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "signum": "^0.0.0",
+        "two-sum": "^1.0.0"
+      },
+      "dependencies": {
+        "signum": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/signum/-/signum-0.0.0.tgz",
+          "integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY="
+        }
+      }
+    },
+    "compare-cell": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/compare-cell/-/compare-cell-1.0.0.tgz",
+      "integrity": "sha1-qetwj24OQa73qlZrEw8ZaNyeGqo="
     },
     "compare-func": {
       "version": "2.0.0",
@@ -21504,6 +25204,27 @@
             "is-obj": "^2.0.0"
           }
         }
+      }
+    },
+    "compare-oriented-cell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
+      "integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
+      "requires": {
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0"
+      }
+    },
+    "compute-dims": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
+      "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
+      "requires": {
+        "utils-copy": "^1.0.0",
+        "validate.io-array": "^1.0.6",
+        "validate.io-matrix-like": "^1.0.2",
+        "validate.io-ndarray-like": "^1.0.0",
+        "validate.io-positive-integer": "^1.0.0"
       }
     },
     "concat-map": {
@@ -21538,6 +25259,16 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
+    },
+    "const-max-uint32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
+      "integrity": "sha1-8Am7YjDmeO2HTdLWqc2ePL+rtnY="
+    },
+    "const-pinf-float64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
+      "integrity": "sha1-9u+w15+cCYbT558pI6v5twtj1yY="
     },
     "conventional-changelog-angular": {
       "version": "5.0.12",
@@ -21643,6 +25374,16 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "convex-hull": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
+      "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
+      "requires": {
+        "affine-hull": "^1.0.0",
+        "incremental-convex-hull": "^1.0.1",
+        "monotone-convex-hull-2d": "^1.0.1"
+      }
+    },
     "core-js-pure": {
       "version": "3.15.2",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.2.tgz",
@@ -21652,8 +25393,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "7.0.0",
@@ -21667,6 +25407,11 @@
         "yaml": "^1.10.0"
       }
     },
+    "country-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
+      "integrity": "sha1-UcMz3N8Sknt+XuucEKyBEqYSCJY="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -21678,10 +25423,61 @@
         "which": "^2.0.1"
       }
     },
+    "css-font": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
+      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+      "requires": {
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
+      }
+    },
+    "css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss="
+    },
+    "css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA="
+    },
+    "css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ="
+    },
+    "css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc="
+    },
+    "css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk="
+    },
+    "css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0="
+    },
     "css-unit-converter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
       "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
+    },
+    "csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -21715,6 +25511,132 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+    },
+    "cubic-hermite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cubic-hermite/-/cubic-hermite-1.0.0.tgz",
+      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU="
+    },
+    "cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "requires": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "d3-force": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "requires": {
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
+      }
+    },
+    "d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "d3-geo": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "d3-geo-projection": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
+      "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
+      "requires": {
+        "commander": "2",
+        "d3-array": "1",
+        "d3-geo": "^1.12.0",
+        "resolve": "^1.1.10"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-quadtree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.7",
@@ -21814,8 +25736,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -21855,6 +25776,15 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
+    "delaunay-triangulate": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
+      "integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
+      "requires": {
+        "incremental-convex-hull": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -21884,6 +25814,11 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
+    },
+    "detect-kerning": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -21991,11 +25926,75 @@
         "is-obj": "^2.0.0"
       }
     },
+    "double-bits": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
+      "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
+    },
+    "draw-svg-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
+      "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
+      "requires": {
+        "abs-svg-path": "~0.1.1",
+        "normalize-svg-path": "~0.1.0"
+      }
+    },
+    "dtype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
+      "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ="
+    },
+    "dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "earcut": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -22007,10 +26006,31 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "edges-to-adjacency-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
+      "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
+      "requires": {
+        "uniq": "^1.0.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.766",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
       "integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w=="
+    },
+    "element-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
+      "integrity": "sha1-ZOXxWdlxIWMYRby67K8nnDm1404="
+    },
+    "elementary-circuits-directed-graph": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
+      "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
+      "requires": {
+        "strongly-connected-components": "^1.0.1"
+      }
     },
     "emittery": {
       "version": "0.8.1",
@@ -22044,6 +26064,14 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         }
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "enquirer": {
@@ -22114,10 +26142,50 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "es6-object-assign": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -22415,8 +26483,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -22452,6 +26519,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "execa": {
       "version": "5.1.1",
@@ -22503,6 +26575,21 @@
         }
       }
     },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -22541,11 +26628,39 @@
         }
       }
     },
+    "extract-frustum-planes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extract-frustum-planes/-/extract-frustum-planes-1.0.0.tgz",
+      "integrity": "sha1-l9VwP/BWTIw8aDjKxF+ee8UsnvU="
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
+    },
+    "falafel": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
+      "integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "foreach": "^2.0.5",
+        "isarray": "^2.0.1",
+        "object-keys": "^1.0.6"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -22565,6 +26680,14 @@
         "micromatch": "^4.0.4"
       }
     },
+    "fast-isnumeric": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
+      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
+      "requires": {
+        "is-string-blank": "^1.0.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -22574,8 +26697,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastq": {
       "version": "1.11.1",
@@ -22634,6 +26756,15 @@
       "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
       "dev": true
     },
+    "filtered-vector": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.5.tgz",
+      "integrity": "sha512-5Vu6wdtQJ1O2nRmz39dIr9m3hEDq1skYby5k1cJQdNWK4dMgvYcUEiA/9j7NcKfNZ5LGxn8w2LSLiigyH7pTAw==",
+      "requires": {
+        "binary-search-bounds": "^2.0.0",
+        "cubic-hermite": "^1.0.0"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -22658,6 +26789,35 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
       "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
+    },
+    "flatten-vertex-data": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
+      "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
+      "requires": {
+        "dtype": "^2.0.0"
+      }
+    },
+    "flip-pixels": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flip-pixels/-/flip-pixels-1.0.2.tgz",
+      "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA=="
+    },
+    "font-atlas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
+      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
+      "requires": {
+        "css-font": "^1.0.0"
+      }
+    },
+    "font-measure": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
+      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
+      "requires": {
+        "css-font": "^1.2.0"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -22685,6 +26845,39 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
       "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg=="
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "fs-extra": {
       "version": "10.0.0",
@@ -22731,8 +26924,12 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "gamma": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
+      "integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA="
     },
     "gauge": {
       "version": "2.7.4",
@@ -22799,11 +26996,21 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "devOptional": true
     },
+    "geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-canvas-context": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
+      "integrity": "sha1-1ue1C8TkyGNXzTnyJkeoS3NgHpM="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -22978,8 +27185,7 @@
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
     "get-value": {
       "version": "2.0.6",
@@ -23065,6 +27271,394 @@
         "ini": "^1.3.2"
       }
     },
+    "gl-axes3d": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.5.3.tgz",
+      "integrity": "sha512-KRYbguKQcDQ6PcB9g1pgqB8Ly4TY1DQODpPKiDTasyWJ8PxQk0t2Q7XoQQijNqvsguITCpVVCzNb5GVtIWiVlQ==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "dup": "^1.0.0",
+        "extract-frustum-planes": "^1.0.0",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-state": "^1.0.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec4": "^1.0.1",
+        "glslify": "^7.0.0",
+        "robust-orientation": "^1.1.3",
+        "split-polygon": "^1.0.0",
+        "vectorize-text": "^3.2.1"
+      }
+    },
+    "gl-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
+      "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
+      "requires": {
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.1.0",
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "gl-cone3d": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/gl-cone3d/-/gl-cone3d-1.5.2.tgz",
+      "integrity": "sha512-1JNeHH4sUtUmDA4ZK7Om8/kShwb8IZVAsnxaaB7IPRJsNGciLj1sTpODrJGeMl41RNkex5kXD2SQFrzyEAR2Rw==",
+      "requires": {
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec3": "^1.1.3",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
+      }
+    },
+    "gl-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-constants/-/gl-constants-1.0.0.tgz",
+      "integrity": "sha1-WXpQTjZHUP9QJTqjX43qevSl0jM="
+    },
+    "gl-error3d": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.16.tgz",
+      "integrity": "sha512-TGJewnKSp7ZnqGgG3XCF9ldrDbxZrO+OWlx6oIet4OdOM//n8xJ5isArnIV/sdPJnFbhfoLxWrW9f5fxHFRQ1A==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0"
+      }
+    },
+    "gl-fbo": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
+      "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
+      "requires": {
+        "gl-texture2d": "^2.0.0"
+      }
+    },
+    "gl-format-compiler-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
+      "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
+      "requires": {
+        "add-line-numbers": "^1.0.1",
+        "gl-constants": "^1.0.0",
+        "glsl-shader-name": "^1.0.0",
+        "sprintf-js": "^1.0.3"
+      }
+    },
+    "gl-heatmap2d": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.1.1.tgz",
+      "integrity": "sha512-6Vo1fPIB1vQFWBA/MR6JAA16XuQuhwvZRbSjYEq++m4QV33iqjGS2HcVIRfJGX+fomd5eiz6bwkVZcKm69zQPw==",
+      "requires": {
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "typedarray-pool": "^1.2.0"
+      }
+    },
+    "gl-line3d": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.2.1.tgz",
+      "integrity": "sha512-eeb0+RI2ZBRqMYJK85SgsRiJK7c4aiOjcnirxv0830A3jmOc99snY3AbPcV8KvKmW0Yaf3KA4e+qNCbHiTOTnA==",
+      "requires": {
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
+      }
+    },
+    "gl-mat3": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
+      "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+    },
+    "gl-mat4": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
+      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
+    },
+    "gl-matrix": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
+    },
+    "gl-mesh3d": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.3.1.tgz",
+      "integrity": "sha512-pXECamyGgu4/9HeAQSE5OEUuLBGS1aq9V4BCsTcxsND4fNLaajEkYKUz/WY2QSYElqKdsMBVsldGiKRKwlybqA==",
+      "requires": {
+        "barycentric": "^1.0.1",
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18",
+        "normals": "^1.1.0",
+        "polytope-closest-point": "^1.0.0",
+        "simplicial-complex-contour": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "gl-plot2d": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.5.tgz",
+      "integrity": "sha512-6GmCN10SWtV+qHFQ1gjdnVubeHFVsm6P4zmo0HrPIl9TcdePCUHDlBKWAuE6XtFhiMKMj7R8rApOX8O8uXUYog==",
+      "requires": {
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-select-static": "^2.0.7",
+        "gl-shader": "^4.2.1",
+        "glsl-inverse": "^1.0.0",
+        "glslify": "^7.0.0",
+        "text-cache": "^4.2.2"
+      }
+    },
+    "gl-plot3d": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.7.tgz",
+      "integrity": "sha512-mLDVWrl4Dj0O0druWyHUK5l7cBQrRIJRn2oROEgrRuOgbbrLAzsREKefwMO0bA0YqkiZMFMnV5VvPA9j57X5Xg==",
+      "requires": {
+        "3d-view": "^2.0.0",
+        "a-big-triangle": "^1.0.3",
+        "gl-axes3d": "^1.5.3",
+        "gl-fbo": "^2.0.5",
+        "gl-mat4": "^1.2.0",
+        "gl-select-static": "^2.0.7",
+        "gl-shader": "^4.2.1",
+        "gl-spikes3d": "^1.0.10",
+        "glslify": "^7.0.0",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.1",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.19",
+        "right-now": "^1.0.0"
+      }
+    },
+    "gl-pointcloud2d": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.3.tgz",
+      "integrity": "sha512-OS2e1irvJXVRpg/GziXj10xrFJm9kkRfFoB6BLUvkjCQV7ZRNNcs2CD+YSK1r0gvMwTg2T3lfLM3UPwNtz+4Xw==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "gl-quat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
+      "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
+      "requires": {
+        "gl-mat3": "^1.0.0",
+        "gl-vec3": "^1.0.3",
+        "gl-vec4": "^1.0.0"
+      }
+    },
+    "gl-scatter3d": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.2.3.tgz",
+      "integrity": "sha512-nXqPlT1w5Qt51dTksj+DUqrZqwWAEWg0PocsKcoDnVNv0X8sGA+LBZ0Y+zrA+KNXUL0PPCX9WR9cF2uJAZl1Sw==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
+        "is-string-blank": "^1.0.1",
+        "typedarray-pool": "^1.1.0",
+        "vectorize-text": "^3.2.1"
+      }
+    },
+    "gl-select-box": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.4.tgz",
+      "integrity": "sha512-mKsCnglraSKyBbQiGq0Ila0WF+m6Tr+EWT2yfaMn/Sh9aMHq5Wt0F/l6Cf/Ed3CdERq5jHWAY5yxLviZteYu2w==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0"
+      }
+    },
+    "gl-select-static": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.7.tgz",
+      "integrity": "sha512-OvpYprd+ngl3liEatBTdXhSyNBjwvjMSvV2rN0KHpTU+BTi4viEETXNZXFgGXY37qARs0L28ybk3UQEW6C5Nnw==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "gl-fbo": "^2.0.5",
+        "ndarray": "^1.0.18",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "gl-shader": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.3.1.tgz",
+      "integrity": "sha512-xLoN6XtRLlg97SEqtuzfKc+pVWpVkQ3YjDI1kuCale8tF7+zMhiKlMfmG4IMQPMdKJZQbIc/Ny8ZusEpfh5U+w==",
+      "requires": {
+        "gl-format-compiler-error": "^1.0.2",
+        "weakmap-shim": "^1.1.0"
+      }
+    },
+    "gl-spikes2d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.2.tgz",
+      "integrity": "sha512-QVeOZsi9nQuJJl7NB3132CCv5KA10BWxAY2QgJNsKqbLsG53B/TrGJpjIAohnJftdZ4fT6b3ZojWgeaXk8bOOA=="
+    },
+    "gl-spikes3d": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.10.tgz",
+      "integrity": "sha512-lT3xroowOFxMvlhT5Mof76B2TE02l5zt/NIWljhczV2FFHgIVhA4jMrd5dIv1so1RXMBDJIKu0uJI3QKliDVLg==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glslify": "^7.0.0"
+      }
+    },
+    "gl-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
+      "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
+      "requires": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "gl-streamtube3d": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/gl-streamtube3d/-/gl-streamtube3d-1.4.1.tgz",
+      "integrity": "sha512-rH02v00kgwgdpkXVo7KsSoPp38bIAYR9TE1iONjcQ4cQAlDhrGRauqT/P5sUaOIzs17A2DxWGcXM+EpNQs9pUA==",
+      "requires": {
+        "gl-cone3d": "^1.5.2",
+        "gl-vec3": "^1.1.3",
+        "gl-vec4": "^1.0.1",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0"
+      }
+    },
+    "gl-surface3d": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.6.0.tgz",
+      "integrity": "sha512-x15+u4712ysnB85G55RLJEml6mOB4VaDn0VTlXCc9JcjRl5Es10Tk7lhGGyiPtkCfHwvhnkxzYA1/rHHYN7Y0A==",
+      "requires": {
+        "binary-search-bounds": "^2.0.4",
+        "bit-twiddle": "^1.0.2",
+        "colormap": "^2.3.1",
+        "dup": "^1.0.0",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-beckmann": "^1.1.2",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18",
+        "ndarray-gradient": "^1.0.0",
+        "ndarray-ops": "^1.2.2",
+        "ndarray-pack": "^1.2.1",
+        "ndarray-scratch": "^1.2.0",
+        "surface-nets": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "gl-text": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.2.0.tgz",
+      "integrity": "sha512-1X5yL8wKjyVMPenPKe7UvDAgyAOstuQ9gRfDBI3OK7ZHqHEnatTT5NaHWoY+II2ZHE35DvePxnOuayukowF0Ow==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^2.0.0",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
+      },
+      "dependencies": {
+        "regl": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.0.tgz",
+          "integrity": "sha512-oWUce/aVoEvW5l2V0LK7O5KJMzUSKeiOwFuJehzpSFd43dO5spP9r+sSUfhKtsky4u6MCqWJaRL+abzExynfTg=="
+        }
+      }
+    },
+    "gl-texture2d": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
+      "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
+      "requires": {
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.2.2",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "gl-util": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
+      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+      "requires": {
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
+      }
+    },
+    "gl-vao": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gl-vao/-/gl-vao-1.3.0.tgz",
+      "integrity": "sha1-6ekqqVWIyrnVwvBLaTRAw99pGSM="
+    },
+    "gl-vec3": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gl-vec3/-/gl-vec3-1.1.3.tgz",
+      "integrity": "sha512-jduKUqT0SGH02l8Yl+mV1yVsDfYgQAJyXGxkJQGyxPLHRiW25DwVIRPt6uvhrEMHftJfqhqKthRcyZqNEl9Xdw=="
+    },
+    "gl-vec4": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gl-vec4/-/gl-vec4-1.0.1.tgz",
+      "integrity": "sha1-l9loeCgbFLUyy84QF4Xf0cs0CWQ="
+    },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -23114,10 +27708,270 @@
         }
       }
     },
+    "glsl-inject-defines": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
+      "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
+      "requires": {
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "glsl-inverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-inverse/-/glsl-inverse-1.0.0.tgz",
+      "integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY="
+    },
+    "glsl-out-of-range": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.4.tgz",
+      "integrity": "sha512-fCcDu2LCQ39VBvfe1FbhuazXEf0CqMZI9OYXrYlL6uUARG48CTAbL04+tZBtVM0zo1Ljx4OLu2AxNquq++lxWQ=="
+    },
+    "glsl-resolve": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
+      "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
+      "requires": {
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
+        },
+        "xtend": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
+          "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
+        }
+      }
+    },
+    "glsl-shader-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
+      "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
+      "requires": {
+        "atob-lite": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "glsl-specular-beckmann": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-specular-beckmann/-/glsl-specular-beckmann-1.1.2.tgz",
+      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE="
+    },
+    "glsl-specular-cook-torrance": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
+      "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
+      "requires": {
+        "glsl-specular-beckmann": "^1.1.1"
+      }
+    },
+    "glsl-token-assignments": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
+      "integrity": "sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8="
+    },
+    "glsl-token-defines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
+      "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
+      "requires": {
+        "glsl-tokenizer": "^2.0.0"
+      }
+    },
+    "glsl-token-depth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
+      "integrity": "sha1-I8XjDuK9JViEtKKLyFC495HpXYQ="
+    },
+    "glsl-token-descope": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
+      "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
+      "requires": {
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
+      }
+    },
+    "glsl-token-inject-block": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
+      "integrity": "sha1-4QFfWYDBCRgkraomJfHf3ovQADQ="
+    },
+    "glsl-token-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
+      "integrity": "sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4="
+    },
+    "glsl-token-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
+      "integrity": "sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E="
+    },
+    "glsl-token-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
+      "integrity": "sha1-WUQdL4V958NEnJRWZgIezjWOSOw="
+    },
+    "glsl-token-whitespace-trim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
+      "integrity": "sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA="
+    },
+    "glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "requires": {
+        "through2": "^0.6.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
+      }
+    },
+    "glslify": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
+      "requires": {
+        "bl": "^2.2.1",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.5",
+        "resolve": "^1.1.5",
+        "stack-trace": "0.0.9",
+        "static-eval": "^2.0.5",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "glslify-bundle": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
+      "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
+      "requires": {
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
+        "shallow-copy": "0.0.1"
+      }
+    },
+    "glslify-deps": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
+      "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
+      "requires": {
+        "@choojs/findup": "^0.2.0",
+        "events": "^3.2.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
+        "map-limit": "0.0.1",
+        "resolve": "^1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "handlebars": {
       "version": "4.7.7",
@@ -23171,6 +28025,22 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "has-hover": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
+      "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
+      "requires": {
+        "is-browser": "^2.0.1"
+      }
+    },
+    "has-passive-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
+      "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
+      "requires": {
+        "is-browser": "^2.0.1"
+      }
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -23242,6 +28112,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "hsluv": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
+      "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -23320,7 +28195,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -23343,6 +28217,16 @@
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "image-palette": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
+      "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
+      "requires": {
+        "color-id": "^1.1.0",
+        "pxls": "^2.0.0",
+        "quantize": "^1.0.2"
       }
     },
     "immer": {
@@ -23397,6 +28281,15 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "incremental-convex-hull": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
+      "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
+      "requires": {
+        "robust-orientation": "^1.1.2",
+        "simplicial-complex": "^1.0.0"
+      }
     },
     "indent-string": {
       "version": "4.0.0",
@@ -23489,6 +28382,24 @@
         "side-channel": "^1.0.4"
       }
     },
+    "interval-tree-1d": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.4.tgz",
+      "integrity": "sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==",
+      "requires": {
+        "binary-search-bounds": "^2.0.0"
+      }
+    },
+    "invert-permutation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-permutation/-/invert-permutation-1.0.0.tgz",
+      "integrity": "sha1-oKeAQurbNrwXVR54fv0UOa3VSTM="
+    },
+    "iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -23525,6 +28436,11 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-base64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.1.0.tgz",
+      "integrity": "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg=="
+    },
     "is-bigint": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
@@ -23538,6 +28454,11 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw=="
+    },
     "is-boolean-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
@@ -23546,11 +28467,15 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
+      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.2.3",
@@ -23629,6 +28554,21 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+    },
+    "is-firefox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
+      "integrity": "sha1-KioVZ3g6QX9uFYMjEI84YbCRhWI="
+    },
+    "is-float-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-float-array/-/is-float-array-1.0.0.tgz",
+      "integrity": "sha512-4ew1Sx6B6kEAl3T3NOM0yB94J3NZnBdNt4paw0e8nY73yHHTeTEhyQ3Lj7EQEnv5LD+GxNTaT4L46jcKjjpLiQ=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -23654,11 +28594,21 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-iexplorer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
+      "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY="
+    },
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
+    },
+    "is-mobile": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
+      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
     },
     "is-nan": {
       "version": "1.3.2",
@@ -23693,8 +28643,7 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -23740,6 +28689,16 @@
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
       "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
     },
+    "is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
+    "is-svg-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
+      "integrity": "sha1-d6tZDBKz0gNI5cehPQBAyHeE3aA="
+    },
     "is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -23778,8 +28737,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -24598,6 +29556,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
     "kind-of": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -24654,6 +29617,11 @@
         "npmlog": "^4.1.2"
       }
     },
+    "lerp": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
+      "integrity": "sha1-oYyJaPkXiW3hXM/MKNVaa3Med24="
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -24664,7 +29632,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -24848,8 +29815,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -24955,11 +29921,112 @@
         "tmpl": "1.0.x"
       }
     },
+    "map-limit": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
+      "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
+      "requires": {
+        "once": "~1.3.0"
+      },
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1"
+          }
+        }
+      }
+    },
     "map-obj": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
       "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
       "dev": true
+    },
+    "mapbox-gl": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.0.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      }
+    },
+    "marching-simplex-table": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
+      "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
+      "requires": {
+        "convex-hull": "^1.0.3"
+      }
+    },
+    "mat4-decompose": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
+      "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
+      "requires": {
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2"
+      }
+    },
+    "mat4-interpolate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
+      "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
+      "requires": {
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2",
+        "mat4-decompose": "^1.0.3",
+        "mat4-recompose": "^1.0.3",
+        "quat-slerp": "^1.0.0"
+      }
+    },
+    "mat4-recompose": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
+      "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
+      "requires": {
+        "gl-mat4": "^1.0.1"
+      }
+    },
+    "math-log2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
+      "integrity": "sha1-+4lBvl9evol55xjmJzsXjlhpRWU="
+    },
+    "matrix-camera-controller": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.4.tgz",
+      "integrity": "sha512-zsPGPONclrKSImNpqqKDTcqFpWLAIwMXEJtCde4IFPOw1dA9udzFg4HOFytOTosOFanchrx7+Hqq6glLATIxBA==",
+      "requires": {
+        "binary-search-bounds": "^2.0.0",
+        "gl-mat4": "^1.1.2",
+        "gl-vec3": "^1.0.3",
+        "mat4-interpolate": "^1.0.3"
+      }
     },
     "memoize-one": {
       "version": "5.2.1",
@@ -25244,11 +30311,46 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "monotone-convex-hull-2d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "mouse-change": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
+      "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
+      "requires": {
+        "mouse-event": "^1.0.0"
+      }
+    },
+    "mouse-event": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
+      "integrity": "sha1-s3ie23EJmX1aky0dAdqhVDpQFzI="
+    },
+    "mouse-event-offset": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+      "integrity": "sha1-39hqbiSMa6jK1TuQXVA3ogY+mYQ="
+    },
+    "mouse-wheel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+      "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
+      "requires": {
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "devOptional": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multimatch": {
       "version": "5.0.0",
@@ -25271,6 +30373,19 @@
         }
       }
     },
+    "mumath": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
+      "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
+      "requires": {
+        "almost-equal": "^1.1.0"
+      }
+    },
+    "murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -25282,11 +30397,102 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
       "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "requires": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "ndarray-extract-contour": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
+      "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
+      "requires": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "ndarray-gradient": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
+      "integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
+      "requires": {
+        "cwise-compiler": "^1.0.0",
+        "dup": "^1.0.0"
+      }
+    },
+    "ndarray-linear-interpolate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ndarray-linear-interpolate/-/ndarray-linear-interpolate-1.0.0.tgz",
+      "integrity": "sha1-eLySuFuavBW25n7mWCj54hN65ys="
+    },
+    "ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+      "requires": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
+    "ndarray-pack": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
+      "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+      "requires": {
+        "cwise-compiler": "^1.1.2",
+        "ndarray": "^1.0.13"
+      }
+    },
+    "ndarray-scratch": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
+      "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
+      "requires": {
+        "ndarray": "^1.0.14",
+        "ndarray-ops": "^1.2.1",
+        "typedarray-pool": "^1.0.2"
+      }
+    },
+    "ndarray-sort": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
+      "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
+      "requires": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "needle": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.8.0.tgz",
+      "integrity": "sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -25299,6 +30505,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "nextafter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
+      "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
+      "requires": {
+        "double-bits": "^1.1.0"
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -25482,11 +30701,21 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
+    "normalize-svg-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
+      "integrity": "sha1-RWNg5g7Odfvve11+FgSA5//Rb+U="
+    },
     "normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true
+    },
+    "normals": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
+      "integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA="
     },
     "npm-bundled": {
       "version": "1.1.2",
@@ -25650,11 +30879,24 @@
         "set-blocking": "~2.0.0"
       }
     },
+    "number-is-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
+      "integrity": "sha1-5ZvKFy/+0nMY55x862y3LAlbIVI=",
+      "requires": {
+        "is-finite": "^1.0.1"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "numeric": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
+      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -25774,7 +31016,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -25782,6 +31023,15 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
+      }
+    },
+    "orbit-camera-controller": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
+      "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
+      "requires": {
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.3"
       }
     },
     "os-homedir": {
@@ -25961,6 +31211,14 @@
         }
       }
     },
+    "pad-left": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
+      "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
+      "requires": {
+        "repeat-string": "^1.3.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -25968,6 +31226,11 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parenthesis": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.7.tgz",
+      "integrity": "sha512-iMtu+HCbLXVrpf6Ys/4YKhcFxbux3xK4ZVB9r+a2kMSqeeQWQoDNYlXIsOjwlT2ldYXZ3k5PVeBnYn7fbAo/Bg=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -25991,6 +31254,24 @@
         "qs": "^6.9.4",
         "query-string": "^6.13.8"
       }
+    },
+    "parse-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
+      "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
+      "requires": {
+        "pick-by-alias": "^1.2.0"
+      }
+    },
+    "parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha1-en7A0esG+lMlx9PgCbhZoJtdSes="
+    },
+    "parse-unit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
     },
     "parse-url": {
       "version": "6.0.0",
@@ -26041,11 +31322,41 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
+    "pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "requires": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      }
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "permutation-parity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
+      "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
+      "requires": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "permutation-rank": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
+      "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
+      "requires": {
+        "invert-permutation": "^1.0.0",
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "pick-by-alias": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
+      "integrity": "sha1-X3yysfIabh6ISgyHhVqko3NhEHs="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -26075,6 +31386,130 @@
         "find-up": "^4.0.0"
       }
     },
+    "planar-dual": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
+      "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
+      "requires": {
+        "compare-angle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
+    },
+    "planar-graph-to-polyline": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.6.tgz",
+      "integrity": "sha512-h8a9kdAjo7mRhC0X6HZ42xzFp7vKDZA+Hygyhsq/08Qi4vVAQYJaLLYLvKUUzRbVKvdYqq0reXHyV0EygyEBHA==",
+      "requires": {
+        "edges-to-adjacency-list": "^1.0.0",
+        "planar-dual": "^1.0.0",
+        "point-in-big-polygon": "^2.0.1",
+        "robust-orientation": "^1.0.1",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0",
+        "uniq": "^1.0.0"
+      }
+    },
+    "plotly.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.3.1.tgz",
+      "integrity": "sha512-Vrm4ElvOoxN/PhWdMc/KsCLhsAsahgIGrJRQ3FgHUgBzM33joR2uQzlUyAFI2jR2kM95V7jG3Bq0qtNswAJNhg==",
+      "requires": {
+        "@plotly/d3": "3.8.0",
+        "@plotly/d3-sankey": "0.7.2",
+        "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/point-cluster": "^3.1.9",
+        "@turf/area": "^6.4.0",
+        "@turf/bbox": "^6.4.0",
+        "@turf/centroid": "^6.0.2",
+        "alpha-shape": "^1.0.0",
+        "canvas-fit": "^1.5.0",
+        "color-alpha": "1.0.4",
+        "color-normalize": "1.5.0",
+        "color-parse": "1.3.8",
+        "color-rgba": "2.1.1",
+        "convex-hull": "^1.0.3",
+        "country-regex": "^1.1.0",
+        "d3-force": "^1.2.1",
+        "d3-format": "^1.4.5",
+        "d3-geo": "^1.12.1",
+        "d3-geo-projection": "^2.9.0",
+        "d3-hierarchy": "^1.1.9",
+        "d3-interpolate": "^1.4.0",
+        "d3-time": "^1.1.0",
+        "d3-time-format": "^2.2.3",
+        "delaunay-triangulate": "^1.1.6",
+        "fast-isnumeric": "^1.1.4",
+        "gl-cone3d": "^1.5.2",
+        "gl-error3d": "^1.0.16",
+        "gl-heatmap2d": "^1.1.1",
+        "gl-line3d": "1.2.1",
+        "gl-mat4": "^1.2.0",
+        "gl-mesh3d": "^2.3.1",
+        "gl-plot2d": "^1.4.5",
+        "gl-plot3d": "^2.4.7",
+        "gl-pointcloud2d": "^1.0.3",
+        "gl-scatter3d": "^1.2.3",
+        "gl-select-box": "^1.0.4",
+        "gl-spikes2d": "^1.0.2",
+        "gl-streamtube3d": "^1.4.1",
+        "gl-surface3d": "^1.6.0",
+        "gl-text": "^1.1.8",
+        "glslify": "^7.1.1",
+        "has-hover": "^1.0.1",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.2",
+        "mapbox-gl": "1.10.1",
+        "matrix-camera-controller": "^2.1.4",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "native-promise-only": "^0.8.1",
+        "ndarray": "^1.0.19",
+        "ndarray-linear-interpolate": "^1.0.0",
+        "parse-svg-path": "^0.1.2",
+        "polybooljs": "^1.2.0",
+        "probe-image-size": "^7.2.1",
+        "regl": "^1.6.1",
+        "regl-error2d": "^2.0.12",
+        "regl-line2d": "^3.1.1",
+        "regl-scatter2d": "^3.2.6",
+        "regl-splom": "^1.0.14",
+        "right-now": "^1.0.0",
+        "robust-orientation": "^1.1.3",
+        "strongly-connected-components": "^1.0.1",
+        "superscript-text": "^1.0.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.2",
+        "to-px": "1.0.1",
+        "topojson-client": "^3.1.0",
+        "webgl-context": "^2.2.0",
+        "world-calendars": "^1.0.3"
+      }
+    },
+    "point-in-big-polygon": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.1.tgz",
+      "integrity": "sha512-DtrN8pa2VfMlvmWlCcypTFeBE4+OYz1ojDNJLKCWa4doiVAD6PRBbxFYAT71tsp5oKaRXT5sxEiHCAQKb1zr2Q==",
+      "requires": {
+        "binary-search-bounds": "^2.0.0",
+        "interval-tree-1d": "^1.0.1",
+        "robust-orientation": "^1.1.3",
+        "slab-decomposition": "^1.0.1"
+      }
+    },
+    "polybooljs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
+      "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g="
+    },
+    "polytope-closest-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
+      "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
+      "requires": {
+        "numeric": "^1.2.6"
+      }
+    },
     "portal-proto": {
       "version": "file:packages/portal-proto",
       "requires": {
@@ -26096,10 +31531,12 @@
         "jest": "^26.0.0",
         "jest-css-modules-transform": "^4.2.0",
         "next": "^11.0.1",
+        "plotly.js": "^2.3.1",
         "postcss": "^8.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-modal": "^3.14.3",
+        "react-plotly.js": "^2.5.1",
         "react-redux": "^7.2.0",
         "react-select": "^4.3.1",
         "react-tabs": "^3.2.2",
@@ -29002,11 +34439,15 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
+    "potpack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
+      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prettier": {
       "version": "2.3.2",
@@ -29045,11 +34486,20 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
+    "probe-image-size": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.1.tgz",
+      "integrity": "sha512-d+6L3NvQBCNt4peRDoEfA7r9bPm6/qy18FnLKwg4NWBC5JrJm0pMLRg1kF4XNsPe1bUdt3WIMonPJzQWN2HXjQ==",
+      "requires": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -29108,6 +34558,11 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
+    "protocol-buffers-schema": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.1.tgz",
+      "integrity": "sha512-YVCvdhxWNDP8/nJDyXLuM+UFsuPk4+1PB7WGPVDzm3HTHbzFLxQYeW2iZpS4mmnXrQJGBzt230t/BbEb7PrQaw=="
+    },
     "protocols": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
@@ -29144,6 +34599,26 @@
         }
       }
     },
+    "pxls": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
+      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "compute-dims": "^1.1.0",
+        "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
+        "is-buffer": "^2.0.3",
+        "to-uint8": "^1.4.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        }
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -29157,6 +34632,19 @@
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
+      }
+    },
+    "quantize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
+      "integrity": "sha1-0lrCAKd7bXD0ASfKFxoQ4zyFRt4="
+    },
+    "quat-slerp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
+      "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
+      "requires": {
+        "gl-quat": "^1.0.0"
       }
     },
     "query-string": {
@@ -29186,12 +34674,33 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "rat-vec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
+      "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
+      "requires": {
+        "big-rat": "^1.0.3"
       }
     },
     "react": {
@@ -29240,6 +34749,14 @@
         "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.0",
         "warning": "^4.0.3"
+      }
+    },
+    "react-plotly.js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.5.1.tgz",
+      "integrity": "sha512-Oya14whSHvPsYXdI0nHOGs1pZhMzV2edV7HAW1xFHD58Y73m/LbG2Encvyz1tztL0vfjph0JNhiwO8cGBJnlhg==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-redux": {
@@ -29572,6 +35089,16 @@
         }
       }
     },
+    "reduce-simplicial-complex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
+      "integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
+      "requires": {
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0",
+        "compare-oriented-cell": "^1.0.1"
+      }
+    },
     "redux": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
@@ -29590,6 +35117,11 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
+    "regex-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-regex/-/regex-regex-1.0.0.tgz",
+      "integrity": "sha1-kEih6uuHD01IDavHb8Qs3MC8OnI="
+    },
     "regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
@@ -29605,6 +35137,87 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "regl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.7.0.tgz",
+      "integrity": "sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w=="
+    },
+    "regl-error2d": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
+      "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "regl-line2d": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.1.tgz",
+      "integrity": "sha512-oxtdSNv2daqwOi72EpaT9WRtvA/DOAq9D/icNBs1fZviPSnC/6O85UgPpAuTguj+ri0n/e9+FDbqauYg+l+uqA==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "array-find-index": "^1.0.2",
+        "array-normalize": "^1.1.4",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0"
+      }
+    },
+    "regl-scatter2d": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.6.tgz",
+      "integrity": "sha512-ElPlu6jIx1Par4pG8OIhBuw5F5d+5qynYIlx4lMgikzkRtBgN5hjB3nfEp6jsMm4INPM367fs5vn6XcHD/s0Ow==",
+      "requires": {
+        "@plotly/point-cluster": "^3.1.9",
+        "array-range": "^1.0.1",
+        "array-rearrange": "^2.2.2",
+        "clamp": "^1.0.1",
+        "color-id": "^1.1.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "image-palette": "^2.1.0",
+        "is-iexplorer": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "regl-splom": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
+      "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "array-range": "^1.0.1",
+        "color-alpha": "^1.0.4",
+        "flatten-vertex-data": "^1.0.2",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.2.3"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
       "version": "2.88.2",
@@ -29709,6 +35322,14 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
     },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -29730,6 +35351,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
+    "right-now": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -29737,6 +35363,97 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "robust-compress": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-compress/-/robust-compress-1.0.0.tgz",
+      "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs="
+    },
+    "robust-determinant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
+      "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
+      "requires": {
+        "robust-compress": "^1.0.0",
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "robust-dot-product": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
+      "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
+      "requires": {
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "robust-in-sphere": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.2.1.tgz",
+      "integrity": "sha512-3zJdcMIOP1gdwux93MKTS0RiMYEGwQBoE5R1IW/9ZQmGeZzP7f7i4+xdcK8ujJvF/dEOS1WPuI9IB1WNFbj3Cg==",
+      "requires": {
+        "robust-scale": "^1.0.0",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "robust-linear-solve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
+      "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
+      "requires": {
+        "robust-determinant": "^1.1.0"
+      }
+    },
+    "robust-orientation": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.2.1.tgz",
+      "integrity": "sha512-FuTptgKwY6iNuU15nrIJDLjXzCChWB+T4AvksRtwPS/WZ3HuP1CElCm1t+OBfgQKfWbtZIawip+61k7+buRKAg==",
+      "requires": {
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
+      }
+    },
+    "robust-product": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
+      "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
+      "requires": {
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "robust-segment-intersect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
+      "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
     },
     "rollup": {
       "version": "2.52.7",
@@ -29768,6 +35485,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
     "rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -29786,6 +35508,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -29833,6 +35560,11 @@
         }
       }
     },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -29865,6 +35597,11 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "signum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+      "integrity": "sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc="
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -29880,11 +35617,80 @@
         }
       }
     },
+    "simplicial-complex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
+      "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
+      "requires": {
+        "bit-twiddle": "^1.0.0",
+        "union-find": "^1.0.0"
+      }
+    },
+    "simplicial-complex-boundary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
+      "integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
+      "requires": {
+        "boundary-cells": "^2.0.0",
+        "reduce-simplicial-complex": "^1.0.0"
+      }
+    },
+    "simplicial-complex-contour": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
+      "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
+      "requires": {
+        "marching-simplex-table": "^1.0.0",
+        "ndarray": "^1.0.15",
+        "ndarray-sort": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "simplify-planar-graph": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
+      "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
+      "requires": {
+        "robust-orientation": "^1.0.1",
+        "simplicial-complex": "^0.3.3"
+      },
+      "dependencies": {
+        "bit-twiddle": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-0.0.2.tgz",
+          "integrity": "sha1-wurruVKjuUrMFASX4c3NLxoz9Y4="
+        },
+        "simplicial-complex": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
+          "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
+          "requires": {
+            "bit-twiddle": "~0.0.1",
+            "union-find": "~0.0.3"
+          }
+        },
+        "union-find": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/union-find/-/union-find-0.0.4.tgz",
+          "integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY="
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
+    },
+    "slab-decomposition": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.3.tgz",
+      "integrity": "sha512-1EfR304JHvX9vYQkUi4AKqN62mLsjk6W45xTk/TxwN8zd3HGwS7PVj9zj0I6fgCZqfGlimDEY+RzzASHn97ZmQ==",
+      "requires": {
+        "binary-search-bounds": "^2.0.0",
+        "functional-red-black-tree": "^1.0.0",
+        "robust-orientation": "^1.1.3"
+      }
     },
     "slash": {
       "version": "3.0.0",
@@ -30030,6 +35836,15 @@
       "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
       "dev": true
     },
+    "split-polygon": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
+      "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
+      "requires": {
+        "robust-dot-product": "^1.0.0",
+        "robust-sum": "^1.0.0"
+      }
+    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -30042,8 +35857,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -30071,6 +35885,11 @@
         "minipass": "^3.1.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+    },
     "stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -30078,6 +35897,33 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
+      }
+    },
+    "static-eval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+      "requires": {
+        "escodegen": "^1.11.1"
+      },
+      "dependencies": {
+        "escodegen": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        }
       }
     },
     "stream-browserify": {
@@ -30099,6 +35945,34 @@
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
       }
+    },
+    "stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
+      "requires": {
+        "debug": "2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "2.0.0",
@@ -30129,6 +36003,30 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "string-split-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
+      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+      "requires": {
+        "parenthesis": "^3.1.5"
+      }
+    },
+    "string-to-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
+      "requires": {
+        "atob-lite": "^2.0.0",
+        "is-base64": "^0.1.0"
+      },
+      "dependencies": {
+        "atob-lite": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+          "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+        }
       }
     },
     "string-width": {
@@ -30222,10 +36120,28 @@
         "through": "^2.3.4"
       }
     },
+    "strongly-connected-components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
+      "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
+    },
     "stylis": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
       "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
+    },
+    "supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-7+bR4FbF5SYsmkHfDp61QiwCKtwNDyPsddk9TzfsDA5DQr5Goii5CVD2SXjglweFCxjrzVZf945ahqYfUIk8UA==",
+      "requires": {
+        "kdbush": "^3.0.0"
+      }
+    },
+    "superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
     },
     "supports-color": {
       "version": "7.2.0",
@@ -30243,6 +36159,54 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      }
+    },
+    "surface-nets": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
+      "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
+      "requires": {
+        "ndarray-extract-contour": "^1.0.0",
+        "triangulate-hypercube": "^1.0.0",
+        "zero-crossings": "^1.0.0"
+      }
+    },
+    "svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
+    },
+    "svg-path-bounds": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
+      "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
+      "requires": {
+        "abs-svg-path": "^0.1.1",
+        "is-svg-path": "^1.0.1",
+        "normalize-svg-path": "^1.0.0",
+        "parse-svg-path": "^0.1.2"
+      },
+      "dependencies": {
+        "normalize-svg-path": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+          "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+          "requires": {
+            "svg-arc-to-cubic-bezier": "^3.0.0"
+          }
+        }
+      }
+    },
+    "svg-path-sdf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
+      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
+      "requires": {
+        "bitmap-sdf": "^1.0.0",
+        "draw-svg-path": "^1.0.0",
+        "is-svg-path": "^1.0.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-path-bounds": "^1.0.1"
       }
     },
     "symbol-tree": {
@@ -30433,6 +36397,14 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-cache": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.2.2.tgz",
+      "integrity": "sha512-zky+UDYiX0a/aPw/YTBD+EzKMlCTu1chFuCMZeAkgoRiceySdROu1V2kJXhCbtEdBhiOviYnAdGiSYl58HW0ZQ==",
+      "requires": {
+        "vectorize-text": "^3.2.1"
+      }
+    },
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -30466,6 +36438,16 @@
         "readable-stream": "3"
       }
     },
+    "tinycolor2": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
+    },
+    "tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -30480,10 +36462,33 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
+    "to-array-buffer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
+      "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
+      "requires": {
+        "flatten-vertex-data": "^1.0.2",
+        "is-blob": "^2.0.1",
+        "string-to-arraybuffer": "^1.0.0"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
+    "to-float32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
+      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
+    },
+    "to-px": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
+      "integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
+      "requires": {
+        "parse-unit": "^1.0.1"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -30491,6 +36496,26 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "to-uint8": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
+      "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "clamp": "^1.0.1",
+        "is-base64": "^0.1.0",
+        "is-float-array": "^1.0.0",
+        "to-array-buffer": "^3.0.0"
+      }
+    },
+    "topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "requires": {
+        "commander": "2"
       }
     },
     "tough-cookie": {
@@ -30511,6 +36536,24 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
+      }
+    },
+    "triangulate-hypercube": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
+      "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
+      "requires": {
+        "gamma": "^0.1.0",
+        "permutation-parity": "^1.0.0",
+        "permutation-rank": "^1.0.0"
+      }
+    },
+    "triangulate-polyline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
+      "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
+      "requires": {
+        "cdt2d": "^1.0.0"
       }
     },
     "trim-newlines": {
@@ -30583,17 +36626,41 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "turntable-camera-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
+      "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
+      "requires": {
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.2",
+        "gl-vec3": "^1.0.2"
+      }
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -30610,11 +36677,24 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
+    "type-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
+      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typedarray-pool": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "requires": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -30661,6 +36741,16 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "union-find": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
+      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -30691,11 +36781,21 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+    },
     "upath": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
       "dev": true
+    },
+    "update-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
+      "integrity": "sha1-9RAYLYHugZ+4LDprIrYrve2ngI8="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -30731,6 +36831,49 @@
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "utils-copy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
+      "integrity": "sha1-biuXmCqozXPhGCo+b4vsPA9AWKc=",
+      "requires": {
+        "const-pinf-float64": "^1.0.0",
+        "object-keys": "^1.0.9",
+        "type-name": "^2.0.0",
+        "utils-copy-error": "^1.0.0",
+        "utils-indexof": "^1.0.0",
+        "utils-regex-from-string": "^1.0.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-buffer": "^1.0.1",
+        "validate.io-nonnegative-integer": "^1.0.0"
+      }
+    },
+    "utils-copy-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
+      "integrity": "sha1-eR3jk8DwmJCv1Z88vqY18HmpT6U=",
+      "requires": {
+        "object-keys": "^1.0.9",
+        "utils-copy": "^1.1.0"
+      }
+    },
+    "utils-indexof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
+      "integrity": "sha1-IP6r8J7xAYtSNkPoOA57yD7GG1w=",
+      "requires": {
+        "validate.io-array-like": "^1.0.1",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
+    "utils-regex-from-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
+      "integrity": "sha1-/hopCfjeD/DVGCyA+8ZU1qaH0Yk=",
+      "requires": {
+        "regex-regex": "^1.0.0",
+        "validate.io-string-primitive": "^1.0.0"
       }
     },
     "uuid": {
@@ -30782,6 +36925,96 @@
         "builtins": "^1.0.3"
       }
     },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "validate.io-array-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
+      "integrity": "sha1-evn363tRcVvrIhVmjsXM5U+t21o=",
+      "requires": {
+        "const-max-uint32": "^1.0.2",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
+    "validate.io-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-buffer/-/validate.io-buffer-1.0.2.tgz",
+      "integrity": "sha1-hS1nNAIZFNXROvwyUxdh43IO1E4="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
+      "integrity": "sha1-qaoBA1X+hoHA/qbBp0rSQZyt3cY=",
+      "requires": {
+        "validate.io-number-primitive": "^1.0.0"
+      }
+    },
+    "validate.io-matrix-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-matrix-like/-/validate.io-matrix-like-1.0.2.tgz",
+      "integrity": "sha1-XsMqddCInaxzbepovdYUWxVe38M="
+    },
+    "validate.io-ndarray-like": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-ndarray-like/-/validate.io-ndarray-like-1.0.0.tgz",
+      "integrity": "sha1-2KOw7RZbvx0vwNAHMnDPpVIpWRk="
+    },
+    "validate.io-nonnegative-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
+      "integrity": "sha1-gGkkOgjF+Y6VQTySnf17GPP28p8=",
+      "requires": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+    },
+    "validate.io-number-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-number-primitive/-/validate.io-number-primitive-1.0.0.tgz",
+      "integrity": "sha1-0uAfICmJNp3PEVVElWQgOv5YTlU="
+    },
+    "validate.io-positive-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
+      "integrity": "sha1-ftLQO0wnVYzGagCqsPDpIYFKZYI=",
+      "requires": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "validate.io-string-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate.io-string-primitive/-/validate.io-string-primitive-1.0.1.tgz",
+      "integrity": "sha1-uBNbn7E3K94C/dU60dDM1t55j+4="
+    },
+    "vectorize-text": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.2.tgz",
+      "integrity": "sha512-34NVOCpMMQVXujU4vb/c6u98h6djI0jGdtC202H4Huvzn48B6ARsR7cmGh1xsAc0pHNQiUKGK/aHF05VtGv+eA==",
+      "requires": {
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.0",
+        "ndarray": "^1.0.11",
+        "planar-graph-to-polyline": "^1.0.6",
+        "simplify-planar-graph": "^2.0.1",
+        "surface-nets": "^1.0.0",
+        "triangulate-polyline": "^1.0.0"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -30791,6 +37024,16 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "requires": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
       }
     },
     "w3c-hr-time": {
@@ -30835,6 +37078,24 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "weak-map": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+    },
+    "weakmap-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
+      "integrity": "sha1-1lr9eEEJshZuAP9XHDMVDsKkC0k="
+    },
+    "webgl-context": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
+      "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
+      "requires": {
+        "get-canvas-context": "^1.0.1"
       }
     },
     "webidl-conversions": {
@@ -30954,14 +37215,21 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "world-calendars": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
+      "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
+      "requires": {
+        "object-assign": "^4.1.0"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -31155,6 +37423,14 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "zero-crossings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
+      "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
+      "requires": {
+        "cwise-compiler": "^1.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/isomorphic-fetch": "^0.0.35",
+    "@types/plotly.js": "^1.54.14",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
     "eslint": "^7.30.0",

--- a/packages/portal-proto/src/features/charts/BarChart.tsx
+++ b/packages/portal-proto/src/features/charts/BarChart.tsx
@@ -1,10 +1,14 @@
+import { Config, Layout } from 'plotly.js';
 import Plot from 'react-plotly.js';
 
 interface BarChartProps {
   readonly data: Record<string, any>;
+  // if defined, this determines the height of the chart. Otherwise, autosizing is used.
+  readonly height?: number;
+  readonly marginBottom?: number;
 }
 
-const BarChart: React.FC<BarChartProps> = ({ data }: BarChartProps) => {
+const BarChart: React.FC<BarChartProps> = ({ data, height, marginBottom }: BarChartProps) => {
 
 const chartData = {
     x: data.x,
@@ -18,13 +22,10 @@ const chartData = {
       },
     },
     type: 'bar',
-
-
   };
 
-  const layout = {
+  const layout: Partial<Layout> = {
     uniformtext: { mode: 'show', minsize: 12 },
-    autosize: true,
     xaxis: {
       tickson: "labels",
       automargin: true,
@@ -56,18 +57,24 @@ const chartData = {
     margin: {
       l: 80,
       r: 40,
-      b: 100,
+      b: marginBottom !== undefined ? marginBottom : 100,
       t: 30,
       pad: 4
     },
   };
+
+  if (height !== undefined) {
+    layout.height = height;
+  } else {
+    layout.autosize = true;
+  } 
 
   if (data.x.length > 6) {
     layout.xaxis.tickangle = 35;
   }
 
 
-  const config = {responsive: true,
+  const config: Partial<Config> = {responsive: true,
     toImageButtonOptions: {
       format: 'png', // one of png, svg, jpeg, webp
       filename: data.filename,

--- a/packages/portal-proto/src/features/charts/FacetChart.tsx
+++ b/packages/portal-proto/src/features/charts/FacetChart.tsx
@@ -46,19 +46,23 @@ const useCaseFacet = (field: string): UseCaseFacetResponse => {
 
 interface FacetProps {
   readonly field: string;
+  readonly showXLabels?: boolean;
+  readonly height?: number;
+  readonly marginBottom?: number;
 }
+
 // from https://stackoverflow.com/questions/33053310/remove-value-from-object-without-mutation
 const removeKey = (key, {[key]: _, ...rest}) => rest;
 
-const processChartData = (facetData:Record<string, any>, field: string, maxBins = 100) => {
+const processChartData = (facetData:Record<string, any>, field: string, maxBins = 100, showXLabels = true) => {
   const data = removeKey('_missing', facetData);
   const xvals = Object.keys(data).slice(0, maxBins).map(x =>x);
   const xlabels = Object.keys(data).slice(0, maxBins).map(x => processLabel(x, 12));
   const results : Record<string, any> = {
     x: xvals,
     y: Object.values(data).slice(0, maxBins),
-    tickvals: xvals,
-    ticktext: xlabels,
+    tickvals: showXLabels ? xvals : [],
+    ticktext: showXLabels ? xlabels : [],
     title: convertFieldToName(field),
     filename: `${field}.svg`,
     yAxisTitle: "# of Cases"
@@ -66,7 +70,7 @@ const processChartData = (facetData:Record<string, any>, field: string, maxBins 
   return results;
 }
 
-export const FacetChart: React.FC<FacetProps> = ({ field }: FacetProps) => {
+export const FacetChart: React.FC<FacetProps> = ({ field, showXLabels = true, height, marginBottom }: FacetProps) => {
   const { data, error, isUninitialized, isFetching, isError } =
     useCaseFacet(field);
 
@@ -84,13 +88,13 @@ export const FacetChart: React.FC<FacetProps> = ({ field }: FacetProps) => {
 
   const maxValuesToDisplay =12;
 
-  const chart_data = processChartData(data, field, maxValuesToDisplay);
+  const chart_data = processChartData(data, field, maxValuesToDisplay, showXLabels);
 
   return <div className="flex flex-col border-2 ">
     <div className="flex items-center justify-between flex-wrap bg-gray-100 p-1.5">
       {convertFieldToName(field)}
     </div>
-    <BarChartWithNoSSR data={chart_data}></BarChartWithNoSSR>
+    <BarChartWithNoSSR data={chart_data} height={height} marginBottom={marginBottom}></BarChartWithNoSSR>
   </div>;
 };
 

--- a/packages/portal-proto/src/pages/charts.tsx
+++ b/packages/portal-proto/src/pages/charts.tsx
@@ -5,7 +5,8 @@ import { FacetChart } from "../features/charts/FacetChart";
 const FacetsPage: NextPage = () => {
   return (
     <SimpleLayout>
-      <div className="flex flex-col content-center">
+      <div className="flex flex-col content-center gap-y-4">
+        <div>Charts with Defaults</div>
         <div className="grid grid-cols-3 gap-4">
           <FacetChart field="primary_site" />
           <FacetChart field="demographic.gender" />
@@ -13,6 +14,16 @@ const FacetsPage: NextPage = () => {
           <FacetChart field="samples.sample_type" />
           <FacetChart field="samples.tissue_type" />
           <FacetChart field="diagnoses.tissue_or_organ_of_origin" />
+        </div>
+
+        <div>Charts with Customizations</div>
+        <div className="grid grid-cols-3 gap-4">
+          <FacetChart field="primary_site" height={200} marginBottom={30} showXLabels={false}/>
+          <FacetChart field="demographic.gender" height={200} marginBottom={30} showXLabels={false}/>
+          <FacetChart field="disease_type" height={200} marginBottom={30} showXLabels={false}/>
+          <FacetChart field="samples.sample_type" height={200} marginBottom={30} showXLabels={false}/>
+          <FacetChart field="samples.tissue_type" height={200} marginBottom={30} showXLabels={false}/>
+          <FacetChart field="diagnoses.tissue_or_organ_of_origin" height={200} marginBottom={30} showXLabels={false}/>
         </div>
       </div>
     </SimpleLayout>


### PR DESCRIPTION
This commit adds some non-breaking changes to the
facet charts.  Optional configurations have been added to support some
of the user flow experiements.  if the configs are not defined, they
default to the original values.