### PR TITLE
PEAR-1310: fix lerna version in Dockerfile

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ dist
 *.css
 setupTests.ts
 holmes-py/**/*
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV NEXT_PUBLIC_BUILD_SHORT_SHA=$BUILD_SHORT_SHA
 
 WORKDIR /app
 ENV npm_config_registry=$NPM_REGISTRY
-RUN npm install --location=global lerna
+RUN npm install --location=global lerna@6.6.1
 COPY ./package.json ./package-lock.json lerna.json ./
 COPY ./packages/core/package.json ./packages/core/
 COPY ./packages/sapien/package.json ./packages/sapien/


### PR DESCRIPTION
## Description
Sets the version of lerna to 6.6.1 as v7 has breaking changes
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
