### PR TITLE
PEAR-1319: Fix for Gene and Somatic Mutation table keeping row expansion between pages

### DIFF
--- a/packages/portal-proto/src/components/expandableTables/genes/GenesTable.tsx
+++ b/packages/portal-proto/src/components/expandableTables/genes/GenesTable.tsx
@@ -9,9 +9,10 @@ import { GenesTableProps } from "./types";
 import { ExpandedState, ColumnDef } from "@tanstack/react-table";
 import { getGene, geneCreateTableColumn } from "./genesTableUtils";
 import { Genes } from "./types";
-import { useGetGeneTableSubrowQuery } from "@gff/core";
+import { useGetGeneTableSubrowQuery, usePrevious } from "@gff/core";
 import { SummaryModalContext } from "src/utils/contexts";
 import { ExpTable, Subrow } from "../shared";
+import isEqual from "lodash/isEqual";
 
 export const GenesTable: React.FC<GenesTableProps> = ({
   status,
@@ -104,6 +105,15 @@ export const GenesTable: React.FC<GenesTableProps> = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedProxy]);
+
+  const prevInitialData = usePrevious(initialData);
+  useEffect(() => {
+    if (!isEqual(prevInitialData, initialData)) {
+      setExpanded({});
+      setExpandedId(undefined);
+      setExpandedProxy({});
+    }
+  }, [initialData, prevInitialData]);
 
   const { setEntityMetadata } = useContext(SummaryModalContext);
 

--- a/packages/portal-proto/src/components/expandableTables/somaticMutations/SomaticMutationsTable.tsx
+++ b/packages/portal-proto/src/components/expandableTables/somaticMutations/SomaticMutationsTable.tsx
@@ -8,9 +8,14 @@ import React, {
 import { SomaticMutationsTableProps, SomaticMutations } from "./types";
 import { ExpandedState, ColumnDef } from "@tanstack/react-table";
 import { getMutation, ssmsCreateTableColumn } from "./smTableUtils";
-import { GDCSsmsTable, useGetSomaticMutationTableSubrowQuery } from "@gff/core";
+import {
+  GDCSsmsTable,
+  useGetSomaticMutationTableSubrowQuery,
+  usePrevious,
+} from "@gff/core";
 import { SummaryModalContext } from "src/utils/contexts";
 import { Column, ExpTable, Subrow } from "../shared";
+import isEqual from "lodash/isEqual";
 
 export const SomaticMutationsTable: React.FC<SomaticMutationsTableProps> = ({
   status,
@@ -92,6 +97,15 @@ export const SomaticMutationsTable: React.FC<SomaticMutationsTableProps> = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedProxy]);
+
+  const prevInitialData = usePrevious(initialData);
+  useEffect(() => {
+    if (!isEqual(prevInitialData, initialData)) {
+      setExpanded({});
+      setExpandedId(undefined);
+      setExpandedProxy({});
+    }
+  }, [initialData, prevInitialData]);
 
   const { setEntityMetadata } = useContext(SummaryModalContext);
 


### PR DESCRIPTION
## Description
Resetting the expansion obects!

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/8c995486-f2d0-4546-8128-a91b0c5dd4df

