### PR TITLE
PEAR-988 adds missing percent_granulocyte_infiltration field

### DIFF
--- a/packages/portal-proto/src/features/files/utils.ts
+++ b/packages/portal-proto/src/features/files/utils.ts
@@ -89,6 +89,10 @@ export const formatImageDetailsInfo: formatImageDetailsInfoFunc = (
       name: "Section_location",
     },
     {
+      field: "percent_granulocyte_infiltration",
+      name: "Percent_granulocyte_infiltration",
+    },
+    {
       field: "percent_necrosis",
       name: "Percent_necrosis",
     },


### PR DESCRIPTION
## Description

Adds the missing percent_granulocyte_infiltration field to the details of slide image viewer.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="814" alt="Screenshot 2023-02-14 at 2 53 30 PM" src="https://user-images.githubusercontent.com/73256434/218860710-de6da67b-e340-41b0-8d79-d02acd9701e9.png">
