### PR TITLE
PEAR-375: Update facets property name to filters in cohort model

### DIFF
--- a/data/cohort-api-db.json
+++ b/data/cohort-api-db.json
@@ -18,14 +18,14 @@
       "id": "f05d91d2-2f06-4b61-bbfe-5098e9464011",
       "context_id": "d88c194d-5313-49df-9908-972626ef1211",
       "name": "New Custom Cohort",
-      "facets": [],
+      "filters": [],
       "frozen": false
     },
     {
       "id": "fa3ec4f4-5530-4e2e-9773-12ba16c95ff2",
       "context_id": "d88c194d-5313-49df-9908-972626ef1211",
       "name": "Baily's Cohort",
-      "facets": [
+      "filters": [
         {
           "field": "cases.primary_site",
           "value": ["breast", "bronchus and lung"]
@@ -37,7 +37,7 @@
       "id": "2f70de91-7c5a-41d2-9620-90670dfdaddb",
       "name": "Mike's Cohort",
       "context_id": "d0b33d2d-4fd4-4654-914a-1afeb98b2e8d",
-      "facets": [
+      "filters": [
         {
           "field": "cases.demographic.gender",
           "value": ["unknown"]

--- a/data/cohort-api-server.js
+++ b/data/cohort-api-server.js
@@ -1,16 +1,17 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Defines mock cohort api server which provides REST endpoints for a cohort
 // database created via the cohort-api-db.json file. To start the mock api
-// service:
-// cd to the /data directory in project root and run: node cohort-api-server.js
+// service from the project root run: node data/cohort-api-server.js
 
-var jsonServer = require("json-server");
+const path = require("path");
+const db_file = path.join(__dirname, "cohort-api-db.json");
+const jsonServer = require("json-server");
 const { isUndefined } = require("lodash");
 const crypto = require("crypto");
 
-var server = jsonServer.create();
-var router = jsonServer.router("cohort-api-db.json");
-var middlewares = jsonServer.defaults();
+const server = jsonServer.create();
+const router = jsonServer.router(db_file);
+const middlewares = jsonServer.defaults();
 
 // custom flags
 const context_auth_enabled = true;
@@ -113,13 +114,13 @@ function readFileAsJson(filename) {
 
 // get all contexts
 function getContexts() {
-  const json_data = readFileAsJson("cohort-api-db.json");
+  const json_data = readFileAsJson(db_file);
   return json_data["contexts"];
 }
 
 // get all cohorts
 function getCohorts() {
-  const json_data = readFileAsJson("cohort-api-db.json");
+  const json_data = readFileAsJson(db_file);
   return json_data["cohorts"];
 }
 

--- a/packages/core/src/features/api/cohortApiSlice.ts
+++ b/packages/core/src/features/api/cohortApiSlice.ts
@@ -1,8 +1,7 @@
 // This defines the middleware for the cohort API POC.
 
-// For this slice to work, the mock cohort api must be started. To do this,
-// run the following command from the /data directory:
-// node cohort-api-server.js
+// For this slice to work, the mock cohort api must be started. See
+// data/cohort-api-server.js for additional details.
 
 import { fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { coreCreateApi } from "../../coreCreateApi";

--- a/packages/core/src/features/api/cohortApiTypes.ts
+++ b/packages/core/src/features/api/cohortApiTypes.ts
@@ -3,7 +3,7 @@ export interface CohortModel {
   id: string;
   context_id: string;
   name: string;
-  facets: ReadonlyArray<string>;
+  filters: ReadonlyArray<string>;
   frozen: boolean;
 }
 

--- a/packages/portal-proto/src/pages/cohort-rtkq-api-analysis-page.tsx
+++ b/packages/portal-proto/src/pages/cohort-rtkq-api-analysis-page.tsx
@@ -23,7 +23,18 @@ const SingleAppsPage: NextPage = () => {
   if (isLoading) {
     cohort_data = [];
   } else if (isSuccess) {
-    cohort_data = data;
+    // this map transformation is only necessary until ContextBar is updated
+    // to use the property name of filters instead of facets
+    cohort_data = data.map((elm) => ({
+      id: elm.id,
+      context_id: elm.context_id,
+      name: elm.name,
+      facets: elm.filters,
+      frozen: elm.frozen,
+    }));
+
+    // TODO: remove map transformation and use the following instead
+    //cohort_data = data;
   }
 
   return (

--- a/packages/portal-proto/src/pages/cohort-rtkq-api-test-cohort.tsx
+++ b/packages/portal-proto/src/pages/cohort-rtkq-api-test-cohort.tsx
@@ -69,7 +69,7 @@ const CohortApiTest: NextPage = () => {
   const addBody = {
     context_id: currentContextId,
     name: testCohortName,
-    facets: [],
+    filters: [],
     frozen: false,
   };
 


### PR DESCRIPTION
Includes the following changes:
- Update property name in cohort model from facets to filters
- Update mock api db file to replace the name facets with filters
- Update json-server implementation to use relative path to mock api db file
- General improvements to json-server implementation
- Update information comments in various files with updated json-server details
- Add transformation in test analysis page to handle filters -> facets name change until ContextBar gets updated
