### PR TITLE
(PEAR-889): Fix download not working in FF, add slight delay on in progress message so it doesnt flicker on fast downloads

### DIFF
--- a/packages/portal-proto/src/utils/download.tsx
+++ b/packages/portal-proto/src/utils/download.tsx
@@ -146,7 +146,7 @@ const download = async ({
         }),
       }),
     100,
-  ); // set to 100 as that is perceved as instent
+  ); // set to 100 as that is perceived as instant
 
   const fields = reduce(
     params,


### PR DESCRIPTION
## Description
Fix download not working in FF, add slight delay on in progress message so it doesn't flicker on fast downloads
