### PR TITLE
PEAR-623: Fix order of Cohort Builder cards to be preserved as default

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/utils.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/utils.ts
@@ -10,7 +10,5 @@ export const getFacetInfo = (
   fields: ReadonlyArray<string>,
   facets: Record<string, FacetDefinition>,
 ): ReadonlyArray<FacetDefinition> => {
-  return Object.entries(facets)
-    .filter(([key, facet]) => fields.includes(key) && facet !== null)
-    .map((f) => f[1]);
+  return fields.map((field) => facets[field]).filter((facet) => facet);
 };


### PR DESCRIPTION
## Description

Fix order of Cohort Builder cards to be preserved as default
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
<img width="1369" alt=" 2022-11-28" src="https://user-images.githubusercontent.com/109599213/204340469-c413dc8e-f61b-456b-bd74-c1e66794311d.png">
