### PR TITLE
PEAR-1268 - fix validation on cdave with trimmed strings

### DIFF
--- a/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
+++ b/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
@@ -442,7 +442,7 @@ const GroupInput: React.FC<GroupInputProps> = ({
           ? "Required field"
           : Object.keys(groupValues).includes(value)
           ? "The group name cannot be the same as the name of a value"
-          : otherGroups.includes(value)
+          : otherGroups.includes(value.trim())
           ? `"${value}" already exists`
           : null,
     },

--- a/packages/portal-proto/src/features/cDave/ContinuousBinningModal/validateInputs.ts
+++ b/packages/portal-proto/src/features/cDave/ContinuousBinningModal/validateInputs.ts
@@ -113,8 +113,8 @@ export const validateRangeInput = (
     } else {
       const otherBinNames = values
         .filter((_, otherIdx) => otherIdx !== idx)
-        .map((v) => v.name);
-      if (otherBinNames.includes(value.name)) {
+        .map((v) => v.name.trim());
+      if (otherBinNames.includes(value.name.trim())) {
         errors[`ranges.${idx}.name`] = "Bin names must be unique";
       } else {
         const overlappingBins = [];

--- a/packages/portal-proto/src/features/cDave/ContinuousBinningModal/validateInputs.unit.test.ts
+++ b/packages/portal-proto/src/features/cDave/ContinuousBinningModal/validateInputs.unit.test.ts
@@ -71,6 +71,16 @@ describe("validateInputs", () => {
     expect(
       validateRangeInput([
         { name: "bin", from: "10", to: "20" },
+        { name: "bin   ", from: "20", to: "30" },
+      ]),
+    ).toEqual({
+      "ranges.0.name": "Bin names must be unique",
+      "ranges.1.name": "Bin names must be unique",
+    });
+
+    expect(
+      validateRangeInput([
+        { name: "bin", from: "10", to: "20" },
         { name: "bin1", from: "15", to: "30" },
       ]),
     ).toEqual({


### PR DESCRIPTION
## Description
Use trimmed string values in the validation code for CDave

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
