### PR TITLE
PEAR-633 : Fix tooltips on app card in analysis center

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
@@ -141,7 +141,12 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
           <div className="flex flex-row items-center text-primary-content-darkest">
             <span>{`${caseCounts.toLocaleString()} Cases`}</span>
             {caseCounts === 0 && (
-              <Tooltip label={entry?.noDataTooltip} withArrow>
+              <Tooltip
+                label={entry?.noDataTooltip}
+                withArrow
+                width={200}
+                multiline
+              >
                 <div>
                   <MdInfo className="inline-block ml-1" />
                 </div>


### PR DESCRIPTION
## Description
Fix tooltips on app card in analysis center

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshot
<img width="1152" alt="Screen Shot 2022-10-06" src="https://user-images.githubusercontent.com/109599213/194332581-8562ffda-8966-43da-a461-7d45745557d3.png">
s/Screen Recordings (if Appropriate)
