### PR TITLE
PEAR-830: add singular label option to CountButton

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CountButton.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CountButton.tsx
@@ -15,21 +15,23 @@ const CountButton: React.FC<CountButtonProp> = ({
   bold = false,
 }: CountButtonProp) => {
   const cohortCounts = useFilteredCohortCounts();
+  const adjustedLabel =
+    cohortCounts.data[countName] !== 1 ? label : label.slice(0, -1);
   return (
     <div className={className}>
-      <div className="flex flex-row flex-nowrap items-center">
+      <div className="flex flex-row flex-nowrap items-center font-heading">
         {cohortCounts.isSuccess ? (
           <>
             <span className={`${bold ? "font-bold pr-1" : "pr-1"}`}>
               {cohortCounts.data[countName].toLocaleString()}
             </span>{" "}
             <span className={`${bold ? "font-medium pr-1" : "pr-1"}`}>
-              {label}
+              {adjustedLabel}
             </span>
           </>
         ) : (
           <>
-            <Loader color="gray" size="xs" className="mr-2" /> {label}{" "}
+            <Loader color="gray" size="xs" className="mr-2" /> {adjustedLabel}{" "}
           </>
         )}
       </div>


### PR DESCRIPTION
## Description
When counts == 1 last char is dropped from label. Cases -> Case
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
![image](https://user-images.githubusercontent.com/1093780/206581717-ccb2465f-8208-4e70-90f6-44daaa7a193f.png)
![image](https://user-images.githubusercontent.com/1093780/206581751-9ee4ffdc-a2a0-4e6b-8251-49ecacd77416.png)
