### PR TITLE
PEAR-702 - no demo for sequence reads, hide scRNA card for now

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
@@ -111,7 +111,7 @@ export const REGISTERED_APPS = [
     name: "Sequence Reads",
     icon: "sequence-reads.png",
     tags: ["sequenceAnalysis"],
-    hasDemo: true,
+    hasDemo: false,
     description:
       "Visualize sequencing reads for a given gene, position, SNP, or variant.",
     id: "SequenceReadApp",
@@ -131,6 +131,7 @@ export const REGISTERED_APPS = [
     noDataTooltip:
       "Current cohort does not have SSM data available for visualization.",
   },
+  /*
   {
     name: "scRNA-Seq",
     icon: "scRnaSeqViz.png",
@@ -144,6 +145,7 @@ export const REGISTERED_APPS = [
     noDataTooltip:
       "Current cohort does not have scRNA-Seq data available for visualization.",
   },
+  */
 ];
 
 export const APPTAGS = [


### PR DESCRIPTION
## Description

* remove the Demo button for the Sequence Reads card in the Analysis Center (there'll be no demo mode since that would require an open access BAM)
* remove/hide the scRNA-Seq card - we won't have scRNA-Seq for UAT but will have the app later

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
