### PR TITLE
PEAR-951: filter the associated entities and display only the ones that have a matching cases.case_id

### DIFF
--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -211,13 +211,14 @@ const AssociatedCB = ({
       );
 
       if (
-        associatedCBSearchTerm === "" ||
-        entity.entity_submitter_id
-          .toLowerCase()
-          .includes(associatedCBSearchTerm.toLowerCase()) ||
-        caseData?.submitter_id
-          .toLowerCase()
-          .includes(associatedCBSearchTerm.toLowerCase())
+        caseData?.submitter_id &&
+        (associatedCBSearchTerm === "" ||
+          entity.entity_submitter_id
+            .toLowerCase()
+            .includes(associatedCBSearchTerm.toLowerCase()) ||
+          caseData?.submitter_id
+            .toLowerCase()
+            .includes(associatedCBSearchTerm.toLowerCase()))
       ) {
         tableRows.push({
           entity_id: (


### PR DESCRIPTION
## Description
filter the associated entities and display only the ones that have a matching cases.case_id

## Checklist

- [ n/a] Added proper unit tests
- [ n/a] Left proper TODO messages for any remaining tasks
- [n/a ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues
