### PR TITLE
fix the cohort creation bug in the PP and OncoMatrix tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6376,13 +6376,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.18.3.tgz",
-      "integrity": "sha512-IARVpG/0aOLDCLeF3oiW87SiLNEFcB/I8DhQ8r1uoJ2KFFoeFS5Ui4ATFvJuhtsH1LswWI15TVWrvotCwFqnbw==",
-      "dependencies": {
-        "d3-regression": "^1.3.10",
-        "three": "^0.152.2"
-      }
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.19.2.tgz",
+      "integrity": "sha512-Gqu+CDwkVykknb2WqFIE9zRGawApp3rYKqd1I5NwCP08Ka11GcHZZDo+4Eu6pHgz2F1IncKzEtM4uImwE/f8Og=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -10624,11 +10620,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
       "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-    },
-    "node_modules/d3-regression": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
-      "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw=="
     },
     "node_modules/d3-request": {
       "version": "1.0.6",
@@ -24366,11 +24357,6 @@
       "integrity": "sha512-X9Mha8cVeBwakunlZXkXL6xRzw8VCcDGWqT59EzeTYAJIi8ien3CuufnEGEx4ZUFahumNQdoOwf4H2T9Ca6lBg==",
       "dev": true
     },
-    "node_modules/three": {
-      "version": "0.152.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.152.2.tgz",
-      "integrity": "sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw=="
-    },
     "node_modules/throat": {
       "version": "6.0.1",
       "dev": true,
@@ -26499,7 +26485,7 @@
         "@mantine/notifications": "^5.10.5",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.18.3",
+        "@sjcrh/proteinpaint-client": "^2.19.2",
         "filesize": "^8.0.7",
         "html-to-image": "^1.11.4",
         "minisearch": "^3.0.4",
@@ -31609,13 +31595,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.18.3.tgz",
-      "integrity": "sha512-IARVpG/0aOLDCLeF3oiW87SiLNEFcB/I8DhQ8r1uoJ2KFFoeFS5Ui4ATFvJuhtsH1LswWI15TVWrvotCwFqnbw==",
-      "requires": {
-        "d3-regression": "^1.3.10",
-        "three": "^0.152.2"
-      }
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.19.2.tgz",
+      "integrity": "sha512-Gqu+CDwkVykknb2WqFIE9zRGawApp3rYKqd1I5NwCP08Ka11GcHZZDo+4Eu6pHgz2F1IncKzEtM4uImwE/f8Og=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -34486,11 +34468,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
       "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-    },
-    "d3-regression": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
-      "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw=="
     },
     "d3-request": {
       "version": "1.0.6",
@@ -41096,7 +41073,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.18.3",
+        "@sjcrh/proteinpaint-client": "^2.19.2",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",
@@ -43543,11 +43520,6 @@
       "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.17.1.tgz",
       "integrity": "sha512-X9Mha8cVeBwakunlZXkXL6xRzw8VCcDGWqT59EzeTYAJIi8ien3CuufnEGEx4ZUFahumNQdoOwf4H2T9Ca6lBg==",
       "dev": true
-    },
-    "three": {
-      "version": "0.152.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.152.2.tgz",
-      "integrity": "sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw=="
     },
     "throat": {
       "version": "6.0.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -26,7 +26,7 @@
     "@mantine/notifications": "^5.10.5",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.18.3",
+    "@sjcrh/proteinpaint-client": "^2.19.2",
     "filesize": "^8.0.7",
     "html-to-image": "^1.11.4",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -150,7 +150,13 @@ function getMatrixTrack(
       matrix: {
         allow2selectSamples: {
           buttonText: "Create Cohort",
-          attributes: ["case.case_id"],
+          attributes: [
+            {
+              from: "sample",
+              to: "cases.case_id",
+              convert: true,
+            },
+          ],
           callback,
         },
       },

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -160,7 +160,9 @@ function getLollipopTrack(
         // allow2selectSamples: { buttons },
         allow2selectSamples: {
           buttonText: "Create Cohort",
-          attributes: ["case.case_id"],
+          attributes: [
+            { from: "sample_id", to: "cases.case_id", convert: true },
+          ],
           callback,
         },
       },

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
@@ -45,7 +45,7 @@ test("SSM lolliplot arguments", () => {
       filter0: { abc: "xyz" },
       allow2selectSamples: {
         buttonText: "Create Cohort",
-        attributes: ["case.case_id"],
+        attributes: [{ from: "sample_id", to: "cases.case_id", convert: true }],
         callback: runpparg.tracks[0]?.allow2selectSamples?.callback,
       },
     },

--- a/packages/portal-proto/src/features/proteinpaint/sjpp-types.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/sjpp-types.tsx
@@ -1,7 +1,7 @@
 import { FilterSet } from "@gff/core";
 
 export type SampleData = {
-  "case.case_id"?: string;
+  "cases.case_id"?: string;
 };
 
 export interface SelectSamplesCallBackArg {
@@ -11,16 +11,22 @@ export interface SelectSamplesCallBackArg {
 
 export type SelectSamplesCallback = (samples: SelectSamplesCallBackArg) => void;
 
+export type attrMapping = {
+  from: string;
+  to?: string;
+  convert?: boolean;
+};
+
 export interface SelectSamples {
   buttonText: string;
-  attributes: string[];
+  attributes: attrMapping[];
   callback?: SelectSamplesCallback;
 }
 
 export function getFilters(arg: SelectSamplesCallBackArg): FilterSet {
   const { samples } = arg;
   // see comments below about SV-2228
-  const ids = samples.map((d) => d["case.case_id"]).filter((d) => d && true);
+  const ids = samples.map((d) => d["cases.case_id"]).filter((d) => d && true);
   return {
     mode: "and",
     root: {


### PR DESCRIPTION
## Description

The update to proteinpaint-client@2.19.2 fixes the cohort creation issues in the PP SSM and OncoMatrix tools.

Related release notes:
### 2.19.2

Fixes
- Use import() instead of require() for dynamic import, so that rollup can bundle properly
 
### 2.19.1

Enhancements
- Display sample counts in matrix sample group labels, mouseovers, and legend.
- Option to toggle a matrix sample group visibility by clicking on the corresponding legend item

Fixes
- Cohort creation in the matrix plot, where sample atttribute mapping is required.
- Allow continuous variables to be added to GDC matrix without breaking. Next will support query of graphql API to retrieve min/max of the variables.
- Sort matrix samples by gene variant hits before grouping, then sort again within each group
- Reenable selecting samples from lollipop view for cohort creation. On the fly aliquote-to-case.case_id conversion is performed on
selected samples, allowing to create GDC cohort; next the conversion will be supported by caching to allow to work with large number of samples.

### 2.19.0

- Fusion event labels in disco plot are prioritized and displayed with a tooltip
- Various minor disco plot bug fixes
- Improved matrix sample sorting options and labels
- Option to truncate matrix labels for columns and rows
- Improved readme detection, sorting, and error handling
- Started type definitions for termwrapper and termsetting-related code
- Prototyped a custom profile barchart

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
