### PR TITLE
PEAR-862 move to relative urls for prod

### DIFF
--- a/packages/portal-proto/.env.production
+++ b/packages/portal-proto/.env.production
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_GDC_APP_API_AUTH=https://portal.gdc.cancer.gov/auth/api/v0
-NEXT_PUBLIC_GDC_AUTH=https://portal.gdc.cancer.gov/auth
-NEXT_PUBLIC_GDC_API=https://api.gdc.cancer.gov
-NEXT_PUBLIC_PROTEINPAINT_API=https://portal.gdc.cancer.gov/auth/api/custom/proteinpaint
+NEXT_PUBLIC_GDC_APP_API_AUTH=/auth/api/v0
+NEXT_PUBLIC_GDC_AUTH=/auth
+NEXT_PUBLIC_GDC_API=/auth/api/v0
+NEXT_PUBLIC_PROTEINPAINT_API=/auth/api/custom/proteinpaint


### PR DESCRIPTION
While setting the uat environment at uat-portal.gdc.cancer.gov, we realized that the prod portal and api urls were still being used. This is because we use absolute urls for backend communications.

To overcome this, I updated the urls to be relative and for all api calls to pass through the portal api proxy at /auth/api/. This will allow the prod portal to run on any domain.

Using the same domain will also avoid CORS issues, such as the ones we saw with cohort api.

The absolution urls for the portal v1 annotations pages were left as-is. These will eventually be replaced by a v2 annotations implementation.

## Description

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
