### PR TITLE
PEAR-1244 fix project names getting cut off in projects table

### DIFF
--- a/packages/portal-proto/src/features/projectsCenter/ProjectsTable.tsx
+++ b/packages/portal-proto/src/features/projectsCenter/ProjectsTable.tsx
@@ -98,7 +98,7 @@ const ProjectsTable: React.FC = () => {
       columnName: "Project",
       visible: true,
       Cell: ({ value }: CellProps) => {
-        return <div className="text-left overflow-visible">{value}</div>;
+        return <div className="text-left">{value}</div>;
       },
     },
     {


### PR DESCRIPTION
## Description
[pear-1244](https://jira.opensciencedatacloud.org/browse/PEAR-1244)

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="553" alt="Screenshot 2023-05-15 at 11 35 44 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/90918464/52176ada-d371-4202-8fea-58c18f23f1bb">
