### PR TITLE
PEAR-639 BCR Auxiliary XML runtime error

### DIFF
--- a/packages/core/src/features/files/filesSlice.ts
+++ b/packages/core/src/features/files/filesSlice.ts
@@ -102,6 +102,7 @@ const dataFormats = [
   "BCR SSF XML",
   "BEDPE",
   "BCR AUXILIARY XML",
+  "BCR Auxiliary XML",
   "BCR OMF XML",
   "BCR BIOTAB",
   "BCR Biotab",


### PR DESCRIPTION
## Description
Fixes error when BCR_Auxiliary_XML is selected in the repository App.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
