### PR TITLE
PEAR-1127 - Adding to a set doesn't add the top entities

### DIFF
--- a/packages/core/src/features/sets/modifySetSlice.ts
+++ b/packages/core/src/features/sets/modifySetSlice.ts
@@ -5,7 +5,7 @@ export const modifySetSlice = graphqlAPISlice
   .injectEndpoints({
     endpoints: (builder) => ({
       appendToGeneSet: builder.mutation({
-        query: ({ setId, filters, size }) => ({
+        query: ({ setId, filters, size, score }) => ({
           graphQLQuery: `
         mutation mutationsAppendExploreGeneSetMutation(
           $input: AppendSetInput
@@ -27,6 +27,7 @@ export const modifySetSlice = graphqlAPISlice
               set_id: `set_id:${setId}`,
               filters,
               size,
+              score,
             },
           },
         }),
@@ -37,7 +38,7 @@ export const modifySetSlice = graphqlAPISlice
         ],
       }),
       appendToSsmSet: builder.mutation({
-        query: ({ setId, filters, size }) => ({
+        query: ({ setId, filters, size, score }) => ({
           graphQLQuery: `mutation mutationsAppendExploreSsmSetMutation(
           $input: AppendSetInput
         ) {
@@ -58,6 +59,7 @@ export const modifySetSlice = graphqlAPISlice
               set_id: `set_id:${setId}`,
               filters,
               size,
+              score,
             },
           },
         }),

--- a/packages/portal-proto/src/components/Modals/SetModals/AddToSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/AddToSetModal.tsx
@@ -31,8 +31,14 @@ interface AddToSetModalProps {
   readonly setType: SetTypes;
   readonly setTypeLabel: string;
   readonly field: string;
+  readonly sort?: string;
   readonly closeModal: () => void;
-  readonly countHook: UseQuery<QueryDefinition<any, any, any, number, string>>;
+  readonly singleCountHook: UseQuery<
+    QueryDefinition<any, any, any, number, string>
+  >;
+  readonly countHook: UseQuery<
+    QueryDefinition<any, any, any, Record<string, number>, string>
+  >;
   readonly appendSetHook: UseMutation<
     MutationDefinition<any, any, any, string, string>
   >;
@@ -44,19 +50,21 @@ const AddToSetModal: React.FC<AddToSetModalProps> = ({
   setType,
   setTypeLabel,
   field,
+  sort,
   closeModal,
+  singleCountHook,
   countHook,
   appendSetHook,
 }: AddToSetModalProps) => {
   const [selectedSets, setSelectedSets] = useState<string[][]>([]);
   const dispatch = useCoreDispatch();
-  const { data: setCount, isSuccess: isSuccessCount } = countHook(
+  const { data: setCount, isSuccess: isSuccessCount } = singleCountHook(
     {
       setId: selectedSets?.[0]?.[0],
     },
     { skip: selectedSets.length === 0 },
   );
-  const { data: countInBoth, isSuccess: isCountBothSuccess } = countHook(
+  const { data: countInBoth, isSuccess: isCountBothSuccess } = singleCountHook(
     {
       setId: selectedSets?.[0]?.[0],
       additionalFilters: buildCohortGqlOperator(filters),
@@ -141,7 +149,9 @@ const AddToSetModal: React.FC<AddToSetModalProps> = ({
       <ModalButtonContainer>
         <FunctionButton onClick={closeModal}>Cancel</FunctionButton>
         <DarkFunctionButton
-          disabled={selectedSets.length === 0 || nothingToAdd}
+          disabled={
+            selectedSets.length === 0 || nothingToAdd || !isSuccessCount
+          }
           onClick={() => {
             appendToSet({
               setId: selectedSets[0][0],
@@ -169,6 +179,7 @@ const AddToSetModal: React.FC<AddToSetModalProps> = ({
                 op: "and",
               },
               size: SET_COUNT_LIMIT - setCount,
+              score: sort,
             });
           }}
         >

--- a/packages/portal-proto/src/components/Modals/SetModals/GeneSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/GeneSetModal.tsx
@@ -5,7 +5,7 @@ import {
   useCoreDispatch,
   hideModal,
   useCreateGeneSetFromValuesMutation,
-  useGeneSetCountQuery,
+  useGeneSetCountsQuery,
 } from "@gff/core";
 import InputEntityList from "@/components/InputEntityList/InputEntityList";
 import SavedSets from "./SavedSets";
@@ -77,7 +77,7 @@ const GeneSetModal: React.FC<SavedSetModalProps> = ({
             </p>
           }
           selectSetInstructions={selectSetInstructions}
-          countHook={useGeneSetCountQuery}
+          countHook={useGeneSetCountsQuery}
           updateFilters={updateFilters}
           facetField={"genes.gene_id"}
           existingFiltersHook={existingFiltersHook}

--- a/packages/portal-proto/src/components/Modals/SetModals/MutationSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/MutationSetModal.tsx
@@ -5,7 +5,7 @@ import {
   useCoreDispatch,
   hideModal,
   useCreateSsmsSetFromValuesMutation,
-  useSsmSetCountQuery,
+  useSsmSetCountsQuery,
 } from "@gff/core";
 import InputEntityList from "@/components/InputEntityList/InputEntityList";
 import SavedSets from "./SavedSets";
@@ -76,7 +76,7 @@ const MutationSetModal: React.FC<SavedSetModalProps> = ({
           }
           selectSetInstructions={selectSetInstructions}
           facetField="ssms.ssm_id"
-          countHook={useSsmSetCountQuery}
+          countHook={useSsmSetCountsQuery}
           updateFilters={updateFilters}
           existingFiltersHook={existingFiltersHook}
         />

--- a/packages/portal-proto/src/components/Modals/SetModals/RemoveFromSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/RemoveFromSetModal.tsx
@@ -28,7 +28,9 @@ interface RemoveFromSetModalProps {
   readonly setType: SetTypes;
   readonly setTypeLabel: string;
   readonly closeModal: () => void;
-  readonly countHook: UseQuery<QueryDefinition<any, any, any, number, string>>;
+  readonly countHook: UseQuery<
+    QueryDefinition<any, any, any, Record<string, number>, string>
+  >;
   readonly removeFromSetHook: UseMutation<
     MutationDefinition<any, any, any, string, string>
   >;

--- a/packages/portal-proto/src/components/Modals/SetModals/SavedSets.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/SavedSets.tsx
@@ -24,17 +24,14 @@ import useStandardPagination from "@/hooks/useStandardPagination";
 import DiscardChangesButton from "../DiscardChangesButton";
 import { UserInputContext } from "../UserInputModal";
 
-const CountCell = ({ countHook, setId }) => {
-  const { data, isSuccess } = countHook({ setId });
-  return isSuccess ? data : "";
-};
-
 interface SavedSetsProps {
   readonly setType: SetTypes;
   readonly setTypeLabel: string;
   readonly createSetsInstructions: React.ReactNode;
   readonly selectSetInstructions: string;
-  readonly countHook: UseQuery<QueryDefinition<any, any, any, any, any>>;
+  readonly countHook: UseQuery<
+    QueryDefinition<any, any, any, Record<string, number>, string>
+  >;
   readonly updateFilters: (field: string, op: Operation) => void;
   readonly facetField: string;
   readonly existingFiltersHook: () => FilterSet;
@@ -53,6 +50,10 @@ const SavedSets: React.FC<SavedSetsProps> = ({
   const [selectedSets, setSelectedSets] = useState<string[]>([]);
   const [, setUserEnteredInput] = useContext(UserInputContext);
   const sets = useCoreSelector((state) => selectSetsByType(state, setType));
+  const { data: counts, isSuccess } = countHook({
+    setIds: Object.keys(sets),
+  });
+
   const dispatch = useCoreDispatch();
   const existingFilters = existingFiltersHook();
   const existingOperation = existingFilters?.root?.[facetField];
@@ -71,9 +72,9 @@ const SavedSets: React.FC<SavedSetsProps> = ({
         />
       ),
       name,
-      count: <CountCell countHook={countHook} setId={setId} />,
+      count: isSuccess ? (counts?.[setId] || 0).toLocaleString() : "...",
     }));
-  }, [sets, selectedSets, countHook]);
+  }, [sets, selectedSets, counts, isSuccess]);
 
   const columns = useMemo(() => {
     return [

--- a/packages/portal-proto/src/components/expandableTables/genes/GTableContainer.tsx
+++ b/packages/portal-proto/src/components/expandableTables/genes/GTableContainer.tsx
@@ -7,6 +7,7 @@ import {
   useCoreSelector,
   selectSetsByType,
   useGeneSetCountQuery,
+  useGeneSetCountsQuery,
   useAppendToGeneSetMutation,
   useRemoveFromGeneSetMutation,
   joinFilters,
@@ -222,10 +223,12 @@ export const GTableContainer: React.FC<GTableContainerProps> = ({
           }
           setType={"genes"}
           setTypeLabel="gene"
-          countHook={useGeneSetCountQuery}
+          singleCountHook={useGeneSetCountQuery}
+          countHook={useGeneSetCountsQuery}
           appendSetHook={useAppendToGeneSetMutation}
           closeModal={() => setShowAddModal(false)}
           field={"genes.gene_id"}
+          sort="case.project.project_id"
         />
       )}
       {showRemoveModal && (
@@ -238,7 +241,7 @@ export const GTableContainer: React.FC<GTableContainerProps> = ({
           }
           setType={"genes"}
           setTypeLabel="gene"
-          countHook={useGeneSetCountQuery}
+          countHook={useGeneSetCountsQuery}
           closeModal={() => setShowRemoveModal(false)}
           removeFromSetHook={useRemoveFromGeneSetMutation}
         />

--- a/packages/portal-proto/src/components/expandableTables/somaticMutations/SMTableContainer.tsx
+++ b/packages/portal-proto/src/components/expandableTables/somaticMutations/SMTableContainer.tsx
@@ -4,6 +4,7 @@ import {
   usePrevious,
   useGetSssmTableDataQuery,
   useSsmSetCountQuery,
+  useSsmSetCountsQuery,
   useAppendToSsmSetMutation,
   useRemoveFromSsmSetMutation,
   useCreateSsmsSetFromFiltersMutation,
@@ -282,10 +283,12 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
               }
               setType={"ssms"}
               setTypeLabel="mutation"
-              countHook={useSsmSetCountQuery}
+              singleCountHook={useSsmSetCountQuery}
+              countHook={useSsmSetCountsQuery}
               appendSetHook={useAppendToSsmSetMutation}
               closeModal={() => setShowAddModal(false)}
               field={"ssms.ssm_id"}
+              sort="occurrence.case.project.project_id"
             />
           )}
           {showRemoveModal && (
@@ -298,7 +301,7 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
               }
               setType={"ssms"}
               setTypeLabel="mutation"
-              countHook={useSsmSetCountQuery}
+              countHook={useSsmSetCountsQuery}
               closeModal={() => setShowRemoveModal(false)}
               removeFromSetHook={useRemoveFromSsmSetMutation}
             />


### PR DESCRIPTION
## Description
Most of this PR is applying a performance improvement I made during the set operations [work](https://github.com/NCI-GDC/gdc-frontend-framework/pull/464) to the rest of the set modals because I noticed they were pretty sluggish. The actual fix for the issue is applying the sort. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
