### PR TITLE
update to proteinpaint-client@2.18.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.17.0.tgz",
-      "integrity": "sha512-2/mqnXO/8gJmVqzc3Fv7OzUxyfq6+26ptfLoUuDIbx/sPQsqKet40GNP16m9LHbUgeBtcesdq5cHbCoyZV9JcQ==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.18.2.tgz",
+      "integrity": "sha512-NNPNVkxmlnJu1c2FGBGegx63t9LPcIuhGai0bQgYk5ZjAzLyWNnXNE4OH/nMKWwXy0JRrznGkG+csMbj2Yo2NQ==",
       "dependencies": {
         "d3-regression": "^1.3.10",
         "three": "^0.152.2"
@@ -26494,7 +26494,7 @@
         "@mantine/notifications": "^5.10.5",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.17.0",
+        "@sjcrh/proteinpaint-client": "^2.18.2",
         "filesize": "^8.0.7",
         "html-to-image": "^1.11.4",
         "minisearch": "^3.0.4",
@@ -31604,9 +31604,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.17.0.tgz",
-      "integrity": "sha512-2/mqnXO/8gJmVqzc3Fv7OzUxyfq6+26ptfLoUuDIbx/sPQsqKet40GNP16m9LHbUgeBtcesdq5cHbCoyZV9JcQ==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.18.2.tgz",
+      "integrity": "sha512-NNPNVkxmlnJu1c2FGBGegx63t9LPcIuhGai0bQgYk5ZjAzLyWNnXNE4OH/nMKWwXy0JRrznGkG+csMbj2Yo2NQ==",
       "requires": {
         "d3-regression": "^1.3.10",
         "three": "^0.152.2"
@@ -41089,7 +41089,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.17.0",
+        "@sjcrh/proteinpaint-client": "^2.18.2",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -26,7 +26,7 @@
     "@mantine/notifications": "^5.10.5",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.17.0",
+    "@sjcrh/proteinpaint-client": "^2.18.2",
     "filesize": "^8.0.7",
     "html-to-image": "^1.11.4",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

@craigrbarnes, I will wait a few hours before converting this PR from draft to ready, in order for your internal registry to hopefully pick up the 2.18.2 version of @sjcrh/proteinpaint-client. Hopefully that will avoid CI check failures related to that recurring known issue.

This will pull the following PP codebase updates. 

### 2.18.2
- handle optional action.config in mass store.plot_edit()
- fix recover to not prematurely replace state
- fix LohArc import for rollup
 
### 2.18.1
- fix the rollup bundling error caused by the dynamic import of Disco.ts

### 2.18.0
- fixed the matrix sample groupung input lag, edit menu error, empty column bug
- contextualized the matrix row label mouseover title
- removed GDC terms that are IDs or cause server response errors
- removed the numeric axis in the matrix row label when switching from continuous to discrete mode 
- removed an empty matrix term group after its last remaining term gets moved to a different term 
- supported launching disco plot from a matrix sample label click
- improved the geneset edit UI by having group input and fixing bugs
- supported a standalone scatter plot button in the charts tab
- mds3 gdc convert to case.case_id on the fly for disco plot
- improved disco plot tooltip, ring logic, other features and bug fixes
- use typescript for genomes, dataset, termsetting code

## Checklist

- [ ] Added proper unit tests (Note: No changes to PP React wrappers, tests were added/run in the sjpp repo)
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
