### PR TITLE
PEAR-904: add zIndex={400} to all <Modal> tags

### DIFF
--- a/packages/portal-proto/src/components/Modals/BaseModal.tsx
+++ b/packages/portal-proto/src/components/Modals/BaseModal.tsx
@@ -38,6 +38,7 @@ export const BaseModal: React.FC<Props> = ({
     <Modal
       opened={openModal}
       title={title}
+      zIndex={400}
       onClose={() => {
         dispatch(hideModal());
         if (onClose) {

--- a/packages/portal-proto/src/components/Modals/SetModals/CaseSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/CaseSetModal.tsx
@@ -13,6 +13,7 @@ const CaseSetModal: React.FC = () => {
       onClose={() => dispatch(hideModal())}
       size="xl"
       withinPortal={false}
+      zIndex={400}
       classNames={modalStyles}
       closeButtonLabel="close modal"
     >

--- a/packages/portal-proto/src/components/Modals/SetModals/GeneSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/GeneSetModal.tsx
@@ -34,6 +34,7 @@ const GeneSetModal: React.FC<GeneSetModalProps> = ({
       withinPortal={false}
       classNames={modalStyles}
       closeButtonLabel="close modal"
+      zIndex={400}
     >
       <Tabs defaultValue="input" classNames={tabStyles}>
         <Tabs.List>

--- a/packages/portal-proto/src/components/Modals/SetModals/MutationSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/MutationSetModal.tsx
@@ -32,6 +32,7 @@ const MutationSetModal: React.FC<MutationSetModalProps> = ({
       onClose={() => dispatch(hideModal())}
       size="xl"
       withinPortal={false}
+      zIndex={400}
       classNames={modalStyles}
       closeButtonLabel="close modal"
     >

--- a/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
+++ b/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
@@ -180,6 +180,7 @@ const CategoricalBinningModal: React.FC<CategoricalBinningModalProps> = ({
       opened
       onClose={() => setModalOpen(false)}
       size={800}
+      zIndex={400}
       title={`Create Custom Bins: ${field}`}
       withinPortal={false}
       classNames={{

--- a/packages/portal-proto/src/features/cDave/ContinuousBinningModal/ContinuousBinningModal.tsx
+++ b/packages/portal-proto/src/features/cDave/ContinuousBinningModal/ContinuousBinningModal.tsx
@@ -166,6 +166,7 @@ const ContinuousBinningModal: React.FC<ContinuousBinningModalProps> = ({
       opened
       onClose={() => setModalOpen(false)}
       size={1000}
+      zIndex={400}
       title={`Create Custom Bins: ${field}`}
       withinPortal={false}
       classNames={{

--- a/packages/portal-proto/src/features/cohortBuilder/CohortFacetSelection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortFacetSelection.tsx
@@ -13,7 +13,12 @@ export const CohortFacetSelectionModal = (): JSX.Element => {
 
   return (
     <>
-      <Modal size="lg" opened={opened} onClose={() => setOpened(false)}>
+      <Modal
+        size="lg"
+        opened={opened}
+        onClose={() => setOpened(false)}
+        zIndex={400}
+      >
         <FacetSelection
           title={"Add a Case Filter"}
           facetType="cases"

--- a/packages/portal-proto/src/features/oncoGrid/ColorPaletteModal.tsx
+++ b/packages/portal-proto/src/features/oncoGrid/ColorPaletteModal.tsx
@@ -106,6 +106,7 @@ const ColorPaletteModal: React.FC<ColorPaletteModalProps> = ({
         body: "px-16",
       }}
       size={800}
+      zIndex={400}
       withinPortal={false}
     >
       Select the colors to display for each element on the OncoGrid. Click on an

--- a/packages/portal-proto/src/features/oncoGrid/TrackSelectionModal.tsx
+++ b/packages/portal-proto/src/features/oncoGrid/TrackSelectionModal.tsx
@@ -29,6 +29,7 @@ const TrackSelectionModal: React.FC<TrackSelectionModalProps> = ({
     <Modal
       opened
       withinPortal={false}
+      zIndex={400}
       onClose={closeModal}
       title="Select Tracks to Add"
     >

--- a/packages/portal-proto/src/features/repositoryApp/FilesFacetSelection.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FilesFacetSelection.tsx
@@ -33,7 +33,12 @@ export const FilesFacetSelectionModal = (): JSX.Element => {
 
   return (
     <>
-      <Modal size="lg" opened={opened} onClose={() => setOpened(false)}>
+      <Modal
+        size="lg"
+        opened={opened}
+        onClose={() => setOpened(false)}
+        zIndex={400}
+      >
         <FacetSelection
           title={"Add Files Filter"}
           facetType="files"


### PR DESCRIPTION
## Description
Updates all Modals to have zIndex=400, which resolves partially hidden modals.
In the future, all <Modal ../> should have zIndex set to 400 until the use of z levels is removed from V2.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
Fixed CDave Modals (chrome)

![image](https://user-images.githubusercontent.com/1093780/210586474-43f51ebb-97c9-4fe9-9778-990e4d43adc9.png)
![image](https://user-images.githubusercontent.com/1093780/210586632-61b2827d-74fb-4f6b-9512-1ee7bc566165.png)

Fixed CDave Modals (firefox)

![GDC-Analysis-Center1](https://user-images.githubusercontent.com/1093780/210588018-9b0fda5a-d8aa-4425-8afa-d32fe14636c6.png)
![GDC-Analysis-Center2](https://user-images.githubusercontent.com/1093780/210588007-7083f093-f32f-4360-94c1-8f4f1a78d073.png)
