### PR TITLE
PEAR-860 - fix height of collapsed query section

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
@@ -150,7 +150,7 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
       const parentStyle = window.getComputedStyle(filtersRef.current);
       // height of rows + top padding of parent + padding below rows
       setCollapsedHeight(
-        tempCollapsedHeight + parseInt(parentStyle.paddingTop) + 8,
+        tempCollapsedHeight + parseInt(parentStyle.paddingTop) + 4,
       );
     }
   }, [filters, filtersRef?.current?.clientHeight, expandedState]);


### PR DESCRIPTION
## Description
Fixes the collapsed height of the query section displaying all rows - 1/2 row instead of 3 rows.

## Checklist

- [N/A] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
Before:
<img width="1432" alt="Screen Shot 2023-01-19 at 10 02 51 AM" src="https://user-images.githubusercontent.com/4624053/213492153-0879b08c-0c9e-4168-afff-f8be39f487aa.png">

After!
<img width="1430" alt="Screen Shot 2023-01-19 at 10 03 15 AM" src="https://user-images.githubusercontent.com/4624053/213492195-a8b09884-b6e7-4e1d-85c8-1962f6d24a30.png">
