### PR TITLE
PEAR-957: remove second zIndex from baseModal

### DIFF
--- a/packages/portal-proto/src/components/Modals/BaseModal.tsx
+++ b/packages/portal-proto/src/components/Modals/BaseModal.tsx
@@ -59,7 +59,6 @@ export const BaseModal: React.FC<Props> = ({
       closeOnClickOutside={closeOnClickOutside ?? true}
       closeOnEscape={closeOnEscape ?? true}
       size={size && size}
-      zIndex={400}
     >
       {children}
       {buttons && (


### PR DESCRIPTION
## Description

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
