### PR TITLE
PEAR-1076: add test so range facets do not display flip icon

### DIFF
--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -806,12 +806,14 @@ const NumericRangeFacet: React.FC<NumericFacetProps> = ({
             </FacetText>
           </Tooltip>
           <div className="flex flex-row">
-            <FacetIconButton
-              onClick={toggleFlip}
-              aria-label="Flip between form and chart"
-            >
-              <FlipIcon size="1.45em" className={controlsIconStyle} />
-            </FacetIconButton>
+            {rangeDatatype !== "range" && (
+              <FacetIconButton
+                onClick={toggleFlip}
+                aria-label="Flip between form and chart"
+              >
+                <FlipIcon size="1.45em" className={controlsIconStyle} />
+              </FacetIconButton>
+            )}
             <FacetIconButton
               onClick={() => {
                 clearFilters(field);


### PR DESCRIPTION
## Description
Removes the flip icon for ranges without a predefined range section as there is only 1 value to plot.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![image](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1093780/5874c818-52db-42f2-83f8-310886f727e3)
