### PR TITLE
PEAR-685 - Cart download spinner fix

### DIFF
--- a/packages/portal-proto/src/components/Modals/BaseModal.tsx
+++ b/packages/portal-proto/src/components/Modals/BaseModal.tsx
@@ -15,6 +15,7 @@ interface Props {
     title: string;
   }>;
   withCloseButton?: boolean;
+  onClose?: () => void;
   closeOnClickOutside?: boolean;
   closeOnEscape?: boolean;
 }
@@ -27,6 +28,7 @@ export const BaseModal: React.FC<Props> = ({
   children,
   buttons,
   withCloseButton,
+  onClose,
   closeOnClickOutside,
   closeOnEscape,
 }: Props) => {
@@ -37,6 +39,9 @@ export const BaseModal: React.FC<Props> = ({
       title={title}
       onClose={() => {
         dispatch(hideModal());
+        if (onClose) {
+          onClose();
+        }
       }}
       styles={() => ({
         header: {

--- a/packages/portal-proto/src/components/Modals/CartDownloadModal.tsx
+++ b/packages/portal-proto/src/components/Modals/CartDownloadModal.tsx
@@ -30,6 +30,7 @@ const CartDownloadModal = ({
       closeButtonLabel="Close"
       openModal={openModal}
       size="xl"
+      onClose={() => setActive(false)}
     >
       <hr />
       {numFilesCannotAccess > 0 && (
@@ -88,7 +89,13 @@ const CartDownloadModal = ({
       )}
       <hr />
       <div className="flex justify-end gap-2 mt-4">
-        <Button onClick={() => dispatch(hideModal())} color="primary">
+        <Button
+          onClick={() => {
+            dispatch(hideModal());
+            setActive(false);
+          }}
+          color="primary"
+        >
           Cancel
         </Button>
         <DownloadButton


### PR DESCRIPTION
## Description
Fixes bug where the download spinner was continuing to ... spin if the download modal was closed without a download initiating. 

## Checklist

- [N/A] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
