### PR TITLE
PEAR-856: do not render children if closed or not active

### DIFF
--- a/packages/portal-proto/src/components/CollapsibleContainer.tsx
+++ b/packages/portal-proto/src/components/CollapsibleContainer.tsx
@@ -42,7 +42,7 @@ export const CollapsibleContainer: React.FC<CollapsibleContainerProps> = (
         transitionDuration={200}
         transitionTimingFunction="linear"
       >
-        {children}
+        {!isCollapsed ? children : null}
       </Collapse>
     </div>
   );

--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -259,6 +259,7 @@ const ContextBar: React.FC = () => {
               }}
               data-tour="cohort_summary"
               defaultValue="summary"
+              keepMounted={false}
             >
               <Tabs.List position="right">
                 <Tabs.Tab


### PR DESCRIPTION
## Description
Changes  CollaspableContainer to no render children when collapsed
Unloads CohortManager tabs (Summary View| Cases View)

Both prevent component updates and data fetched when not visible.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
