### PR TITLE
PEAR-655: Fix button background to be transparent on AnalysisCards

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
@@ -116,7 +116,7 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
             )
           }
           classNames={{
-            root: "text-primary-content-darkest font-bold",
+            root: "text-primary-content-darkest font-bold bg-transparent",
             rightIcon: "ml-0",
           }}
         >


### PR DESCRIPTION
## Description
Fix button background to be transparent on AnalysisCards

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
<img width="993" alt="Screen Shot 2022-10-14" src="https://user-images.githubusercontent.com/109599213/195929979-98441be4-aa93-4640-a2cc-f04b95c782cd.png">
