### PR TITLE
PEAR-902: reset mutation frequency tables when cohort changes

### DIFF
--- a/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
+++ b/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
@@ -271,6 +271,7 @@ const GenesAndMutationFrequencyAnalysisTool: React.FC = () => {
               )}
               toggledGenes={currentGenes}
               genomicFilters={genomicFilters}
+              cohortFilters={cohortFilters}
             />
           </div>
         </Tabs.Panel>
@@ -301,6 +302,7 @@ const GenesAndMutationFrequencyAnalysisTool: React.FC = () => {
             selectedSurvivalPlot={comparativeSurvival}
             handleSurvivalPlotToggled={handleSurvivalPlotToggled}
             genomicFilters={genomicFilters}
+            cohortFilters={cohortFilters}
             handleSsmToggled={partial(
               handleGeneAndSSmToggled,
               currentMutations,


### PR DESCRIPTION
## Description
Resets the gene and ssm table to page 0 when the filters change.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
