### PR TITLE
changed date range picker end date dropdown orientation to bottom-end

### DIFF
--- a/packages/portal-proto/src/features/facets/DateRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/DateRangeFacet.tsx
@@ -149,6 +149,7 @@ const DateRangeFacet: React.FC<DateRangeFacetProps> = ({
           placeholder="Through"
           className="px-1"
           inputFormat="YYYY/MM/DD"
+          dropdownPosition="bottom-end"
           value={dateRangeValue[1]}
           minDate={dateRangeValue[0]}
           onChange={(d: Date | null) =>


### PR DESCRIPTION
## Description
moves dropdown position for date picker "through" date to bottom-end, in order to eliminate datepicker cutoff on right

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
