### PR TITLE
disable caseSet creation listener

### DIFF
--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -12,7 +12,7 @@ import {
 } from "redux-persist";
 import { reducers } from "./reducers";
 import { cohortApiSliceMiddleware } from "./features/api/cohortApiSlice";
-import { caseSetListenerMiddleware } from "./listeners";
+// import { caseSetListenerMiddleware } from "./listeners";
 
 import storage from "./storage-persist";
 import { survivalApiSliceMiddleware } from "./features/survival/survivalApiSlice";
@@ -35,13 +35,13 @@ export const coreStore = configureStore({
       serializableCheck: {
         ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
       },
-    })
-      .concat(
-        cohortApiSliceMiddleware,
-        survivalApiSliceMiddleware,
-        graphqlAPISliceMiddleware,
-      )
-      .prepend(caseSetListenerMiddleware.middleware), // needs to be prepended
+    }).concat(
+      cohortApiSliceMiddleware,
+      survivalApiSliceMiddleware,
+      graphqlAPISliceMiddleware,
+    ),
+  // TODO: fix caseSet creation
+  //  .prepend(caseSetListenerMiddleware.middleware), // needs to be prepended
 });
 
 setupListeners(coreStore.dispatch);


### PR DESCRIPTION
## Description
Removes the caseSet listener as caseSet creation is slow in UAT
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
