### PR TITLE
PEAR-776 updates the dbSNP link in mutation summary page

### DIFF
--- a/packages/portal-proto/src/utils/index.ts
+++ b/packages/portal-proto/src/utils/index.ts
@@ -87,8 +87,7 @@ export const externalLinks = {
     `http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=${id}`,
   cosn: (id: string): string =>
     `http://cancer.sanger.ac.uk/cosmic/ncv/overview?id=${id}`,
-  dbsnp: (id: string): string =>
-    `https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${id}`,
+  dbsnp: (id: string): string => `https://www.ncbi.nlm.nih.gov/snp/${id}`,
   ensembl: (id: string): string =>
     `http://nov2020.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${id}`,
   entrez_gene: (id: string): string => `http://www.ncbi.nlm.nih.gov/gene/${id}`,


### PR DESCRIPTION
## Description
Updates the dbSNP link in mutation summary page to a working link.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
