### PR TITLE
PEAR-612: Fix-edit-icon-position-in-CategoricalBinningModal

### DIFF
--- a/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
+++ b/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
@@ -467,7 +467,7 @@ const GroupInput: React.FC<GroupInputProps> = ({
         >
           {groupName}{" "}
           <PencilIcon
-            className="ml-2"
+            className="ml-2 shrink-0"
             onClick={(e) => {
               e.stopPropagation();
               setEditField(groupName);


### PR DESCRIPTION
## Description

Fix-edit-icon-position-in-CategoricalBinningModal

## Checklist

- [ ] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
<img width="998" alt="Screen Shot 2022-10-17" src="https://user-images.githubusercontent.com/109599213/196192101-3bd5e674-24ba-4d33-90f4-dc14f4abe232.png">
