### PR TITLE
(PEAR-1075): Adjust 'Controlled' and 'Open' access ovals in tables

### DIFF
--- a/packages/portal-proto/src/components/FileAccessBadge/index.tsx
+++ b/packages/portal-proto/src/components/FileAccessBadge/index.tsx
@@ -7,7 +7,7 @@ export const FileAccessBadge = ({
   access: AccessType;
 }): JSX.Element => (
   <Badge
-    className={`w-full capitalize text-xs font-bold font-content
+    className={`w-full max-w-[8em] capitalize text-xs font-bold font-content
       ${
         access === "open" //TODO: keep or change to theme color (used same for the repository file table)
           ? "bg-nci-green-lighter/50 text-nci-green-darkest"


### PR DESCRIPTION
## Description
- Adjust 'Controlled' and 'Open' access ovals in tables, make them full width so they are both the same size 
## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot from 2023-06-27 11-40-41](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1020732/bb74eedf-b8f4-496c-ae79-3d973769ff35)
