### PR TITLE
hot fix to show the PP SSM lollipop track 

### DIFF
--- a/packages/portal-proto/src/features/apps/ProteinPaintApp.tsx
+++ b/packages/portal-proto/src/features/apps/ProteinPaintApp.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { ProteinPaintWrapper } from "../proteinpaint/ProteinPaintWrapper";
 
 const ProteinPaintApp: FC = () => {
-  return <ProteinPaintWrapper track="lolliplot" />;
+  return <ProteinPaintWrapper track="lollipop" />;
 };
 
 export default ProteinPaintApp;

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -47,8 +47,8 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
       }
 
       const data =
-        props.track == "lolliplot"
-          ? getLolliplotTrack(props, filter0)
+        props.track == "lollipop"
+          ? getLollipopTrack(props, filter0)
           : props.track == "bam" && userDetails?.username
           ? getBamTrack(props, filter0)
           : props.track == "matrix"
@@ -68,7 +68,7 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
 
       if (ppRef.current) {
         ppRef.current.update(arg);
-      } else if (userDetails?.username) {
+      } else if (props.track != "bam" || userDetails?.username) {
         const pp_holder = rootElem.querySelector(".sja_root_holder");
         if (pp_holder) pp_holder.remove();
         runproteinpaint(arg).then((pp) => {
@@ -116,7 +116,7 @@ interface PpApi {
   update(arg: any): null;
 }
 
-function getLolliplotTrack(props: PpProps, filter0: any) {
+function getLollipopTrack(props: PpProps, filter0: any) {
   // host in gdc is just a relative url path,
   // using the same domain as the GDC portal where PP is embedded
   const arg: Mds3Arg = {

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
@@ -22,7 +22,7 @@ jest.mock("@stjude/proteinpaint-client", () => ({
 test("SSM lolliplot arguments", () => {
   userDetails = { data: { username: "test" } };
   filter = { abc: "xyz" };
-  const { unmount } = render(<ProteinPaintWrapper track="lolliplot" />);
+  const { unmount } = render(<ProteinPaintWrapper track="lollipop" />);
   expect(typeof runpparg).toBe("object");
   expect(typeof runpparg.host).toBe("string");
   expect(runpparg.noheader).toEqual(true);


### PR DESCRIPTION
even if the user is not logged in; rename track to 'lollipop'

## Description
Fixes the bug introduced when checking for the user login status for the bam track, should not have affected the SSM track

## Checklist

- [X] Added proper unit tests
