### PR TITLE
PEAR-1324: Fix for custom filters modal title area getting cut off

### DIFF
--- a/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
+++ b/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
@@ -155,7 +155,7 @@ export const UserFlowVariedPages: React.FC<UserFlowVariedPagesProps> = ({
         <Header {...{ headerElements, indexPath, Options }} />
       </header>
       <div
-        className={`${isContextBarSticky ? `sticky z-[200]` : ""}`}
+        className={`${isContextBarSticky ? `sticky z-[300]` : ""}`}
         style={{
           top: `${isContextBarSticky && `${Math.round(headerHeight)}px`}`, // switching this to tailwind does not work
         }}


### PR DESCRIPTION
## Description
Fixed incorrect z-index for context bar.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/f71b45fb-675c-419a-85e7-27163449ab0b

