### PR TITLE
feat: Update gitlab-templates pin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@ include:
 stages:
   - .pre
   - test
-  - build
   - unit
   - release
   - build_ui_tests_image
@@ -65,7 +64,7 @@ Prettier Checks:
   <<: *default_rules
 
 Build and test core and portal:
-  stage: build
+  stage: test
   before_script:
     - npm install npm@7
     - npm ci --cache .npm


### PR DESCRIPTION
## Description
- Updated gitlab-templates pin
- Removed shared job cache until we have a shared cache in S3 set up for the runners
- Consolidated jobs to reduce running time (Avg build time right now is 20 minutes, this branch finished in 14)

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
