### PR TITLE
PEAR-872: update caseSet GraphQL query builder function

### DIFF
--- a/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
@@ -13,7 +13,7 @@ import {
   addNewCohortWithFilterAndMessage,
   divideCurrentCohortFilterSetFilterByPrefix,
   divideFilterSetByPrefix,
-  buildCaseSetGQLQueryAndVariables,
+  buildCaseSetGQLQueryAndVariablesFromFilters,
   buildCaseSetMutationQuery,
   REQUIRES_CASE_SET_FILTERS,
   processCaseSetResponse,
@@ -745,10 +745,11 @@ describe("caseSet creation", () => {
       cohortFilters,
       REQUIRES_CASE_SET_FILTERS,
     );
-    const { query, parameters, variables } = buildCaseSetGQLQueryAndVariables(
-      dividedFilters.withPrefix,
-      "2394944y3",
-    );
+    const { query, parameters, variables } =
+      buildCaseSetGQLQueryAndVariablesFromFilters(
+        dividedFilters.withPrefix,
+        "2394944y3",
+      );
 
     expect(query).toEqual(
       "genesCases : case (input: $inputgenes) { set_id size }," +


### PR DESCRIPTION
## Description
Refactors the support function for creating caseSets for filters that match a certain prefix (for example, "genes.").

## Checklist

- [X] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
