### PR TITLE
PEAR 1179 adds sites of involvement card

### DIFF
--- a/packages/core/src/features/cohort/data/cohort_builder.json
+++ b/packages/core/src/features/cohort/data/cohort_builder.json
@@ -31,6 +31,7 @@
         "cases.diagnoses.morphology",
         "cases.diagnoses.year_of_diagnosis",
         "cases.diagnoses.site_of_resection_or_biopsy",
+        "cases.diagnoses.sites_of_involvement",
         "cases.diagnoses.laterality"
       ],
       "docType": "cases",

--- a/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
@@ -228,6 +228,7 @@ describe("cohortConfig reducer", () => {
       "cases.diagnoses.morphology",
       "cases.diagnoses.year_of_diagnosis",
       "cases.diagnoses.site_of_resection_or_biopsy",
+      "cases.diagnoses.sites_of_involvement",
       "cases.diagnoses.laterality",
       "cases.diagnoses.prior_malignancy",
       "cases.diagnoses.prior_treatment",


### PR DESCRIPTION
## Description
Adds the sites of involvement card to general diagnosis category in Cohort Builder.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1582" alt="Screenshot 2023-03-30 at 1 07 20 PM" src="https://user-images.githubusercontent.com/73256434/228925702-d09b32fe-39fe-4924-b32d-2bcaa273e3a5.png">
