### PR TITLE
PEAR-1326 adds who cns grade card to cohort builder

### DIFF
--- a/packages/core/src/features/cohort/data/cohort_builder.json
+++ b/packages/core/src/features/cohort/data/cohort_builder.json
@@ -68,7 +68,10 @@
     },
     "grade_classification": {
       "label": "Grade Classification",
-      "facets": ["cases.diagnoses.tumor_grade"],
+      "facets": [
+        "cases.diagnoses.tumor_grade",
+        "cases.diagnoses.who_cns_grade"
+      ],
       "docType": "cases",
       "index": "repository"
     },

--- a/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
@@ -246,6 +246,7 @@ describe("cohortConfig reducer", () => {
       "cases.diagnoses.iss_stage",
       "cases.diagnoses.masaoka_stage",
       "cases.diagnoses.tumor_grade",
+      "cases.diagnoses.who_cns_grade",
       "cases.diagnoses.cog_rhabdomyosarcoma_risk_group",
       "cases.diagnoses.eln_risk_classification",
       "cases.diagnoses.international_prognostic_index",


### PR DESCRIPTION
## Description
Added the Who CNS Grade card to the Grade Classification category of Cohort Builder.

## Checklist
- [/] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1030" alt="Screenshot 2023-06-29 at 4 28 19 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/5be02af2-ada9-481d-b747-1c7d87df2f8e">

