### PR TITLE
PEAR-858: adjust zIndex for Custom Facet Modal

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
@@ -155,7 +155,12 @@ const CustomFacetGroup = (): JSX.Element => {
   return (
     <div className="flex flex-col w-screen/1.5 h-full bg-base-max pr-6">
       <LoadingOverlay visible={!isDictionaryReady} />
-      <Modal size="lg" opened={opened} onClose={() => setOpened(false)}>
+      <Modal
+        size="lg"
+        opened={opened}
+        onClose={() => setOpened(false)}
+        zIndex={400}
+      >
         <FacetSelection
           title={"Add a Case Filter"}
           facetType="cases"

--- a/packages/portal-proto/src/features/cohortBuilder/Modals/GenericCohortModal.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/Modals/GenericCohortModal.tsx
@@ -24,7 +24,7 @@ export const GenericCohortModal = ({
       padding={0}
       radius="md"
       onClose={onClose}
-      zIndex={450}
+      zIndex={400}
       styles={(theme) => ({
         header: {
           color: theme.colors.primary[8],

--- a/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
@@ -164,7 +164,12 @@ export const FileFacetPanel = (): JSX.Element => {
         </Text>
       </Button>
       <div className="flex flex-col gap-y-4 mr-3 h-screen overflow-y-scroll">
-        <Modal size="lg" opened={opened} onClose={() => setOpened(false)}>
+        <Modal
+          size="lg"
+          opened={opened}
+          onClose={() => setOpened(false)}
+          zIndex={400}
+        >
           <FacetSelection
             title={"Add a File Filter"}
             facetType="files"


### PR DESCRIPTION
## Description
Continuing to find zLevel issues. Modals should be set to zIndex={400}.
This fixes the Custom Facet Modals in ChortBuilder and RepositoryFilters.
Verified for Chrome and Firefox
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
Chrome
![image](https://user-images.githubusercontent.com/1093780/207765094-1e8f3aae-9316-4dc5-9754-bf661e728479.png)
Firefox (for Cohort Custom Filters)
![image](https://user-images.githubusercontent.com/1093780/207765286-20a1e740-a413-441b-934b-9e7384257cc1.png)

