### PR TITLE
PEAR-1361 adjusts Cohort Comparison headers to disambiguate "%"

### DIFF
--- a/packages/portal-proto/src/features/cohortComparison/FacetCard.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/FacetCard.tsx
@@ -215,11 +215,15 @@ export const FacetCard: React.FC<FacetCardProps> = ({
             <th>
               # Cases S<sub>1</sub>
             </th>
-            <th>%</th>
+            <th>
+              % Cases S<sub>1</sub>
+            </th>
             <th>
               # Cases S<sub>2</sub>
             </th>
-            <th>%</th>
+            <th>
+              % Cases S<sub>2</sub>
+            </th>
           </tr>
         </thead>
         <tbody className="font-content text-sm text-semibold">

--- a/packages/portal-proto/src/features/cohortComparison/SurvivalCard.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/SurvivalCard.tsx
@@ -175,11 +175,15 @@ const SurvivalCard: React.FC<SurvivalCardProps> = ({
                   <th>
                     # Cases S<sub>1</sub>
                   </th>
-                  <th>%</th>
+                  <th>
+                    % Cases S<sub>1</sub>
+                  </th>
                   <th>
                     # Cases S<sub>2</sub>
                   </th>
-                  <th>%</th>
+                  <th>
+                    % Cases S<sub>2</sub>
+                  </th>
                 </tr>
               </thead>
               <tbody className="font-content text-md">


### PR DESCRIPTION
## Description
Changed the Cohort Comparison "%" headers to "% Cases S1" / "% Cases S2".

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="861" alt="Screenshot 2023-07-25 at 4 32 12 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/fa1e6f21-e012-4965-ac0a-ab55318bde4a">
