### PR TITLE
PEAR-1120 - 'Age at Diagnosis' showing an empty graph when there is no value to display

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
@@ -130,21 +130,19 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
           </Tooltip>
         </div>
       </div>
-      {continuous ? (
-        noData ? (
-          <div className="h-[32.1rem] w-full flex flex-col justify-start">
-            <p className="mx-auto my-2">No data for this property</p>
-          </div>
-        ) : (
-          <ContinuousData
-            initialData={(data as Stats)?.stats}
-            field={field}
-            fieldName={fieldName}
-            chartType={chartType}
-            noData={noData}
-            cohortFilters={cohortFilters}
-          />
-        )
+      {noData ? (
+        <div className="h-[32.1rem] w-full flex flex-col justify-start">
+          <p className="mx-auto my-2">No data for this property</p>
+        </div>
+      ) : continuous ? (
+        <ContinuousData
+          initialData={(data as Stats)?.stats}
+          field={field}
+          fieldName={fieldName}
+          chartType={chartType}
+          noData={noData}
+          cohortFilters={cohortFilters}
+        />
       ) : (
         <CategoricalData
           initialData={(data as Buckets)?.buckets}

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
@@ -60,6 +60,7 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
     tailwindConfig.theme.extend.colors[COLOR_MAP[field.split(".").at(-2)]]
       ?.DEFAULT;
   const hideXTicks = barChartData.length > 20;
+  const hideYTicks = continuous && barChartData.every((d) => d.yCount === 0);
 
   return (
     <>
@@ -124,6 +125,7 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
               width={900}
               height={500}
               hideXTicks={hideXTicks}
+              hideYTicks={hideYTicks}
               xLabel={
                 hideXTicks
                   ? "Mouse over the histogram to see x-axis labels"

--- a/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
+++ b/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
@@ -84,6 +84,7 @@ interface VictoryBarChartProps {
   readonly xLabel?: string;
   readonly width?: number;
   readonly height?: number;
+  readonly hideYTicks?: boolean;
   readonly hideXTicks?: boolean;
 }
 
@@ -94,6 +95,7 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
   xLabel,
   width = 400,
   height = 400,
+  hideYTicks = false,
   hideXTicks = false,
 }: VictoryBarChartProps) => {
   return (
@@ -107,6 +109,7 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
         dependentAxis
         label={yLabel}
         axisLabelComponent={<VictoryLabel dy={-70} />}
+        tickLabelComponent={hideYTicks ? <></> : undefined}
         style={{
           tickLabels: { fontSize: 25, fontFamily: "Noto Sans" },
           grid: { stroke: "#F5F5F5", strokeWidth: 1 },


### PR DESCRIPTION
## Description
* Fix chart showing scale when there's no data points
* Fix table showing up in no data state

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
Before:
![image](https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/3e1d0a7a-2e09-4761-b0ec-715ece253c09)
After!
<img width="631" alt="Screenshot 2023-05-26 at 11 51 49 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/98c1fe8b-ec8e-4d45-86c7-8f7dc0a39eab">

Before:
<img width="496" alt="Screenshot 2023-05-26 at 7 48 10 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/4a0ad9dd-2d17-4f25-a4cf-5330b06650da">

After!
<img width="603" alt="Screenshot 2023-05-30 at 10 39 32 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/6804d1d6-d726-42a4-9860-69d134f03acb">

