### PR TITLE
PEAR-704 hide cancer distribution charts w/o data

### DIFF
--- a/packages/portal-proto/src/features/charts/CNVPlot.tsx
+++ b/packages/portal-proto/src/features/charts/CNVPlot.tsx
@@ -149,7 +149,7 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
   const chartDivId = `${CHART_NAME}_${Math.floor(Math.random() * 100)}`;
   return (
     <>
-      {data?.caseTotal ? (
+      {data?.mutationTotal ? (
         <div className="border border-base-lighter p-4">
           <div>
             <ChartTitleBar
@@ -208,9 +208,7 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
             </label>
           </div>
         </div>
-      ) : (
-        <div className="w-full m-auto font-semibold">{title}</div>
-      )}
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
## Description
[pear-704](https://jira.opensciencedatacloud.org/browse/PEAR-704)

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1438" alt="Screenshot 2023-05-15 at 11 00 38 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/90918464/e6f8e657-0898-4acc-9439-deadbe6e9797">
