### PR TITLE
PEAR-1020 prune datadog dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@datadog/browser-rum": "4.17.1",
         "@reactour/tour": "^2.9.0",
         "@tanstack/react-table": "8.5.13",
         "classnames": "^2.3.1",
@@ -958,28 +957,6 @@
       "peerDependencies": {
         "postcss": "^8.2",
         "postcss-selector-parser": "^6.0.10"
-      }
-    },
-    "node_modules/@datadog/browser-core": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.17.1.tgz",
-      "integrity": "sha512-M34aI8PhRP7K7FkULI7B2Qeoy+V93wlHd5O7s5Q2Y2PAhkjpNWpUMBtmvIE77wCx/VaZxGlwaDWL+Oj9vliW0g=="
-    },
-    "node_modules/@datadog/browser-rum": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.17.1.tgz",
-      "integrity": "sha512-dg9YkDKITUCzEYD7Avb8ranr1D9262WC2ryP3T435H38DoKVag+RvjBO5J1vY8R90OqxBRd2qQtFVNhRuDeKEg==",
-      "dependencies": {
-        "@datadog/browser-core": "4.17.1",
-        "@datadog/browser-rum-core": "4.17.1"
-      }
-    },
-    "node_modules/@datadog/browser-rum-core": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.17.1.tgz",
-      "integrity": "sha512-DMUOJsotTwbsJT/wtGabTwC0laBB8RF55aCUk6Tqd4cZWJRnMIZHKgPB+KbTLunxg6Kw9PSGsvKXFPMcKy8UCg==",
-      "dependencies": {
-        "@datadog/browser-core": "4.17.1"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -26097,28 +26074,6 @@
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
       "requires": {}
     },
-    "@datadog/browser-core": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.17.1.tgz",
-      "integrity": "sha512-M34aI8PhRP7K7FkULI7B2Qeoy+V93wlHd5O7s5Q2Y2PAhkjpNWpUMBtmvIE77wCx/VaZxGlwaDWL+Oj9vliW0g=="
-    },
-    "@datadog/browser-rum": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.17.1.tgz",
-      "integrity": "sha512-dg9YkDKITUCzEYD7Avb8ranr1D9262WC2ryP3T435H38DoKVag+RvjBO5J1vY8R90OqxBRd2qQtFVNhRuDeKEg==",
-      "requires": {
-        "@datadog/browser-core": "4.17.1",
-        "@datadog/browser-rum-core": "4.17.1"
-      }
-    },
-    "@datadog/browser-rum-core": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.17.1.tgz",
-      "integrity": "sha512-DMUOJsotTwbsJT/wtGabTwC0laBB8RF55aCUk6Tqd4cZWJRnMIZHKgPB+KbTLunxg6Kw9PSGsvKXFPMcKy8UCg==",
-      "requires": {
-        "@datadog/browser-core": "4.17.1"
-      }
-    },
     "@emotion/babel-plugin": {
       "version": "11.10.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz",
@@ -40314,7 +40269,7 @@
     "portal-proto": {
       "version": "file:packages/portal-proto",
       "requires": {
-        "@datadog/browser-rum": "*",
+        "@datadog/browser-rum": "^4.32.0",
         "@gff/core": "0.0.1",
         "@iconify/icons-mdi": "^1.1.42",
         "@iconify/react": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/NCI-GDC/gdc-frontend-framework#readme",
   "dependencies": {
-    "@datadog/browser-rum": "4.17.1",
     "@reactour/tour": "^2.9.0",
     "@tanstack/react-table": "8.5.13",
     "classnames": "^2.3.1",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -20,7 +20,6 @@ const globals = {
   immer: "immer",
   "redux-persist/integration/react": "integration",
   "react-cookie": "reactCookie",
-  "@datadog/browser-rum": "browserRum",
 };
 
 const config = [
@@ -58,7 +57,6 @@ const config = [
       "redux",
       "redux-toolkit",
       "react-cookie",
-      "@datadog/browser-rum",
     ],
     plugins: [
       peerDepsExternal(),


### PR DESCRIPTION
Some unneeded dependencies remained after moving dd to the portal package. This commit cleans that up

## Description

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
