### PR TITLE
PEAR-580 - facet card search feedback

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/SummaryFacets.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/SummaryFacets.tsx
@@ -33,7 +33,6 @@ export const SummaryFacets: React.FC<SummaryFacetProps> = ({
                 field={entry.field}
                 docType={entry.docType}
                 facetName={entry.name}
-                showSearch
                 startShowingData={false}
                 key={`summary-chart-${index}`}
                 width="w-64"

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -358,9 +358,9 @@ export const EnumFacet: React.FC<EnumFacetCardProps> = ({
                           {showPercent ? (
                             <div className="flex-none text-right w-18 ">
                               (
-                              {(((count as number) / totalCount) * 100)
-                                .toFixed(2)
-                                .toLocaleString()}
+                              {(((count as number) / totalCount) * 100).toFixed(
+                                2,
+                              )}
                               %)
                             </div>
                           ) : null}


### PR DESCRIPTION
## Description
- summary cards are searchable
- search is moved out of the bar
- focus on search when it's opened
- search applies to chart side

## Checklist

- [ ] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
![2022-09-19 12 51 16](https://user-images.githubusercontent.com/4624053/191082014-58fb2fca-5398-4d38-8863-f6c39a4db641.gif)
