### PR TITLE
improve the PP wrapper jsx template and react useState()

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, FC } from "react";
+import { useEffect, useRef, useState, FC } from "react";
 import { runproteinpaint } from "@stjude/proteinpaint-client";
 import {
   useCoreSelector,
@@ -27,6 +27,8 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
   );
 
   const { data: userDetails } = useUserDetails();
+  const [alertDisplay, setAlertDisplay] = useState("none");
+  const [rootDisplay, setRootDisplay] = useState("none");
 
   // to track reusable instance for mds3 skewer track
   const ppRef = useRef<PpApi>();
@@ -34,17 +36,10 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
   useEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
-      const loginPrompt =
-        "Please login to access the Sequence Read visualization tool.";
-      if (props.track == "bam") {
-        if (!userDetails.username) {
-          rootElem.innerHTML = `<div style='margin: 32px'><b>Access alert</b><hr><p>${loginPrompt}</p></div>`;
-          ppRef.current = null;
-          return;
-        } else if (rootElem.innerHTML.includes(loginPrompt)) {
-          rootElem.innerHTML = "";
-        }
-      }
+      const isAuthorized = props.track != "bam" || userDetails.username;
+      setAlertDisplay(isAuthorized ? "none" : "block");
+      setRootDisplay(isAuthorized ? "block" : "none");
+      if (!isAuthorized) return;
 
       const data =
         props.track == "lollipop"
@@ -68,7 +63,7 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
 
       if (ppRef.current) {
         ppRef.current.update(arg);
-      } else if (props.track != "bam" || userDetails?.username) {
+      } else {
         const pp_holder = rootElem.querySelector(".sja_root_holder");
         if (pp_holder) pp_holder.remove();
         runproteinpaint(arg).then((pp) => {
@@ -86,8 +81,26 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
     ],
   );
 
+  const alertRef = useRef();
   const divRef = useRef();
-  return <div ref={divRef} />;
+  return (
+    <div>
+      <div
+        ref={alertRef}
+        style={{ margin: "32px", display: `${alertDisplay}` }}
+        className="sjpp-wrapper-alert-div"
+      >
+        <b>Access alert</b>
+        <hr />
+        <p>Please login to access the Sequence Read visualization tool.</p>
+      </div>
+      <div
+        ref={divRef}
+        style={{ display: `${rootDisplay}` }}
+        className="sjpp-wrapper-root-div"
+      ></div>
+    </div>
+  );
 };
 
 interface Mds3Arg {

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
@@ -40,7 +40,7 @@ test("SSM lolliplot arguments", () => {
 test("Sequence Read arguments - logged in", () => {
   userDetails = { data: { username: "test" } };
   filter = { test: 1 };
-  const { unmount, queryByText } = render(<ProteinPaintWrapper track="bam" />);
+  const { unmount, container } = render(<ProteinPaintWrapper track="bam" />);
   expect(typeof runpparg).toBe("object");
   expect(typeof runpparg.host).toBe("string");
   expect(runpparg.noheader).toEqual(true);
@@ -49,7 +49,12 @@ test("Sequence Read arguments - logged in", () => {
   expect(runpparg.holder instanceof HTMLElement).toBe(true);
   expect(runpparg.gdcbamslice).toEqual({ hideTokenInput: true });
   expect(runpparg.filter0).toEqual({ test: 1 });
-  expect(queryByText("Access alert")).not.toBeInTheDocument();
+  expect(container.querySelector(".sjpp-wrapper-alert-div")).toHaveStyle(
+    `display: none`,
+  );
+  expect(container.querySelector(".sjpp-wrapper-root-div")).toHaveStyle(
+    `display: block`,
+  );
   unmount();
 });
 
@@ -57,7 +62,12 @@ test("Sequence Read arguments - logged in", () => {
 test("Sequence Read arguments - not logged in", () => {
   userDetails = { data: { username: null } };
   filter = { test: 1 };
-  const { unmount, queryByText } = render(<ProteinPaintWrapper track="bam" />);
-  expect(queryByText("Access alert")).toBeInTheDocument();
+  const { unmount, container } = render(<ProteinPaintWrapper track="bam" />);
+  expect(container.querySelector(".sjpp-wrapper-alert-div")).toHaveStyle(
+    `display: block`,
+  );
+  expect(container.querySelector(".sjpp-wrapper-root-div")).toHaveStyle(
+    `display: none`,
+  );
   unmount();
 });


### PR DESCRIPTION
for a more predictable rendering of PP sequence read access alert

## Description
Previously, native DOM properties, such as innerHTML, were set outside of the jsx template in the PP react wrapper. This resulted in clunky, unpredictable rendering of the access alert versus bam track divs. Adding the alert div to the jsx template with `useState()` to dynamically set display styles makes the rendering more reliable.

## Checklist

- [x] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
![Screen Shot 2022-12-08 at 2 08 20 PM](https://user-images.githubusercontent.com/411031/206557575-91e3aae3-bcda-412f-9083-d6b37c6baf24.png)
![Screen Shot 2022-12-08 at 2 06 51 PM](https://user-images.githubusercontent.com/411031/206557583-2e19236c-df14-4abf-a42c-4911bbac6107.png)
