### PR TITLE
PEAR-1193 changes title of the non-core apps

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisWorkspace.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisWorkspace.tsx
@@ -79,7 +79,7 @@ const AnalysisGrid: React.FC<AnalysisGridProps> = ({
       </div>
       <div className="mx-4 my-2">
         <h2 className="text-primary-content-darkest font-bold uppercase text-xl mb-2">
-          Tools
+          Analysis Tools
         </h2>
 
         <div className="flex gap-6 flex-wrap">


### PR DESCRIPTION
## Description
PEAR-1193 changes the title of the non-core apps from "Tools" to "Analysis Tools"
## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1581" alt="Screenshot 2023-04-04 at 8 34 25 PM" src="https://user-images.githubusercontent.com/73256434/229958569-b3af47c4-1f42-466d-9ba7-71a81e18bea4.png">
