### PR TITLE
PEAR-882: add ssmsCases and sequenceRead counts to Analysis Cards

### DIFF
--- a/packages/core/src/features/cohort/countSlice.ts
+++ b/packages/core/src/features/cohort/countSlice.ts
@@ -5,7 +5,7 @@ import {
   createUseFiltersCoreDataHook,
   DataStatus,
 } from "../../dataAccess";
-import { buildCohortGqlOperator } from "./filters";
+import { buildCohortGqlOperator, joinFilters } from "./filters";
 
 import { CoreDispatch } from "../../store";
 import { CoreState } from "../../reducers";
@@ -24,6 +24,8 @@ const initialState: CountsState = {
     fileCounts: -1,
     genesCounts: -1,
     mutationCounts: -1,
+    ssmCaseCounts: -1,
+    sequenceReadCaseCounts: -1,
     casesMax: -1,
   },
   status: "uninitialized",
@@ -35,7 +37,9 @@ export interface CountsState {
 }
 
 const CountsGraphQLQuery = `
-  query countsQuery($filters: FiltersArgument) {
+  query countsQuery($filters: FiltersArgument, 
+  $ssmCaseFilter: FiltersArgument,
+  $sequenceReadsCaseFilter: FiltersArgument) {
   viewer {
     repository {
       cases {
@@ -45,6 +49,11 @@ const CountsGraphQLQuery = `
       },
       files {
         hits(filters: $filters, first: 0) {
+          total
+        }
+      },
+      sequenceReads : cases {
+        hits(filters: $sequenceReadsCaseFilter, first: 0) {
           total
         }
       }
@@ -65,6 +74,11 @@ const CountsGraphQLQuery = `
           total
         }
       }
+     ssmsCases : cases {
+        hits(filters: $ssmCaseFilter, first: 0) {
+          total
+        }
+      }
     }
   }
 }`;
@@ -74,10 +88,47 @@ export const fetchCohortCaseCounts = createAsyncThunk<
   void,
   { dispatch: CoreDispatch; state: CoreState }
 >("cohort/CohortCounts", async (_, thunkAPI): Promise<GraphQLApiResponse> => {
-  const cohortFilters = buildCohortGqlOperator(
-    selectCurrentCohortFilterSet(thunkAPI.getState()),
+  const cohortFilters = selectCurrentCohortFilterSet(thunkAPI.getState());
+  const caseSSMFilter = buildCohortGqlOperator(
+    joinFilters(cohortFilters ?? { mode: "and", root: {} }, {
+      mode: "and",
+      root: {
+        "cases.available_variation_data": {
+          operator: "includes",
+          field: "cases.available_variation_data",
+          operands: ["ssm"],
+        },
+      },
+    }),
   );
-  const graphQlFilters = cohortFilters ? { filters: cohortFilters } : {};
+  const sequenceReadsFilters = buildCohortGqlOperator(
+    joinFilters(cohortFilters ?? { mode: "and", root: {} }, {
+      mode: "and",
+      root: {
+        "files.index_files.data_format": {
+          operator: "=",
+          field: "files.index_files.data_format",
+          operand: "bai",
+        },
+        "files.data_type": {
+          operator: "=",
+          field: "files.data_type",
+          operand: "Aligned Reads",
+        },
+        "files.data_format": {
+          operator: "=",
+          field: "files.data_format",
+          operand: "bam",
+        },
+      },
+    }),
+  );
+  const cohortFiltersGQL = buildCohortGqlOperator(cohortFilters);
+  const graphQlFilters = {
+    filters: cohortFiltersGQL ?? {},
+    ssmCaseFilter: caseSSMFilter,
+    sequenceReadsCaseFilter: sequenceReadsFilters,
+  };
   return await graphqlAPI(CountsGraphQLQuery, graphQlFilters);
 });
 
@@ -95,10 +146,14 @@ const slice = createSlice({
         } else {
           // copy the counts for explore and repository
           state.counts = {
+            // TODO rename **Counts to count
             caseCounts: response.data.viewer.explore.cases.hits.total,
             genesCounts: response.data.viewer.explore.genes.hits.total,
             mutationCounts: response.data.viewer.explore.ssms.hits.total,
             fileCounts: response.data.viewer.repository.files.hits.total,
+            ssmCaseCounts: response.data.viewer.explore.ssmsCases.hits.total,
+            sequenceReadCaseCounts:
+              response.data.viewer.repository.sequenceReads.hits.total,
             repositoryCaseCounts:
               response.data.viewer.repository.cases.hits.total,
             casesMax: Math.max(

--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
@@ -26,7 +26,7 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
   setDescriptionVisible,
 }: AnalysisCardProps) => {
   const cohortCounts = useCoreSelector((state) => selectCohortCounts(state));
-  let caseCounts = cohortCounts?.repositoryCaseCounts || 0;
+  let caseCounts = cohortCounts?.[entry.countsField] || 0;
 
   // TODO - remove, just for demo purposes
   if (entry.name === "scRNA-Seq" || entry.name === "Gene Expression") {

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
@@ -18,6 +18,7 @@ export const REGISTERED_APPS = [
     icon: "icons/apps/cdave.svg",
     tags: ["clinicalAnalysis"],
     hasDemo: true,
+    countsField: "repositoryCaseCounts",
     id: "CDave",
     description:
       "Use clinical variables to perform basic statistical analysis of your cohort.",
@@ -28,6 +29,7 @@ export const REGISTERED_APPS = [
     tags: ["generalUtility"],
     hasDemo: false,
     id: "CohortBuilder",
+    countsField: "repositoryCaseCounts",
     description:
       "Build and define your custom cohorts using a variety of clinical and biospecimen features.",
   },
@@ -37,6 +39,7 @@ export const REGISTERED_APPS = [
     tags: ["variantAnalysis", "ssm"],
     hasDemo: true,
     id: "MutationFrequencyApp",
+    countsField: "ssmCaseCounts",
     description:
       "Visualize most frequently mutated genes and somatic mutations.",
     noDataTooltip:
@@ -48,6 +51,7 @@ export const REGISTERED_APPS = [
     icon: "icons/database.svg",
     tags: ["files"],
     hasDemo: false,
+    countsField: "repositoryCaseCounts",
     id: "Downloads",
     description:
       "Browse and download the files associated with your cohort for more sophisticated analysis.",
@@ -58,6 +62,7 @@ export const REGISTERED_APPS = [
     tags: [],
     hasDemo: false,
     id: "Projects",
+    countsField: "repositoryCaseCounts",
     description:
       "View the Projects available within the GDC and select them for further exploration and analysis.",
   },
@@ -67,6 +72,7 @@ export const REGISTERED_APPS = [
     tags: ["clinicalAnalysis"],
     hasDemo: true,
     id: "CohortComparisonApp",
+    countsField: "repositoryCaseCounts",
     description:
       "Display the survival analysis of your cohorts and compare characteristics such as gender, vital status and age at diagnosis.",
     selectAdditionalCohort: true,
@@ -92,6 +98,7 @@ export const REGISTERED_APPS = [
     tags: ["generalUtility"],
     hasDemo: true,
     hideCounts: true,
+    countsField: "repositoryCaseCounts",
     description:
       "Display Venn diagram and find intersection or union, etc. of your cohorts.",
     id: "SetOperations",
@@ -103,6 +110,7 @@ export const REGISTERED_APPS = [
     iconSize: { width: 80, height: 48 },
     tags: ["variantAnalysis", "cnv", "ssm"],
     hasDemo: true,
+    countsField: "ssmCaseCounts",
     description:
       "Visualize the top most mutated cases and genes affected by high impact mutations in your cohort.",
     id: "OncoGridApp",
@@ -115,6 +123,7 @@ export const REGISTERED_APPS = [
     icon: "sequence-reads.png",
     tags: ["sequenceAnalysis"],
     hasDemo: false,
+    countsField: "sequenceReadCaseCounts",
     description:
       "Visualize sequencing reads for a given gene, position, SNP, or variant.",
     id: "SequenceReadApp",
@@ -129,6 +138,7 @@ export const REGISTERED_APPS = [
     description:
       "Visualize mutations in protein-coding genes by consequence type and protein domain.",
     id: "ProteinPaintApp",
+    countsField: "ssmCaseCounts",
     caseCounts: 0.25,
     optimizeRules: ["available data = ssm"],
     noDataTooltip:

--- a/packages/portal-proto/src/features/user-flow/workflow/utils.ts
+++ b/packages/portal-proto/src/features/user-flow/workflow/utils.ts
@@ -12,6 +12,7 @@ export interface AppRegistrationEntry {
   readonly id?: string;
   readonly description?: string;
   readonly iconSize?: IconSize;
+  readonly countsField?: string;
   readonly caseCounts?: number; // Added for MR Demo TODO: Compute real values
   readonly hideCounts?: boolean;
   readonly optimizeRules?: ReadonlyArray<string>;


### PR DESCRIPTION
## Description
Adds ssmCases and sequenceReads case counts to appropriate Analysis cards
## Checklist

- [ ] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
![image](https://user-images.githubusercontent.com/1093780/206103420-0bda1aa7-e066-4144-89a5-2e6cdd949bdc.png)
