### PR TITLE
PEAR-295: Link annotation counts in file table to annotations browser

### DIFF
--- a/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
@@ -86,8 +86,8 @@ const FilesTables: React.FC = () => {
 
   const getAnnotationsLinkParams = (file: GdcFile): string | null => {
     // Due to limitation in the length of URI, we decided to cap a link to be created for files which has < 150 annotations for now
-    // 150 annotations was a safe number. It was tested in Chrome, Firefox, Safari and Edge
-    // TODO: after the fix for v2 this needs to be updated (https://jira.opensciencedatacloud.org/browse/PEAR-758)
+    // 150 annotations was a safe number. It was tested in Chrome, Firefox, Safari and Edge.
+    // TODO: Follow Up Ticket - https://jira.opensciencedatacloud.org/browse/PEAR-758
     const MAX_ANNOATATION_COUNT = 150;
     if (!file?.annotations || file.annotations.length > MAX_ANNOATATION_COUNT)
       return null;


### PR DESCRIPTION
## Description
Linking annotation count to annotation page in portal v1.

## Checklist
- [N/A] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)

https://user-images.githubusercontent.com/101295912/202237166-5299862c-e96d-4fca-8779-e69f8517c0af.mov

