### PR TITLE
PEAR-504 - missing enum bars 

### DIFF
--- a/packages/portal-proto/src/features/charts/EnumFacetChart.tsx
+++ b/packages/portal-proto/src/features/charts/EnumFacetChart.tsx
@@ -51,9 +51,9 @@ const processChartData = (
     )
     .slice(0, maxBins)
     .map((d) => ({
-      x: truncateString(processLabel(d), 35),
+      x: processLabel(d),
+      truncatedXName: truncateString(processLabel(d), 35),
       y: data[d],
-      fullXName: processLabel(d),
     }));
   return results.reverse();
 };
@@ -125,7 +125,7 @@ interface EnumBarChartTooltipProps {
   readonly y?: number;
   readonly datum?: {
     y: number;
-    fullXName: string;
+    x: string;
   };
 }
 
@@ -140,7 +140,7 @@ const EnumBarChartTooltip: React.FC<EnumBarChartTooltipProps> = ({
         <Tooltip
           label={
             <>
-              <b>{datum.fullXName}</b>
+              <b>{datum.x}</b>
               <p>{datum.y.toLocaleString()} Cases</p>
             </>
           }
@@ -158,6 +158,7 @@ const EnumBarChartTooltip: React.FC<EnumBarChartTooltipProps> = ({
 interface EnumBarChartData {
   x: string;
   y: number;
+  truncatedXName: string;
 }
 
 interface BarChartProps {
@@ -190,6 +191,7 @@ const EnumBarChart: React.FC<BarChartProps> = ({
             dy={-15}
             textAnchor={"start"}
             style={[{ fontSize: 23 }]}
+            text={({ datum }) => data[datum - 1]?.truncatedXName}
           />
         }
         style={{


### PR DESCRIPTION
## Description
Fixes this issue where the bars were disappearing if the truncated values of two fields were the same (Victory chart doesn't seem to like duplicate x values). Just switched the actual x value to be the untruncated name and had the tick label display the truncated name. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
Broken:
![image](https://user-images.githubusercontent.com/4624053/184983559-9d22738f-5cb4-47e9-b147-b869787f7a86.png)
Fixed!
<img width="268" alt="Screen Shot 2022-08-16 at 3 57 01 PM" src="https://user-images.githubusercontent.com/4624053/184983762-9f2e6d2c-3f46-4770-9f41-b6ae4a02b716.png">


