### PR TITLE
update the proteinpaint-client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.19.2.tgz",
-      "integrity": "sha512-Gqu+CDwkVykknb2WqFIE9zRGawApp3rYKqd1I5NwCP08Ka11GcHZZDo+4Eu6pHgz2F1IncKzEtM4uImwE/f8Og=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.24.0.tgz",
+      "integrity": "sha512-AMxmiIVKTtKbAoYI5/pMQwegz6aI4zh0X2JL3tiiZP7tuK8rLnx63VlPn7Df6nIQiUR5VbVPrOLzaMsL+mW0PA=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26485,7 +26485,7 @@
         "@mantine/notifications": "^5.10.5",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.19.2",
+        "@sjcrh/proteinpaint-client": "^2.24.0",
         "filesize": "^8.0.7",
         "html-to-image": "^1.11.4",
         "minisearch": "^3.0.4",
@@ -31595,9 +31595,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.19.2.tgz",
-      "integrity": "sha512-Gqu+CDwkVykknb2WqFIE9zRGawApp3rYKqd1I5NwCP08Ka11GcHZZDo+4Eu6pHgz2F1IncKzEtM4uImwE/f8Og=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.24.0.tgz",
+      "integrity": "sha512-AMxmiIVKTtKbAoYI5/pMQwegz6aI4zh0X2JL3tiiZP7tuK8rLnx63VlPn7Df6nIQiUR5VbVPrOLzaMsL+mW0PA=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41073,7 +41073,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.19.2",
+        "@sjcrh/proteinpaint-client": "^2.24.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -26,7 +26,7 @@
     "@mantine/notifications": "^5.10.5",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.19.2",
+    "@sjcrh/proteinpaint-client": "^2.24.0",
     "filesize": "^8.0.7",
     "html-to-image": "^1.11.4",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Updated to sjcrh/proteinpaint-client@^2.24.0. Changes related to GDC:

Features
- Make disco plot rings width configurable
- OncoMatrix `Restore` button: support a reset button option for the rx recover component

Fixes:
- Selecting hundreds of samples from GDC lollipop no longer hangs or crashes (using a cached mapping to case uuid)
- Fix the numeric edit menu when violin plot data is requested for a GDC variable, which needs currentGeneNames
- Bug fix to show reduced sample summaries when creating sub-track from GDC lollipop (mds3) track
- Correctly handle special uncomputable numeric term values in a matrix row bar plot, when mode='continuous' 
- GDC OncoMatrix has switched to use case uuid but not case submitter id to align data, while still displaying submitter ids on UI; the latter is not unique between projects.

## Checklist

- [x] Added proper unit tests (in PP code)
- [x] Left proper TODO messages for any remaining tasks (in PP code)
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
