### PR TITLE
PEAR-1180: Added datatest id to homepage stats and cohort bar buttons

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -598,7 +598,7 @@ const CohortManager: React.FC<CohortManagerProps> = ({
 
           <Tooltip label="Delete Cohort" position="bottom" withArrow>
             <CohortGroupButton
-            data-testid="deleteButton"
+              data-testid="deleteButton"
               onClick={() => {
                 if (isDefaultCohort) return;
                 setShowDelete(true);

--- a/packages/portal-proto/src/features/homepage/HorizontalSummaryTotalsPanel.tsx
+++ b/packages/portal-proto/src/features/homepage/HorizontalSummaryTotalsPanel.tsx
@@ -18,7 +18,10 @@ const HorizontalSummaryTotalsPanel = (): JSX.Element => {
           href="https://docs.gdc.cancer.gov/Data/Release_Notes/Data_Release_Notes/"
         />
       </div>
-      <div className="grid grid-cols-6 divide-x py-3 mt-2 bg-base-max rounded-md border-1 border-summarybar-border shadow-lg justify-between" data-testid="homepage-live-statistics">
+      <div
+        className="grid grid-cols-6 divide-x py-3 mt-2 bg-base-max rounded-md border-1 border-summarybar-border shadow-lg justify-between"
+        data-testid="homepage-live-statistics"
+      >
         <SummaryStatsItem
           title="Projects"
           count={countsInfo.projectsCounts}


### PR DESCRIPTION
## Description
- Added a data-testid to the home page live stat box
- Added a few data-testids to the cohort bar buttons and dropdown

