### PR TITLE
QA-1665 Remove hardcoded localhost

### DIFF
--- a/holmes-py/docs/test-framework.md
+++ b/holmes-py/docs/test-framework.md
@@ -13,3 +13,25 @@ Use `data-testid={elementIdentifierName}` within a tag to help locate the elemen
 Reference:
 1. **Using "data-test" in Tests** - https://blog.rstankov.com/using-rel-in-testing/
 2. **data-\*** - https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*
+
+### Target Test Environment setup
+The following environment are supported:
+
+| environment | environment variable  | value    | target url                        |
+|-------------|-----------------------|----------|-----------------------------------|
+| Shared QA / Prod  | APP_ENVIRONMENT | (default)| https://portal.gdc.cancer.gov/v2  |
+| Local / Localhost | APP_ENVIRONMENT | _LOCAL   | http://localhost:3000/v2          |
+
+Example: run the following command in your CLI before running tests
+1. Run tests in particular environment
+```bash
+# localhost
+export APP_ENVIRONMENT=_LOCAL
+
+# Shared QA / Prod
+unset APP_ENVIRONMENT
+```
+2. Then run tests
+```bash
+gauge run specs
+```

--- a/holmes-py/env/default/default.properties
+++ b/holmes-py/env/default/default.properties
@@ -20,7 +20,8 @@ logs_directory = logs
 enable_multithreading = true
 
 # use for testing single apps purpose in a repo
-APP_ENDPOINT = http://google.com
+APP_ENDPOINT = https://portal.gdc.cancer.gov/v2
+APP_ENDPOINT_LOCAL = http://localhost:3000/v2
 
 # set default browser
 browser = chrome

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/app.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/app.py
@@ -1,3 +1,5 @@
+import os
+
 from step_impl.apps.gdc_data_portal_v2.pages.home_page import HomePage
 from step_impl.apps.gdc_data_portal_v2.pages.nav_analysis_center import NavAnalysisCenterPage
 from step_impl.apps.gdc_data_portal_v2.pages.clinical_data_analysis import ClinicalDataAnalysisPage
@@ -5,7 +7,8 @@ from step_impl.apps.gdc_data_portal_v2.pages.clinical_data_analysis import Clini
 
 class GDCDataPortalV2App:
     def __init__(self, webdriver):  # webdriver is page now.
-        self.url = "http://localhost:3000/v2/user-flow/workbench"
+        APP_ENDPOINT = f"APP_ENDPOINT{os.getenv('APP_ENVIRONMENT','')}"
+        self.url = f"{os.getenv(APP_ENDPOINT)}/user-flow/workbench"
         self.driver = webdriver
         self.init_pages()
 


### PR DESCRIPTION
## Description
Use APP_ENVIRONMENT variable to set _LOCAL in order to run tests against localhost:3000. By default, the tests will run against https://portal.gdc.cancer.gov/v2 and points to any VPN that we're connected to while running the tests. Removes hardcoded value for URL.

## Checklist - n/a

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
