### PR TITLE
PEAR-967: add check for subrow

### DIFF
--- a/packages/portal-proto/src/components/expandableTables/genes/genesTableUtils.tsx
+++ b/packages/portal-proto/src/components/expandableTables/genes/genesTableUtils.tsx
@@ -121,6 +121,11 @@ export const createTableColumn = (
               />
             ),
             cell: ({ row }) => {
+              if (row.depth > 0) {
+                // this is an expanded row
+                return null;
+              }
+
               const { numerator } = row?.original[
                 "SSMSAffectedCasesInCohort"
               ] ?? { numerator: 0 };

--- a/packages/portal-proto/src/components/expandableTables/somaticMutations/smTableUtils.tsx
+++ b/packages/portal-proto/src/components/expandableTables/somaticMutations/smTableUtils.tsx
@@ -129,6 +129,10 @@ export const createTableColumn = (
               />
             ),
             cell: ({ row }) => {
+              if (row.depth > 0) {
+                // this is an expanded row
+                return null;
+              }
               const { numerator } = row?.original["affectedCasesInCohort"] ?? {
                 numerator: 0,
               };


### PR DESCRIPTION
## Description
Add check in expTable for Gene/SSMS to check if the row is a sub row. If so, it will return nill and not perform the survival plot checks.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks

## Screenshots/Screen Recordings (if Appropriate)
