### PR TITLE
PEAR-809: remove second download button in cart/FileTable

### DIFF
--- a/packages/portal-proto/src/features/cart/FilesTable.tsx
+++ b/packages/portal-proto/src/features/cart/FilesTable.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import fileSize from "filesize";
-import { Button, Menu } from "@mantine/core";
-import { MdArrowDropDown as DropdownIcon } from "react-icons/md";
-import { VscTrash as TrashIcon } from "react-icons/vsc";
 import { capitalize } from "lodash";
 import {
   useCoreSelector,
@@ -16,7 +13,7 @@ import {
   VerticalTable,
   HandleChangeInput,
 } from "@/features/shared/VerticalTable";
-import { removeFromCart, RemoveFromCartButton } from "./updateCart";
+import { RemoveFromCartButton } from "./updateCart";
 import FunctionButton from "@/components/FunctionButton";
 import { downloadTSV } from "../shared/TableUtils";
 import { convertDateToString } from "src/utils/date";
@@ -47,9 +44,7 @@ interface FilesTableProps {
   readonly filesByCanAccess: Record<string, CartFile[]>;
 }
 
-const FilesTable: React.FC<FilesTableProps> = ({
-  filesByCanAccess,
-}: FilesTableProps) => {
+const FilesTable: React.FC<FilesTableProps> = () => {
   const [tableData, setTableData] = useState([]);
   const [pageSize, setPageSize] = useState(20);
   const [activePage, setActivePage] = useState(1);


### PR DESCRIPTION
## Description
Remove the second download button from FileTable in the cart View.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
![image](https://user-images.githubusercontent.com/1093780/205688703-4bcfd31f-343e-4186-bc17-e54d4908948e.png)
