### PR TITLE
PEAR-828 adds tooltip to sequence reads app

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
@@ -118,6 +118,8 @@ export const REGISTERED_APPS = [
     description:
       "Visualize sequencing reads for a given gene, position, SNP, or variant.",
     id: "SequenceReadApp",
+    noDataTooltip:
+      "Current cohort does not have available BAMs for visualization.",
     optimizeRules: ["data format = BAM"],
   },
   {


### PR DESCRIPTION
## Description

Add for Sequence Reads tooltip when no available cases with BAMs: "Current cohort does not have available BAMs for visualization."

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
<img width="454" alt="Screen Shot 2022-12-08 at 10 00 29 PM" src="https://user-images.githubusercontent.com/73256434/206621202-965f4891-dc4b-4f3b-be26-8082207cca17.png">