### PR TITLE
PEAR-873: unload hidden tab to prevent -70 width errors

### DIFF
--- a/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
+++ b/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
@@ -225,6 +225,7 @@ const GenesAndMutationFrequencyAnalysisTool: React.FC = () => {
           root: "bg-base-max border-0 w-full",
         }}
         onTabChange={handleTabChanged}
+        keepMounted={false}
       >
         <Tabs.List>
           <Tabs.Tab value="genes">Genes</Tabs.Tab>


### PR DESCRIPTION
## Description
Unload the hiddle tab in Mutations App, which seems to eliminate the -70 width console errors.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
