### PR TITLE
update the @sjcrh/proteinpaint-client version to 2.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6256,11 +6256,12 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.16.0.tgz",
-      "integrity": "sha512-9mtSn6cXS3G4w8fKblNJ/vd8mhTJIxTANCnXqv7iAUWbdXlylRGNNX5CAqIpA/EoyoeY3bYDpfJnHet+B0D1DA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.17.0.tgz",
+      "integrity": "sha512-2/mqnXO/8gJmVqzc3Fv7OzUxyfq6+26ptfLoUuDIbx/sPQsqKet40GNP16m9LHbUgeBtcesdq5cHbCoyZV9JcQ==",
       "dependencies": {
-        "d3-regression": "^1.3.10"
+        "d3-regression": "^1.3.10",
+        "three": "^0.152.2"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -24226,6 +24227,11 @@
       "integrity": "sha512-X9Mha8cVeBwakunlZXkXL6xRzw8VCcDGWqT59EzeTYAJIi8ien3CuufnEGEx4ZUFahumNQdoOwf4H2T9Ca6lBg==",
       "dev": true
     },
+    "node_modules/three": {
+      "version": "0.152.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.152.2.tgz",
+      "integrity": "sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw=="
+    },
     "node_modules/throat": {
       "version": "6.0.1",
       "dev": true,
@@ -26350,7 +26356,7 @@
         "@mantine/notifications": "^5.10.2",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.16.0",
+        "@sjcrh/proteinpaint-client": "^2.17.0",
         "filesize": "^8.0.7",
         "html-to-image": "^1.11.4",
         "minisearch": "^3.0.4",
@@ -31497,11 +31503,12 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.16.0.tgz",
-      "integrity": "sha512-9mtSn6cXS3G4w8fKblNJ/vd8mhTJIxTANCnXqv7iAUWbdXlylRGNNX5CAqIpA/EoyoeY3bYDpfJnHet+B0D1DA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.17.0.tgz",
+      "integrity": "sha512-2/mqnXO/8gJmVqzc3Fv7OzUxyfq6+26ptfLoUuDIbx/sPQsqKet40GNP16m9LHbUgeBtcesdq5cHbCoyZV9JcQ==",
       "requires": {
-        "d3-regression": "^1.3.10"
+        "d3-regression": "^1.3.10",
+        "three": "^0.152.2"
       }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -40949,7 +40956,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.16.0",
+        "@sjcrh/proteinpaint-client": "^2.17.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",
@@ -43487,6 +43494,11 @@
       "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.17.1.tgz",
       "integrity": "sha512-X9Mha8cVeBwakunlZXkXL6xRzw8VCcDGWqT59EzeTYAJIi8ien3CuufnEGEx4ZUFahumNQdoOwf4H2T9Ca6lBg==",
       "dev": true
+    },
+    "three": {
+      "version": "0.152.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.152.2.tgz",
+      "integrity": "sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw=="
     },
     "throat": {
       "version": "6.0.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -26,7 +26,7 @@
     "@mantine/notifications": "^5.10.2",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.16.0",
+    "@sjcrh/proteinpaint-client": "^2.17.0",
     "filesize": "^8.0.7",
     "html-to-image": "^1.11.4",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -139,7 +139,7 @@ function getMatrixTrack(
     launchGdcMatrix: true,
     filter0: filter0 || defaultFilter,
     allow2selectSamples: {
-      buttonText: "Update Cohort",
+      buttonText: "Create Cohort",
       attributes: ["case.case_id"],
       callback,
     },


### PR DESCRIPTION
## Description
These are the changes meant for the next release:

GDC-related:
- reactivate the support for selecting samples in the matrix plot
- create an improved geneset edit UI that can be used in matrix and other plots
- disambiguate variant and testing status matrix data by alteration type and origin
- fix the matrix sorting by fusion data
- experimental: prototype more features in the new disco plot (NOTE: may be active in a release next week)
- fix the GDC server-side data query for matrix data, using cnv_occurrences

Unrelated updates:
- start using typescript in "core" code
- option to filter by survival data
- precompute intermediate cuminc data to improve server response
- fix the barchart sort order
- option to customize the violin plot "thickeness"

## Checklist

- [X] Added proper unit tests: tests were added to the PP code
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
