### PR TITLE
PEAR-1288 adds cog rhabdomysarcoma risk group card to cohort builder

### DIFF
--- a/packages/core/src/features/cohort/data/cohort_builder.json
+++ b/packages/core/src/features/cohort/data/cohort_builder.json
@@ -75,6 +75,7 @@
     "other_classification": {
       "label": "Other Classification",
       "facets": [
+        "cases.diagnoses.cog_rhabdomyosarcoma_risk_group",
         "cases.diagnoses.eln_risk_classification",
         "cases.diagnoses.international_prognostic_index",
         "cases.diagnoses.wilms_tumor_histologic_subtype"

--- a/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
@@ -246,6 +246,7 @@ describe("cohortConfig reducer", () => {
       "cases.diagnoses.iss_stage",
       "cases.diagnoses.masaoka_stage",
       "cases.diagnoses.tumor_grade",
+      "cases.diagnoses.cog_rhabdomyosarcoma_risk_group",
       "cases.diagnoses.eln_risk_classification",
       "cases.diagnoses.international_prognostic_index",
       "cases.diagnoses.wilms_tumor_histologic_subtype",


### PR DESCRIPTION
## Description

Adds the COG rhabdomysarcoma risk group card to the general diagnosis category in cohort builder because it now has data.

## Checklist

- [/] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="798" alt="Screenshot 2023-05-24 at 3 32 21 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/2c70bb5a-8189-4767-956d-02f603145670">
