### PR TITLE
PEAR-1135: add gene.symbol to ssms table search

### DIFF
--- a/packages/core/src/features/genomic/ssmsTableSlice.ts
+++ b/packages/core/src/features/genomic/ssmsTableSlice.ts
@@ -155,6 +155,11 @@ export const buildSSMSTableSearchFilters = (
         },
         {
           operator: "includes",
+          field: "genes.symbol",
+          operands: [`*${term}*`],
+        },
+        {
+          operator: "includes",
           field: "ssms.gene_aa_change",
           operands: [`*${term}*`],
         },


### PR DESCRIPTION
## Description
Adds the gene.symbol field to the search filters for the mutations table search. This fixes the missing mutations reported in this ticket.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

Search TP53: count should be 1325
![image](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1093780/256f0350-626e-4209-b4b4-200e8d51ac3e)
