### PR TITLE
PEAR-1225 - Add and adjust text to clarify cohort creation vs saving

### DIFF
--- a/packages/portal-proto/src/components/InputEntityList/SaveSetButton.tsx
+++ b/packages/portal-proto/src/components/InputEntityList/SaveSetButton.tsx
@@ -9,7 +9,7 @@ import {
   SetTypes,
 } from "@gff/core";
 import { showNotification } from "@mantine/notifications";
-import { SaveOrCreateCohortModal } from "@/components/Modals/SaveOrCreateCohortModal";
+import { SaveOrCreateEntityModal } from "@/components/Modals/SaveOrCreateEntityModal";
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
 
 interface SaveSetButttonProps {
@@ -50,7 +50,7 @@ const SaveSetButton: React.FC<SaveSetButttonProps> = ({
 
   return (
     <>
-      <SaveOrCreateCohortModal
+      <SaveOrCreateEntityModal
         entity="set"
         initialName=""
         opened={showSaveModal}

--- a/packages/portal-proto/src/components/Modals/CreateCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/CreateCohortModal.tsx
@@ -1,0 +1,31 @@
+import { useCoreSelector, selectAvailableCohorts } from "@gff/core";
+import { SaveOrCreateEntityModal } from "./SaveOrCreateEntityModal";
+
+const CreateCohortModal = ({
+  onClose,
+  onActionClick,
+}: {
+  onClose: () => void;
+  onActionClick: (name: string) => void;
+}): JSX.Element => {
+  const cohorts = useCoreSelector((state) => selectAvailableCohorts(state));
+
+  const onNameChange = (name: string) =>
+    cohorts.every((cohort) => cohort.name !== name);
+
+  return (
+    <SaveOrCreateEntityModal
+      entity="cohort"
+      action="Create"
+      opened
+      onClose={onClose}
+      onActionClick={onActionClick}
+      onNameChange={onNameChange}
+      descriptionMessage={
+        "Create a new unsaved cohort. This cohort will not be saved until you click the Save Cohort button in the Cohort Bar."
+      }
+    />
+  );
+};
+
+export default CreateCohortModal;

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
@@ -1,0 +1,31 @@
+import { SaveOrCreateEntityModal } from "./SaveOrCreateEntityModal";
+
+const SaveCohortModal = ({
+  initialName = "",
+  opened,
+  onClose,
+  onActionClick,
+  onNameChange,
+  additionalDuplicateMessage,
+}: {
+  initialName?: string;
+  opened: boolean;
+  onClose: () => void;
+  onActionClick: (name: string) => void;
+  onNameChange: (name: string) => boolean;
+  additionalDuplicateMessage?: string;
+}): JSX.Element => (
+  <SaveOrCreateEntityModal
+    entity="cohort"
+    action="Save"
+    initialName={initialName}
+    opened={opened}
+    onClose={onClose}
+    onActionClick={onActionClick}
+    onNameChange={onNameChange}
+    descriptionMessage={"Provide a name to save your current cohort."}
+    additionalDuplicateMessage={additionalDuplicateMessage}
+  />
+);
+
+export default SaveCohortModal;

--- a/packages/portal-proto/src/components/Modals/SaveOrCreateEntityModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveOrCreateEntityModal.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Group, Modal, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { RiErrorWarningFill as WarningIcon } from "react-icons/ri";
 
-export const SaveOrCreateCohortModal = ({
+export const SaveOrCreateEntityModal = ({
   entity,
   action = "Save",
   initialName = "",
@@ -11,6 +11,7 @@ export const SaveOrCreateCohortModal = ({
   onClose,
   onActionClick,
   onNameChange,
+  descriptionMessage,
   additionalDuplicateMessage,
 }: {
   entity: string;
@@ -20,6 +21,7 @@ export const SaveOrCreateCohortModal = ({
   onClose: () => void;
   onActionClick: (name: string) => void;
   onNameChange: (name: string) => boolean;
+  descriptionMessage?: string;
   additionalDuplicateMessage?: string;
 }): JSX.Element => {
   const form = useForm({
@@ -67,6 +69,9 @@ export const SaveOrCreateCohortModal = ({
           padding: "5px 25px 20px 10px",
         })}
       >
+        <p className="mb-2 text-sm font-content">
+          {descriptionMessage && descriptionMessage}
+        </p>
         <TextInput
           withAsterisk
           label="Name"

--- a/packages/portal-proto/src/components/Modals/tests/SaveOrCreateEntityModal.unit.test.tsx
+++ b/packages/portal-proto/src/components/Modals/tests/SaveOrCreateEntityModal.unit.test.tsx
@@ -1,6 +1,6 @@
 import { MantineProvider } from "@mantine/core";
 import { render } from "@testing-library/react";
-import { SaveOrCreateCohortModal } from "../SaveOrCreateCohortModal";
+import { SaveOrCreateEntityModal } from "../SaveOrCreateEntityModal";
 import tailwindConfig from "tailwind.config";
 import userEvent from "@testing-library/user-event";
 import * as mantine_form from "@mantine/form";
@@ -13,7 +13,7 @@ beforeAll(() => {
   jest.clearAllMocks();
 });
 
-describe("<SaveOrCreateCohortModal />", () => {
+describe("<SaveOrCreateEntityModal />", () => {
   it("default action should be Save", () => {
     const { getByText } = render(
       <MantineProvider
@@ -24,7 +24,7 @@ describe("<SaveOrCreateCohortModal />", () => {
           },
         }}
       >
-        <SaveOrCreateCohortModal
+        <SaveOrCreateEntityModal
           entity="cohort"
           initialName="testName"
           opened={true}
@@ -48,7 +48,7 @@ describe("<SaveOrCreateCohortModal />", () => {
           },
         }}
       >
-        <SaveOrCreateCohortModal
+        <SaveOrCreateEntityModal
           entity="cohort"
           action="test"
           initialName="testName"
@@ -81,7 +81,7 @@ describe("<SaveOrCreateCohortModal />", () => {
           },
         }}
       >
-        <SaveOrCreateCohortModal
+        <SaveOrCreateEntityModal
           entity="cohort"
           action="test"
           initialName="lorem"
@@ -110,7 +110,7 @@ describe("<SaveOrCreateCohortModal />", () => {
           },
         }}
       >
-        <SaveOrCreateCohortModal
+        <SaveOrCreateEntityModal
           entity="cohort"
           action="test"
           initialName=""
@@ -140,7 +140,7 @@ describe("<SaveOrCreateCohortModal />", () => {
           },
         }}
       >
-        <SaveOrCreateCohortModal
+        <SaveOrCreateEntityModal
           entity="cohort"
           action="test"
           initialName=""
@@ -169,7 +169,7 @@ describe("<SaveOrCreateCohortModal />", () => {
           },
         }}
       >
-        <SaveOrCreateCohortModal
+        <SaveOrCreateEntityModal
           entity="cohort"
           action="test"
           initialName=""

--- a/packages/portal-proto/src/features/cases/CasesView/CasesCohortButton.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/CasesCohortButton.tsx
@@ -6,14 +6,13 @@ import {
   FilterSet,
   resetSelectedCases,
   addNewCohortWithFilterAndMessage,
-  selectAvailableCohorts,
   useCreateCaseSetFromValuesMutation,
 } from "@gff/core";
 import {
   SelectCohortsModal,
   WithOrWithoutCohortType,
 } from "./SelectCohortsModal";
-import { SaveOrCreateCohortModal } from "@/components/Modals/SaveOrCreateCohortModal";
+import CreateCohortModal from "@/components/Modals/CreateCohortModal";
 import { DropdownWithIcon } from "@/components/DropdownWithIcon/DropdownWithIcon";
 import { CountsIcon } from "@/features/shared/tailwindComponents";
 
@@ -24,11 +23,7 @@ export const CasesCohortButton = (): JSX.Element => {
   const [name, setName] = useState(undefined);
   const [createSet, response] = useCreateCaseSetFromValuesMutation();
 
-  const cohorts = useCoreSelector((state) => selectAvailableCohorts(state));
   const coreDispatch = useCoreDispatch();
-
-  const onNameChange = (name: string) =>
-    cohorts.every((cohort) => cohort.name !== name);
 
   useEffect(() => {
     if (response.isSuccess) {
@@ -108,10 +103,7 @@ export const CasesCohortButton = (): JSX.Element => {
         />
       )}
       {showCreateCohort && (
-        <SaveOrCreateCohortModal
-          entity="cohort"
-          action="create"
-          opened
+        <CreateCohortModal
           onClose={() => setShowCreateCohort(false)}
           onActionClick={(newName: string) => {
             setName(newName);
@@ -119,7 +111,6 @@ export const CasesCohortButton = (): JSX.Element => {
               createSet({ values: pickedCases });
             }
           }}
-          onNameChange={onNameChange}
         />
       )}
     </>

--- a/packages/portal-proto/src/features/cases/CasesView/SelectCohortsModal.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/SelectCohortsModal.tsx
@@ -1,5 +1,5 @@
 import FunctionButton from "@/components/FunctionButton";
-import { SaveOrCreateCohortModal } from "@/components/Modals/SaveOrCreateCohortModal";
+import CreateCohortModal from "@/components/Modals/CreateCohortModal";
 import { modalStyles } from "@/components/Modals/styles";
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
 import {
@@ -189,9 +189,6 @@ export const SelectCohortsModal = ({
       isWithCohort ? "and" : "except"
     } the cases previously selected.`;
 
-  const onNameChange = (name: string) =>
-    cohorts.every((cohort) => cohort.name !== name);
-
   const [showCreateCohort, setShowCreateCohorts] = useState(false);
   return (
     <>
@@ -212,16 +209,12 @@ export const SelectCohortsModal = ({
           zIndex={400}
         >
           {showCreateCohort && (
-            <SaveOrCreateCohortModal
-              entity="cohort"
-              action="create"
-              opened={showCreateCohort}
+            <CreateCohortModal
               onClose={() => setShowCreateCohorts(false)}
               onActionClick={async (newName: string) => {
                 await createCohortFromCases(newName);
                 onClose();
               }}
-              onNameChange={onNameChange}
             />
           )}
 

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -48,7 +48,8 @@ import {
   updateCohortName,
 } from "@gff/core";
 import { useCohortFacetFilters } from "./utils";
-import { SaveOrCreateCohortModal } from "@/components/Modals/SaveOrCreateCohortModal";
+import SaveCohortModal from "@/components/Modals/SaveCohortModal";
+import CreateCohortModal from "@/components/Modals/CreateCohortModal";
 import { GenericCohortModal } from "./Modals/GenericCohortModal";
 import CaseSetModal from "@/components/Modals/SetModals/CaseSetModal";
 import GeneSetModal from "@/components/Modals/SetModals/GeneSetModal";
@@ -152,13 +153,6 @@ const CohortManager: React.FC<CohortManagerProps> = ({
     cohorts
       .filter((cohort) => cohort.id !== cohortId)
       .every((cohort) => cohort.name !== name);
-
-  // util function to check for duplicate names while creating the cohort
-  // passed to SavingCohortModal as a prop
-  const onCreateCohort = useCallback(
-    (name: string) => cohorts.every((cohort) => cohort.name !== name),
-    [cohorts],
-  );
 
   // Cohort specific actions
   const newCohort = useCallback(
@@ -391,9 +385,8 @@ const CohortManager: React.FC<CohortManagerProps> = ({
       )}
 
       {showSaveCohort && (
-        <SaveOrCreateCohortModal
+        <SaveCohortModal
           initialName={cohortName}
-          entity="cohort"
           opened
           onClose={() => setShowSaveCohort(false)}
           onActionClick={async (newName: string) => {
@@ -439,15 +432,11 @@ const CohortManager: React.FC<CohortManagerProps> = ({
       )}
 
       {showCreateCohort && (
-        <SaveOrCreateCohortModal
-          entity="cohort"
-          action="create"
-          opened
+        <CreateCohortModal
           onClose={() => setShowCreateCohort(false)}
           onActionClick={async (newName: string) => {
             newCohort(newName);
           }}
-          onNameChange={onCreateCohort}
         />
       )}
 
@@ -560,7 +549,11 @@ const CohortManager: React.FC<CohortManagerProps> = ({
               </CohortGroupButton>
             </span>
           </Tooltip>
-          <Tooltip label="Add New Cohort" position="bottom" withArrow>
+          <Tooltip
+            label="Create New Unsaved Cohort"
+            position="bottom"
+            withArrow
+          >
             <CohortGroupButton
               onClick={() => setShowCreateCohort(true)}
               data-testid="addButton"

--- a/packages/portal-proto/src/features/cohortBuilder/Modals/ImportCohortModal.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/Modals/ImportCohortModal.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react";
 import {
-  useCoreSelector,
   useCoreDispatch,
-  selectAvailableCohorts,
   addNewCohortWithFilterAndMessage,
   FilterSet,
   hideModal,
@@ -11,7 +9,7 @@ import {
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
 import UserInputModal from "@/components/Modals/UserInputModal";
 import InputEntityList from "@/components/InputEntityList/InputEntityList";
-import { SaveOrCreateCohortModal } from "@/components/Modals/SaveOrCreateCohortModal";
+import CreateCohortModal from "@/components/Modals/CreateCohortModal";
 
 interface SubmitButtonProps {
   readonly ids: string[];
@@ -22,7 +20,6 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
   ids,
   disabled,
 }: SubmitButtonProps) => {
-  const cohorts = useCoreSelector((state) => selectAvailableCohorts(state));
   const coreDispatch = useCoreDispatch();
   const [name, setName] = useState(undefined);
   const [createSet, response] = useCreateCaseSetFromValuesMutation();
@@ -51,23 +48,17 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
     }
   }, [response.isSuccess, name, coreDispatch, response.data]);
 
-  const onNameChange = (name: string) =>
-    cohorts.every((cohort) => cohort.name !== name);
   const [showCreateCohort, setShowCreateCohort] = useState(false);
 
   return (
     <>
       {showCreateCohort && (
-        <SaveOrCreateCohortModal
-          entity="cohort"
-          action="create"
-          opened
+        <CreateCohortModal
           onClose={() => setShowCreateCohort(false)}
           onActionClick={(newName: string) => {
             setName(newName);
             createSet({ values: ids });
           }}
-          onNameChange={onNameChange}
         />
       )}
       <DarkFunctionButton

--- a/packages/portal-proto/src/features/projects/ProjectSummary.tsx
+++ b/packages/portal-proto/src/features/projects/ProjectSummary.tsx
@@ -7,8 +7,6 @@ import {
   useFilesFacetsByNameFilter,
   useCoreDispatch,
   FilterSet,
-  useCoreSelector,
-  selectAvailableCohorts,
   addNewCohortWithFilterAndMessage,
 } from "@gff/core";
 import { FaUser, FaFile, FaEdit } from "react-icons/fa";
@@ -34,7 +32,7 @@ import {
 import { DropdownWithIcon } from "@/components/DropdownWithIcon/DropdownWithIcon";
 import { HorizontalTable } from "@/components/HorizontalTable";
 import { SingularOrPluralSpan } from "@/components/SingularOrPluralSpan/SingularOrPluralSpan";
-import { SaveOrCreateCohortModal } from "@/components/Modals/SaveOrCreateCohortModal";
+import CreateCohortModal from "@/components/Modals/CreateCohortModal";
 import download from "src/utils/download";
 import PrimarySiteTable from "./PrimarySiteTable";
 
@@ -137,7 +135,6 @@ export const ProjectView: React.FC<ProjectViewProps> = (
   const dispatch = useCoreDispatch();
   const [manifestDownloadActive, setManifestDownloadActive] = useState(false);
   const [showCreateCohort, setShowCreateCohort] = useState(false);
-  const cohorts = useCoreSelector((state) => selectAvailableCohorts(state));
 
   const createCohortFromProjects = (name: string) => {
     const filters: FilterSet = {
@@ -158,9 +155,6 @@ export const ProjectView: React.FC<ProjectViewProps> = (
       }),
     );
   };
-
-  const onNameChange = (name: string) =>
-    cohorts.every((cohort) => cohort.name !== name);
 
   const formatDataForSummary = () => {
     const {
@@ -463,24 +457,25 @@ export const ProjectView: React.FC<ProjectViewProps> = (
         isModal={projectData.isModal}
         leftElement={
           <div className="flex gap-4">
-            <Button
-              color="primary"
-              variant="outline"
-              className="bg-base-max border-primary font-medium text-sm"
-              onClick={() => setShowCreateCohort(true)}
+            <Tooltip
+              label={`Create a new unsaved cohort of ${projectData.project_id} cases`}
+              withArrow
             >
-              Create New Cohort
-            </Button>
+              <Button
+                color="primary"
+                variant="outline"
+                className="bg-base-max border-primary font-medium text-sm"
+                onClick={() => setShowCreateCohort(true)}
+              >
+                Create New Cohort
+              </Button>
+            </Tooltip>
             {showCreateCohort && (
-              <SaveOrCreateCohortModal
-                entity="cohort"
-                action="create"
-                opened
+              <CreateCohortModal
                 onClose={() => setShowCreateCohort(false)}
                 onActionClick={(newName: string) => {
                   createCohortFromProjects(newName);
                 }}
-                onNameChange={onNameChange}
               />
             )}
             <DropdownWithIcon

--- a/packages/portal-proto/src/features/projectsCenter/ProjectsCohortButton.tsx
+++ b/packages/portal-proto/src/features/projectsCenter/ProjectsCohortButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button } from "@mantine/core";
+import { Button, Tooltip } from "@mantine/core";
 import {
   useAppSelector,
   useAppDispatch,
@@ -10,12 +10,10 @@ import {
 } from "@/features/projectsCenter/pickedProjectsSlice";
 import {
   FilterSet,
-  useCoreSelector,
   useCoreDispatch,
   addNewCohortWithFilterAndMessage,
-  selectAvailableCohorts,
 } from "@gff/core";
-import { SaveOrCreateCohortModal } from "@/components/Modals/SaveOrCreateCohortModal";
+import CreateCohortModal from "@/components/Modals/CreateCohortModal";
 import { CountsIcon } from "../shared/tailwindComponents";
 
 const ProjectsCohortButton = (): JSX.Element => {
@@ -25,7 +23,6 @@ const ProjectsCohortButton = (): JSX.Element => {
   const coreDispatch = useCoreDispatch();
   const appDispatch = useAppDispatch();
   const [showCreateCohort, setShowCreateCohort] = useState(false);
-  const cohorts = useCoreSelector((state) => selectAvailableCohorts(state));
 
   const createCohortFromProjects = (name: string) => {
     const filters: FilterSet = {
@@ -48,38 +45,38 @@ const ProjectsCohortButton = (): JSX.Element => {
     );
   };
 
-  const onNameChange = (name: string) =>
-    cohorts.every((cohort) => cohort.name !== name);
-
   return (
     <>
-      <Button
-        data-testid="button-create-new-cohort-projects-table"
-        variant="outline"
-        color="primary"
-        disabled={pickedProjects.length == 0}
-        leftIcon={
-          pickedProjects.length ? (
-            <CountsIcon $count={pickedProjects.length}>
-              {pickedProjects.length}{" "}
-            </CountsIcon>
-          ) : null
-        }
-        onClick={() => setShowCreateCohort(true)}
-        className="border-primary data-disabled:opacity-50 data-disabled:bg-base-max data-disabled:text-primary"
+      <Tooltip
+        label="Create a new unsaved cohort of cases in selected project(s)"
+        withArrow
       >
-        Create New Cohort
-      </Button>
+        <span>
+          <Button
+            data-testid="button-create-new-cohort-projects-table"
+            variant="outline"
+            color="primary"
+            disabled={pickedProjects.length == 0}
+            leftIcon={
+              pickedProjects.length ? (
+                <CountsIcon $count={pickedProjects.length}>
+                  {pickedProjects.length}{" "}
+                </CountsIcon>
+              ) : null
+            }
+            onClick={() => setShowCreateCohort(true)}
+            className="border-primary data-disabled:opacity-50 data-disabled:bg-base-max data-disabled:text-primary"
+          >
+            Create New Cohort
+          </Button>
+        </span>
+      </Tooltip>
       {showCreateCohort && (
-        <SaveOrCreateCohortModal
-          entity="cohort"
-          action="create"
-          opened
+        <CreateCohortModal
           onClose={() => setShowCreateCohort(false)}
           onActionClick={(newName: string) => {
             createCohortFromProjects(newName);
           }}
-          onNameChange={onNameChange}
         />
       )}
     </>


### PR DESCRIPTION
## Description
Most of this is a refactor to create a `<SaveCohortModal />` and `<CreateCohortModal />` component so that the new text didn't need to be passed in everywhere we were previously using `<SaveOrCreateCohortModal />`

## Checklist
- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="486" alt="Screenshot 2023-06-08 at 2 33 18 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/0702000d-1e51-4902-9c97-990a475b7845">
<img width="780" alt="Screenshot 2023-06-08 at 2 33 31 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/0aabb095-d084-4015-b48c-1f75be555531">

<img width="951" alt="Screenshot 2023-06-08 at 2 41 17 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/48e5599e-b541-4c14-9d46-e021421f3f3a">
<img width="765" alt="Screenshot 2023-06-08 at 2 32 21 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/46c21856-72d8-4041-98b8-d6795f3f5a42">
<img width="568" alt="Screenshot 2023-06-08 at 2 32 39 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/8876814d-8e22-4054-9d4b-a90a023f76b6">
