### PR TITLE
PEAR-1121: Hide Files Tables when it's empty in case summary

### DIFF
--- a/packages/portal-proto/src/features/cases/CaseView.tsx
+++ b/packages/portal-proto/src/features/cases/CaseView.tsx
@@ -482,13 +482,22 @@ export const CaseView: React.FC<CaseViewProps> = ({
           )}
         </div>
 
-        <ClinicalSummary
-          diagnoses={diagnoses}
-          follow_ups={follow_ups}
-          demographic={demographic}
-          family_histories={family_histories}
-          exposures={exposures}
-        />
+        <div
+          className={`${
+            !(
+              data.summary.data_categories ||
+              data.summary.experimental_strategies
+            ) && "mt-14"
+          }`}
+        >
+          <ClinicalSummary
+            diagnoses={diagnoses}
+            follow_ups={follow_ups}
+            demographic={demographic}
+            family_histories={family_histories}
+            exposures={exposures}
+          />
+        </div>
 
         {clinicalFilteredFiles?.length > 0 && (
           <div className="mt-8">

--- a/packages/portal-proto/src/features/files/utils.ts
+++ b/packages/portal-proto/src/features/files/utils.ts
@@ -139,9 +139,9 @@ export const parseSlideDetailsInfo: parseSlideDetailsInfoFunc = (
 };
 
 export const mapGdcFileToCartFile = (
-  files: GdcFile[] | caseFileType[],
+  files: GdcFile[] | caseFileType[] | undefined,
 ): CartFile[] =>
-  files.map((file: GdcFile | caseFileType) =>
+  files?.map((file: GdcFile | caseFileType) =>
     pick(file, [
       "access",
       "acl",


### PR DESCRIPTION
## Description
Added a undefined check for the function.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

**_NO Files_** `f03a74d3-1d40-43f9-9207-7e323b7253e9`
![Screenshot 2023-03-17 at 4 47 58 PM](https://user-images.githubusercontent.com/101295912/226059330-aa086f56-7254-4eef-8ec0-d956bec38f7d.png)

**_Only DATA CATEGORY_**  `a4faf514-50af-43ed-b294-350ee0756250`
![Screenshot 2023-03-17 at 4 48 07 PM](https://user-images.githubusercontent.com/101295912/226059371-d05a92f6-cfa0-4627-b86e-7fe0e48ab52e.png)

**_BOTH PRESENT_** `f38a6799-11e0-471c-834e-0d97e00aec07`
![Screenshot 2023-03-17 at 4 48 16 PM](https://user-images.githubusercontent.com/101295912/226059419-5ef4546c-c6b9-4524-965c-df920131cbcf.png)
