### PR TITLE
remove compile from portal-proto/package.json

### DIFF
--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -5,7 +5,6 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "compile": "tsc",
     "test": "jest unit",
     "test:watch": "jest unit --watch",
     "test:int": "echo No integrations tests yet",


### PR DESCRIPTION
## Description
Remove compile step from package.json in portal-proto as Docker build requires only core to be compiled before a build.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
