### PR TITLE
PEAR-1031 - Sample sheet and metadata options both highlighted

### DIFF
--- a/packages/portal-proto/src/components/DownloadButtons/DownloadButton.tsx
+++ b/packages/portal-proto/src/components/DownloadButtons/DownloadButton.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonProps, Loader, Tooltip } from "@mantine/core";
 import { FiDownload } from "react-icons/fi";
 import download from "src/utils/download";
 import { hideModal, Modals, useCoreDispatch } from "@gff/core";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, forwardRef } from "react";
 
 interface DownloadButtonProps {
   endpoint?: string;
@@ -30,85 +30,94 @@ interface DownloadButtonProps {
   toolTip?: string;
 }
 
-export const DownloadButton: React.FC<DownloadButtonProps & ButtonProps> = ({
-  endpoint,
-  disabled = false,
-  filename,
-  size = 10000,
-  format = "JSON",
-  fields = [],
-  filters = {},
-  inactiveText,
-  activeText,
-  extraParams,
-  method = "POST",
-  queryParams,
-  options,
-  customStyle,
-  setActive,
-  onClick,
-  showLoading = true,
-  showIcon = true,
-  preventClickEvent = false,
-  active,
-  Modal400,
-  Modal403,
-  toolTip,
-  ...buttonProps
-}: DownloadButtonProps) => {
-  const text = active ? activeText : inactiveText;
-  const dispatch = useCoreDispatch();
-  const Icon = active ? (
-    <Loader size="sm" className="p-1" />
-  ) : (
-    <FiDownload title="download" size={16} />
-  );
+export const DownloadButton = forwardRef<
+  HTMLButtonElement,
+  DownloadButtonProps & ButtonProps
+>(
+  (
+    {
+      endpoint,
+      disabled = false,
+      filename,
+      size = 10000,
+      format = "JSON",
+      fields = [],
+      filters = {},
+      inactiveText,
+      activeText,
+      extraParams,
+      method = "POST",
+      queryParams,
+      options,
+      customStyle,
+      setActive,
+      onClick,
+      showLoading = true,
+      showIcon = true,
+      preventClickEvent = false,
+      active,
+      Modal400,
+      Modal403,
+      toolTip,
+      ...buttonProps
+    }: DownloadButtonProps,
+    ref,
+  ) => {
+    const text = active ? activeText : inactiveText;
+    const dispatch = useCoreDispatch();
+    const Icon = active ? (
+      <Loader size="sm" className="p-1" />
+    ) : (
+      <FiDownload title="download" size={16} />
+    );
 
-  return (
-    <Tooltip disabled={!toolTip} label={toolTip}>
-      <Button
-        leftIcon={showIcon && inactiveText && <FiDownload />}
-        disabled={disabled}
-        className={
-          customStyle ||
-          `text-base-lightest ${
-            disabled ? "bg-base" : "bg-primary hover:bg-primary-darker"
-          } `
-        }
-        loading={showLoading && active}
-        onClick={() => {
-          if (!preventClickEvent && onClick) {
-            onClick();
-            return;
+    return (
+      <Tooltip disabled={!toolTip} label={toolTip}>
+        <Button
+          ref={ref}
+          leftIcon={showIcon && inactiveText && <FiDownload />}
+          disabled={disabled}
+          className={
+            customStyle ||
+            `text-base-lightest ${
+              disabled ? "bg-base" : "bg-primary hover:bg-primary-darker"
+            } `
           }
-          dispatch(hideModal());
-          const params = {
-            size,
-            attachment: true,
-            format,
-            fields: fields.join(),
-            filters,
-            pretty: true,
-            ...(filename ? { filename } : {}),
-            ...extraParams,
-          };
-          setActive && setActive(true);
-          download({
-            params,
-            endpoint,
-            method,
-            queryParams,
-            done: () => setActive && setActive(false),
-            dispatch,
-            Modal400,
-            Modal403,
-            options,
-          });
-        }}
-        {...buttonProps}
-      >
-        {text || Icon}
-      </Button>
-    </Tooltip>
-  );
-};
+          loading={showLoading && active}
+          onClick={() => {
+            if (!preventClickEvent && onClick) {
+              onClick();
+              return;
+            }
+            dispatch(hideModal());
+            const params = {
+              size,
+              attachment: true,
+              format,
+              fields: fields.join(),
+              filters,
+              pretty: true,
+              ...(filename ? { filename } : {}),
+              ...extraParams,
+            };
+            setActive && setActive(true);
+            download({
+              params,
+              endpoint,
+              method,
+              queryParams,
+              done: () => setActive && setActive(false),
+              dispatch,
+              Modal400,
+              Modal403,
+              options,
+            });
+          }}
+          {...buttonProps}
+        >
+          {text || Icon}
+        </Button>
+      </Tooltip>
+    );
+  },
+);

--- a/packages/portal-proto/src/features/cart/CartHeader.tsx
+++ b/packages/portal-proto/src/features/cart/CartHeader.tsx
@@ -254,7 +254,6 @@ const CartHeader: React.FC<CartHeaderProps> = ({
                 tsv_format: "sample-sheet",
               }}
             />
-            <Menu.Divider />
             <Menu.Item
               component={DownloadButton}
               classNames={{ inner: "font-normal" }}


### PR DESCRIPTION
## Description
Mantine uses the refs on the menu items to add the data attribute for hovered items (https://github.com/mantinedev/mantine/blob/master/src/mantine-core/src/Menu/MenuItem/MenuItem.tsx#L68). Since our custom component couldn't accept a ref, menu items weren't highlighted correctly. 

## Checklist
- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
Before:
![image](https://user-images.githubusercontent.com/4624053/235944085-4f7b3b01-ac56-4888-8fd5-f0c65fc1c953.png)
After!
<img width="486" alt="Screenshot 2023-05-03 at 9 20 08 AM" src="https://user-images.githubusercontent.com/4624053/235944164-ee518205-344f-4a6c-aaea-48a5866ca3af.png">
