### PR TITLE
PEAR-715 adjust cDAVE survival buttons tooltips logic

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveTable.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveTable.tsx
@@ -88,10 +88,10 @@ const CDaveTable: React.FC<CDaveTableProps> = ({
                     <td className="float-right">
                       <Tooltip
                         label={
-                          !enoughCasesForSurvival
-                            ? "Not enough data"
-                            : key === "missing"
+                          key === "missing"
                             ? `Plot cannot be generated for this value`
+                            : !enoughCasesForSurvival
+                            ? "Not enough data"
                             : survivalSelected
                             ? `Click to remove ${key} from plot`
                             : selectedSurvivalPlots.length === 5


### PR DESCRIPTION
## Description
Adjusts tooltips logic for cDAVE survival plot button. If value is "missing" and the number of cases is <10, it displays "Plot cannot be generated for this value" instead of "Not enough data". 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)

<img width="856" alt="Screen Shot 2022-11-01 at 8 32 33 PM" src="https://user-images.githubusercontent.com/73256434/199373814-584a19a9-8667-4a5b-a67b-576a7b8fc5c0.png">
