### PR TITLE
PEAR-996: change countsField for Oncomatrix

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.ts
@@ -155,7 +155,7 @@ export const REGISTERED_APPS = [
     description:
       "Visualize the top most mutated cases and genes affected by high impact mutations in your cohort.",
     id: "OncoMatrix",
-    countsField: "ssmCaseCounts",
+    countsField: "ssmCaseCount",
     caseCounts: 0.25,
     optimizeRules: ["available data = ssm or cnv"],
     noDataTooltip:


### PR DESCRIPTION
## Description
Oncomatrix's countsField was set to an old value which caused the card always to display zero counts.
This PR changes the countField to the correct value, showing the counts correctly.
## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![image](https://user-images.githubusercontent.com/1093780/215137402-bb8457b3-b064-4dae-b8f7-38bb87972ae0.png)
