### PR TITLE
PEAR-1221 standardizes cohort builder cards' tooltips style

### DIFF
--- a/packages/portal-proto/src/features/facets/DateRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/DateRangeFacet.tsx
@@ -94,10 +94,6 @@ const DateRangeFacet: React.FC<DateRangeFacetProps> = ({
       <FacetHeader>
         <Tooltip
           label={description}
-          classNames={{
-            arrow: "bg-base-light",
-            tooltip: "bg-base-max text-base-contrast-max",
-          }}
           position="bottom-start"
           multiline
           width={220}

--- a/packages/portal-proto/src/features/facets/ExactValueFacet.tsx
+++ b/packages/portal-proto/src/features/facets/ExactValueFacet.tsx
@@ -111,10 +111,6 @@ const ExactValueFacet: React.FC<ExactValueProps> = ({
       <FacetHeader>
         <Tooltip
           label={description || "No description available"}
-          classNames={{
-            arrow: "bg-base-light",
-            tooltip: "bg-base-max text-base-contrast-max",
-          }}
           position="bottom-start"
           multiline
           width={220}

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -794,10 +794,6 @@ const NumericRangeFacet: React.FC<NumericFacetProps> = ({
         <FacetHeader>
           <Tooltip
             label={description}
-            classNames={{
-              arrow: "bg-base-light",
-              tooltip: "bg-base-max text-base-contrast-max",
-            }}
             position="bottom-start"
             multiline
             width={220}

--- a/packages/portal-proto/src/features/facets/ToggleFacet.tsx
+++ b/packages/portal-proto/src/features/facets/ToggleFacet.tsx
@@ -55,10 +55,6 @@ const ToggleFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
       <FacetHeader>
         <Tooltip
           label={description || "No description available"}
-          classNames={{
-            arrow: "bg-base-light",
-            tooltip: "bg-base-max text-base-contrast-max",
-          }}
           position="bottom-start"
           multiline
           width={220}


### PR DESCRIPTION
## Description
Standardizes the tooltip style on some Cohort Builder facet cards with tooltips elsewhere in portal. They should have black background with white-ish text.
## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="427" alt="Screenshot 2023-05-23 at 10 17 35 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/077d03e9-d3de-4584-9b4d-5edcb56cadcc">
<img width="459" alt="Screenshot 2023-05-23 at 10 22 12 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/d88eaa49-9d87-4214-8b31-d4e35703a1d4">
<img width="436" alt="Screenshot 2023-05-23 at 10 23 03 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/acc6e2e7-b997-4498-9f72-ed55523dfb78">
<img width="248" alt="Screenshot 2023-05-23 at 10 23 48 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/d153cbf8-e318-48a8-a5d6-bdbf09097040">
