### PR TITLE
PEAR-1177: fix repository FileTable error on All GDC cohort

### DIFF
--- a/packages/core/src/features/files/filesSlice.ts
+++ b/packages/core/src/features/files/filesSlice.ts
@@ -44,6 +44,7 @@ const fileTypes = [
   "masked_methylation_array",
   "protein_expression",
   "pathology_report",
+  "simple_germline_variation",
   "submitted_genotyping_array",
 ] as const;
 
@@ -151,6 +152,7 @@ const dataTypes = [
   "Raw CGI Variant",
   "Raw Intensities",
   "Raw Simple Somatic Mutation",
+  "Simple Germline Variation",
   "Single Cell Analysis",
   "Slide Image",
   "Splice Junction Quantification",


### PR DESCRIPTION
## Description

Fixes the file table in Repository "Error in loading data" message. The solution was to add  `simple_germline_variation` to FileTypes, `Simple Germline Variation`  to DataTypes. NOTE: This method of not automatically adjusting for new File and Data types is an ongoing issue.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
