### PR TITLE
PEAR-700: QuickSearch fix for uppercased query string

### DIFF
--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -67,7 +67,7 @@ export const QuickSearch = ({
               color: `${idx === focusedListElemIdx && "#38393a"}`, //nciGrayDarkest : might need to change the color
             }}
           >
-            {findMatchingToken(item, searchText.trim())}
+            {findMatchingToken(item, searchText.trim().toLocaleLowerCase())}
           </Highlight>
         </span>
       </div>


### PR DESCRIPTION
## Description
The query string was not being converted to lowercase before passing to the `findMatchingToken` util function.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
<img width="1439" alt="Screen Shot 2022-11-08 at 5 34 51 PM" src="https://user-images.githubusercontent.com/101295912/200699143-9b8ec473-a3f4-4695-ae8c-27a0afb1e072.png">
<img width="1436" alt="Screen Shot 2022-11-08 at 5 34 59 PM" src="https://user-images.githubusercontent.com/101295912/200699147-44f36a8d-5a10-4073-bca5-88ae05dc683c.png">
