### PR TITLE
PEAR-535 add base path

### DIFF
--- a/packages/portal-proto/README.md
+++ b/packages/portal-proto/README.md
@@ -16,3 +16,20 @@ To start a dev server on port 3000, run:
 ```bash
 npm run dev
 ```
+
+You can connect at http://localhost:3000/v2
+
+## Base Path
+
+This application is configured to use a base path. It is configured in next.config.js.
+
+### Images
+
+In next.js, the configuring the basePath does not automatically apply the base path to
+the image components from `next/image`. To make development easier, we added the `Image`
+component int `components/Image.tsx`. This will automatically add the base path if needed.
+It has the same props as `next/image`.
+
+```
+import { Image } from "@/components/Image";
+```

--- a/packages/portal-proto/next.config.js
+++ b/packages/portal-proto/next.config.js
@@ -6,8 +6,19 @@ const withTM = require("next-transpile-modules")([
   "@stjude/proteinpaint-client",
 ]);
 
+/**
+ * This basePath defines root of the application. This must match
+ * the intended deployment path. For example, the basePath of "/v2"
+ * means that the application will be available at "https://<host>/v2"
+ */
+const basePath = "/v2";
+
 module.exports = withTM({
   experimental: {
     outputStandalone: true,
+  },
+  basePath,
+  publicRuntimeConfig: {
+    basePath,
   },
 });

--- a/packages/portal-proto/setupTests.ts
+++ b/packages/portal-proto/setupTests.ts
@@ -4,3 +4,9 @@ import { loadEnvConfig } from "@next/env";
 window.URL.createObjectURL = (input: any) => "";
 
 loadEnvConfig(__dirname, true, { info: () => null, error: console.error });
+
+jest.mock("next/config", () => () => ({
+  publicRuntimeConfig: {
+    basePath: "/v2",
+  },
+}));

--- a/packages/portal-proto/src/components/Image.tsx
+++ b/packages/portal-proto/src/components/Image.tsx
@@ -1,0 +1,35 @@
+import getConfig from "next/config";
+import NextImage, { ImageProps } from "next/image";
+
+/**
+ * This is a wrapper around the next/image Image component. The only
+ * difference is that this wrapper is aware of the basePath.  If the
+ * basePath is set, then it prepends the basePath to the image source
+ * path.
+ * @param props
+ * @returns
+ */
+export const Image = (props: ImageProps): JSX.Element => {
+  const { src } = props;
+
+  if (typeof src === "string") {
+    const {
+      publicRuntimeConfig: { basePath },
+    } = getConfig();
+    const newSrc = generateImageSource(src, basePath);
+
+    return <NextImage {...{ ...props, src: newSrc }} />;
+  }
+
+  return <NextImage {...props} />;
+};
+
+export const generateImageSource = (src: string, basePath?: string): string => {
+  if (basePath !== undefined && basePath !== null) {
+    if (!src.startsWith("http")) {
+      return `${basePath}${src}`;
+    }
+  }
+
+  return src;
+};

--- a/packages/portal-proto/src/components/Image.unit.test.tsx
+++ b/packages/portal-proto/src/components/Image.unit.test.tsx
@@ -1,0 +1,29 @@
+import { generateImageSource } from "@/components/Image";
+
+describe("Image", () => {
+  describe("generateImageSource", () => {
+    describe("when basePath exists", () => {
+      test("should return new source", () => {
+        const src = "/original";
+        const basePath = "/prefix";
+        const imageSource = generateImageSource(src, basePath);
+        expect(imageSource).toBe("/prefix/original");
+      });
+
+      test("should return same source when it is a url", () => {
+        const src = "https://example.com/image.png";
+        const basePath = "/prefix";
+        const imageSource = generateImageSource(src, basePath);
+        expect(imageSource).toBe(src);
+      });
+    });
+
+    describe("when basePath does not exist", () => {
+      test("should return source", () => {
+        const src = "/original";
+        const imageSource = generateImageSource(src, undefined);
+        expect(imageSource).toBe("/original");
+      });
+    });
+  });
+});

--- a/packages/portal-proto/src/features/apps/Apps.tsx
+++ b/packages/portal-proto/src/features/apps/Apps.tsx
@@ -1,6 +1,5 @@
 import { App, Initials } from "../layout/UserFlowVariedPages";
-import Image from "next/image";
-
+import { Image } from "@/components/Image";
 export interface Clickable {
   readonly onClick?: () => void;
 }

--- a/packages/portal-proto/src/features/apps/NullApp.tsx
+++ b/packages/portal-proto/src/features/apps/NullApp.tsx
@@ -1,4 +1,5 @@
-import Image from "next/image";
+import { Image } from "@/components/Image";
+
 const NullApp: React.FC = () => {
   return (
     <div className=" flex flex-col bg-nci-gray-lighter items-center justify-center  w-100 h-screen/2 m-4 rounded-lg shadow-lg">

--- a/packages/portal-proto/src/features/cases/CaseView.tsx
+++ b/packages/portal-proto/src/features/cases/CaseView.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from "react";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { Case } from "./CasesView";
 import ReactModal from "react-modal";
 

--- a/packages/portal-proto/src/features/layout/Header.tsx
+++ b/packages/portal-proto/src/features/layout/Header.tsx
@@ -15,7 +15,7 @@ import { Button, LoadingOverlay, Menu } from "@mantine/core";
 import { NextLink } from "@mantine/next";
 import { useTour } from "@reactour/tour";
 import { ReactNode } from "react";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import {
   MdShoppingCart as CartIcon,
   MdOutlineApps as AppsIcon,

--- a/packages/portal-proto/src/features/layout/Simple.tsx
+++ b/packages/portal-proto/src/features/layout/Simple.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { PropsWithChildren } from "react";
 
 /**

--- a/packages/portal-proto/src/features/studies/StudiesView.tsx
+++ b/packages/portal-proto/src/features/studies/StudiesView.tsx
@@ -1,6 +1,6 @@
 import { ProjectDefaults, useProjects } from "@gff/core";
 import { Option, Select } from "../../components/Select";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { Button } from "@mantine/core";
 import { MdFlip, MdSearch } from "react-icons/md";
 import { BsQuestionCircleFill, BsFillTriangleFill } from "react-icons/bs";

--- a/packages/portal-proto/src/features/studies/StudiesViewLeft.tsx
+++ b/packages/portal-proto/src/features/studies/StudiesViewLeft.tsx
@@ -1,6 +1,6 @@
 import { ProjectDefaults, useProjects } from "@gff/core";
 import { Option, Select } from "../../components/Select";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { MdFlip, MdSearch } from "react-icons/md";
 import { BsQuestionCircleFill, BsFillTriangleFill } from "react-icons/bs";
 import { useState } from "react";

--- a/packages/portal-proto/src/features/studies/StudyView.tsx
+++ b/packages/portal-proto/src/features/studies/StudyView.tsx
@@ -1,5 +1,4 @@
-import Image from "next/image";
-
+import { Image } from "@/components/Image";
 export const StudyView: React.FC<unknown> = () => {
   return (
     <div className="flex flex-col gap-y-4">

--- a/packages/portal-proto/src/features/styleguide/NullCard.tsx
+++ b/packages/portal-proto/src/features/styleguide/NullCard.tsx
@@ -1,4 +1,5 @@
-import Image from "next/image";
+import { Image } from "@/components/Image";
+
 const NullApp: React.FC = () => {
   return (
     <div className=" flex flex-col bg-nci-gray-lighter items-center justify-center  w-100 h-screen/2 m-4 rounded-lg shadow-lg">

--- a/packages/portal-proto/src/features/user-flow/all-apps/baseExploration.tsx
+++ b/packages/portal-proto/src/features/user-flow/all-apps/baseExploration.tsx
@@ -4,7 +4,7 @@ import React, { PropsWithChildren, useRef } from "react";
 import { useState } from "react";
 import { ContextualStudiesView } from "../../studies/StudiesView";
 import { StudyView } from "../../studies/StudyView";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { FacetChart } from "../../charts/FacetChart";
 import ReactModal from "react-modal";
 import { Case, ContextualCasesView } from "../../cases/CasesView";

--- a/packages/portal-proto/src/features/user-flow/many-pages/cohort.tsx
+++ b/packages/portal-proto/src/features/user-flow/many-pages/cohort.tsx
@@ -9,7 +9,7 @@ import {
   MdExpandLess as ExpandLessIcon,
 } from "react-icons/md";
 import classNames from "classnames";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import ReactModal from "react-modal";
 import { Select } from "../../../components/Select";
 import { Case, ContextualCasesView } from "../../cases/CasesView";

--- a/packages/portal-proto/src/features/user-flow/many-pages/navigation-utils.tsx
+++ b/packages/portal-proto/src/features/user-flow/many-pages/navigation-utils.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import Image from "next/image";
-
+import { Image } from "@/components/Image";
 export const headerElements = [
   <Link key="BuildCohort" href="/cohort-builder">
     <div className="text-sm font-heading  hover:bg-nci-blue-lighter text-nci-gray-darkest p-2 rounded inline-flex flex-nowrap items-center shadow-md ">

--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { Divider } from "@mantine/core";
 import {
   MdPlayArrow,

--- a/packages/portal-proto/src/features/user-flow/workflow/FeaturedToolCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/FeaturedToolCard.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { ActionIcon, Grid } from "@mantine/core";
 import { MdPlayArrow } from "react-icons/md";
 import { AppRegistrationEntry } from "./utils";

--- a/packages/portal-proto/src/features/user-flow/workflow/navigation-utils.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/navigation-utils.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { Button, Tooltip } from "@mantine/core";
 import { NextLink } from "@mantine/next";
 

--- a/packages/portal-proto/src/pages/colors.tsx
+++ b/packages/portal-proto/src/pages/colors.tsx
@@ -1,7 +1,6 @@
 import { NextPage } from "next";
 import { SimpleLayout } from "../features/layout/Simple";
-import Image from "next/image";
-
+import { Image } from "@/components/Image";
 const nciPrimaryColors = ["gray", "red", "blumine", "blue", "teal", "cyan"];
 const nciSecondaryColors = ["green", "violet", "purple", "orange", "yellow"];
 const gdcPrimaryColors = [

--- a/packages/portal-proto/src/pages/user-flow/all-apps-v2/index.tsx
+++ b/packages/portal-proto/src/pages/user-flow/all-apps-v2/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import Link from "next/link";
 
 const IndexPage: NextPage = () => {

--- a/packages/portal-proto/src/pages/user-flow/all-apps/index.tsx
+++ b/packages/portal-proto/src/pages/user-flow/all-apps/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import Link from "next/link";
 
 const IndexPage: NextPage = () => {

--- a/packages/portal-proto/src/pages/user-flow/many-pages-v2/analysis.tsx
+++ b/packages/portal-proto/src/pages/user-flow/many-pages-v2/analysis.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from "next";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import Link from "next/link";
 import { useState } from "react";
 import ReactModal from "react-modal";

--- a/packages/portal-proto/src/pages/user-flow/many-pages-v2/index.tsx
+++ b/packages/portal-proto/src/pages/user-flow/many-pages-v2/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import Link from "next/link";
 
 const IndexPage: NextPage = () => {

--- a/packages/portal-proto/src/pages/user-flow/many-pages-v2/studies.tsx
+++ b/packages/portal-proto/src/pages/user-flow/many-pages-v2/studies.tsx
@@ -1,7 +1,7 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";
 import Link from "next/link";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { useState } from "react";
 import ReactModal from "react-modal";
 import { ContextualStudiesView } from "../../../features/studies/StudiesView";

--- a/packages/portal-proto/src/pages/user-flow/many-pages/analysis.tsx
+++ b/packages/portal-proto/src/pages/user-flow/many-pages/analysis.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from "next";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import React, { PropsWithChildren, useState } from "react";
 import ReactModal from "react-modal";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";

--- a/packages/portal-proto/src/pages/user-flow/many-pages/index.tsx
+++ b/packages/portal-proto/src/pages/user-flow/many-pages/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import Link from "next/link";
 import { headerElements } from "@/features/user-flow/many-pages/navigation-utils";
 

--- a/packages/portal-proto/src/pages/user-flow/many-pages/studies.tsx
+++ b/packages/portal-proto/src/pages/user-flow/many-pages/studies.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { useState } from "react";
 import ReactModal from "react-modal";
 import { ContextualStudiesView } from "../../../features/studies/StudiesView";

--- a/packages/portal-proto/src/pages/user-flow/many-pages/studiesleft.tsx
+++ b/packages/portal-proto/src/pages/user-flow/many-pages/studiesleft.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import { useState } from "react";
 import ReactModal from "react-modal";
 import { ContextualStudiesView } from "../../../features/studies/StudiesViewLeft";

--- a/packages/portal-proto/src/pages/user-flow/workbench/analysis.tsx
+++ b/packages/portal-proto/src/pages/user-flow/workbench/analysis.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from "next";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import React, { PropsWithChildren, useState } from "react";
 import ReactModal from "react-modal";
 import { UserFlowVariedPages } from "../../../features/layout/UserFlowVariedPages";

--- a/packages/portal-proto/src/pages/user-flow/workbench/index.tsx
+++ b/packages/portal-proto/src/pages/user-flow/workbench/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { UserFlowVariedPages } from "@/features/layout/UserFlowVariedPages";
-import Image from "next/image";
+import { Image } from "@/components/Image";
 import Link from "next/link";
 import { headerElements } from "@/features/user-flow/workflow/navigation-utils";
 import { Button, Tooltip } from "@mantine/core";


### PR DESCRIPTION
The next.js configuration for basePath has been set to /v2 to
support the deployment of portal v2 in conjunction with portal v1.

Since the image component from next/image does not support basePath,
a wrapper component has been added to automatically add the basePath
when appropriate. This removes the need to manually add the base
path to image sources.

## Description

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
