### PR TITLE
PEAR 1405 fix impact tooltips

### DIFF
--- a/packages/portal-proto/src/components/expandableTables/somaticMutations/smTableCells.tsx
+++ b/packages/portal-proto/src/components/expandableTables/somaticMutations/smTableCells.tsx
@@ -85,7 +85,7 @@ export const Impacts = ({ impact }: { impact: Impact }): JSX.Element => {
   const generateSiftTooltipLabel = () => {
     const label = [];
 
-    if (siftImpact !== null) {
+    if (siftImpact) {
       label.push(`SIFT Impact: ${siftImpact}`);
     }
 
@@ -100,7 +100,7 @@ export const Impacts = ({ impact }: { impact: Impact }): JSX.Element => {
   const generatePolyphenTooltipLabel = () => {
     const label = [];
 
-    if (polyphenImpact !== null) {
+    if (polyphenImpact) {
       label.push(`PolyPhen Impact: ${polyphenImpact}`);
     }
 


### PR DESCRIPTION
## Description
Fixed issue where SIFT score of 0 caused tooltip not to be displayed. Adjusted logic to account for possibility of SIFT and PolyPhen having impacts, but no scores.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

<img width="582" alt="Screenshot 2023-08-02 at 8 22 44 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/f6522a54-bb84-490b-a258-6c1d8eebf0fb">
