### PR TITLE
PEAR-951: Fix File summary page, Case ID missing

### DIFF
--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -215,7 +215,7 @@ const AssociatedCB = ({
         entity.entity_submitter_id
           .toLowerCase()
           .includes(associatedCBSearchTerm.toLowerCase()) ||
-        caseData.submitter_id
+        caseData?.submitter_id
           .toLowerCase()
           .includes(associatedCBSearchTerm.toLowerCase())
       ) {
@@ -229,10 +229,10 @@ const AssociatedCB = ({
           ),
           entity_type: entity.entity_type,
           sample_type: sample_type,
-          case_id: () => (
+          case_id: (
             <GenericLink
               path={`/cases/${entity.case_id}`}
-              text={caseData.submitter_id}
+              text={caseData?.submitter_id}
             />
           ),
           annotations: annotationsLink,


### PR DESCRIPTION
## Description
- Fix bug in File summary page, Case ID missing
- Fix bug in search bar as well that crashed page 
