### PR TITLE
PEAR-1321:  Mutation Frequency - saving a cohort with genes causes page to freeze

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/hooks.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/hooks.ts
@@ -70,7 +70,7 @@ export const useSetupInitialCohorts = (): void => {
     isSuccess,
     isError,
     JSON.stringify(outdatedCohortsIds),
-    JSON.stringify(cohorts),
+    JSON.stringify(cohorts.map((cohort) => cohort.id)),
   ]);
   /* eslint-enable */
 };


### PR DESCRIPTION
## Description
Fixes infinite loop where saving a cohort that needed a case set would cause the hook to get called repeatedly and freeze the page.

## Checklist

- [N/A] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
