### PR TITLE
PEAR-989 - "View Images" button for cohorts with no images is disabled, but still clickable

### DIFF
--- a/packages/portal-proto/src/components/FunctionButton.tsx
+++ b/packages/portal-proto/src/components/FunctionButton.tsx
@@ -2,12 +2,12 @@ import tw from "tailwind-styled-components";
 import { Button } from "@mantine/core";
 
 interface FunctionButtonProps {
-  $disabled: boolean;
+  disabled: boolean;
 }
 
 export default tw(Button)<FunctionButtonProps>`
  ${(p) =>
-   p.$disabled
+   p.disabled
      ? "opacity-60 border-opacity-60 text-opacity-60 aria-disabled"
      : null}
 flex

--- a/packages/portal-proto/src/features/cDave/ContinuousBinningModal/ContinuousBinningModal.tsx
+++ b/packages/portal-proto/src/features/cDave/ContinuousBinningModal/ContinuousBinningModal.tsx
@@ -400,11 +400,6 @@ const ContinuousBinningModal: React.FC<ContinuousBinningModalProps> = ({
                           rangeForm.values.ranges[idx].from === "" ||
                           rangeForm.values.ranges[idx].to === ""
                         }
-                        $disabled={
-                          rangeForm.values.ranges[idx].name === "" ||
-                          rangeForm.values.ranges[idx].from === "" ||
-                          rangeForm.values.ranges[idx].to === ""
-                        }
                       >
                         Add
                       </FunctionButton>

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -22,7 +22,6 @@ import {
   removeFromCart,
   showCartOverLimitNotification,
 } from "@/features/cart/updateCart";
-import Link from "next/link";
 import { FileFacetPanel } from "./FileFacetPanel";
 import { mapGdcFileToCartFile } from "../files/utils";
 import { selectFilters } from "@/features/repositoryApp/repositoryFiltersSlice";
@@ -35,6 +34,7 @@ import { Tooltip } from "@mantine/core";
 import FilesTables from "../repositoryApp/FilesTable";
 import { persistStore } from "redux-persist";
 import { PersistGate } from "redux-persist/integration/react";
+import { useRouter } from "next/router";
 
 const persistor = persistStore(AppStore);
 
@@ -70,6 +70,7 @@ const useCohortCentricFiles = () => {
 export const RepositoryApp = (): JSX.Element => {
   const currentCart = useCoreSelector((state) => selectCart(state));
   const dispatch = useCoreDispatch();
+  const router = useRouter();
   const { allFilters, pagination, repositoryFilters, imagesCount } =
     useCohortCentricFiles();
   const [
@@ -156,25 +157,26 @@ export const RepositoryApp = (): JSX.Element => {
                   setActive={setActive}
                   active={active}
                 />
-
-                <Link
-                  href={`/image-viewer/MultipleImageViewerPage?isCohortCentric=true&additionalFilters=${encodeURIComponent(
-                    stringifyJSONParam(repositoryFilters),
-                  )}`}
+                <Tooltip
+                  label={"No images available to be viewed"}
+                  disabled={!viewImageDisabled}
                 >
-                  <Tooltip
-                    label={"No images available to be viewed"}
-                    disabled={!viewImageDisabled}
-                  >
+                  <span>
                     <FunctionButton
-                      component="a"
-                      $disabled={viewImageDisabled}
+                      onClick={() =>
+                        router.push(
+                          `/image-viewer/MultipleImageViewerPage?isCohortCentric=true&additionalFilters=${encodeURIComponent(
+                            stringifyJSONParam(repositoryFilters),
+                          )}`,
+                        )
+                      }
+                      disabled={viewImageDisabled}
                       data-testid="button-view-images-files-table"
                     >
                       View Images
                     </FunctionButton>
-                  </Tooltip>
-                </Link>
+                  </span>
+                </Tooltip>
 
                 <FunctionButton
                   data-testid="button-add-all-files-table"


### PR DESCRIPTION
## Description
Disables view images button when there are no images to view

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
