### PR TITLE
PEAR-1352: add additional check to prevent looping of saved  cohorts with gene/ssms filters

### DIFF
--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -1362,7 +1362,11 @@ export const setActiveCohortList =
     const cohort = selectCurrentCohort(getState());
 
     if (!cohort) return;
-    if (cohortId && willRequireCaseSet(cohort.filters)) {
+    if (
+      cohortId &&
+      willRequireCaseSet(cohort.filters) &&
+      cohort.caseSet.status === "uninitialized"
+    ) {
       dispatch(
         createCaseSet({
           caseSetId: cohortId,

--- a/packages/portal-proto/src/features/cohortBuilder/hooks.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/hooks.ts
@@ -6,7 +6,6 @@ import {
   useGetCohortsByContextIdQuery,
   buildGqlOperationToFilterSet,
   setActiveCohortList,
-  DataStatus,
   Cohort,
   removeCohort,
   addNewCohort,
@@ -44,8 +43,7 @@ export const useSetupInitialCohorts = (): void => {
                 name: data.name,
                 filters: buildGqlOperationToFilterSet(data.filters),
                 caseSet: {
-                  caseSetId: buildGqlOperationToFilterSet(data.filters),
-                  status: "fulfilled" as DataStatus,
+                  ...(existingCohort?.caseSet ?? { status: "uninitialized" }),
                 },
                 modified_datetime: data.modified_datetime,
                 saved: true,
@@ -66,7 +64,7 @@ export const useSetupInitialCohorts = (): void => {
     /* eslint-disable react-hooks/exhaustive-deps */
   }, [
     coreDispatch,
-    cohortsListData,
+    JSON.stringify(cohortsListData),
     isSuccess,
     isError,
     JSON.stringify(outdatedCohortsIds),


### PR DESCRIPTION
Addresses issues in PEAR-1352.

## Description

- Initializes a recently saved cohort with the caseSet information
- Adds additional conditions to prevent unneeded caseSet creation

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
