### PR TITLE
PEAR-906 removes duplicate ISS Stage card from cohort builder

### DIFF
--- a/packages/core/src/features/cohort/data/cohort_builder.json
+++ b/packages/core/src/features/cohort/data/cohort_builder.json
@@ -60,7 +60,6 @@
         "cases.diagnoses.igcccg_stage",
         "cases.diagnoses.inss_stage",
         "cases.diagnoses.iss_stage",
-        "cases.diagnoses.iss_stage",
         "cases.diagnoses.masaoka_stage"
       ],
       "docType": "cases",

--- a/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
@@ -243,7 +243,6 @@ describe("cohortConfig reducer", () => {
       "cases.diagnoses.igcccg_stage",
       "cases.diagnoses.inss_stage",
       "cases.diagnoses.iss_stage",
-      "cases.diagnoses.iss_stage",
       "cases.diagnoses.masaoka_stage",
       "cases.diagnoses.tumor_grade",
       "cases.diagnoses.eln_risk_classification",


### PR DESCRIPTION
## Description
Removes the extra ISS Stage card from Cohort Builder
## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
<img width="1491" alt="Screen Shot 2023-01-06 at 12 27 05 AM" src="https://user-images.githubusercontent.com/73256434/210943276-cf89b6ee-815a-436f-a60b-5b540cf843ab.png">
