### PR TITLE
label close modal button QA-2008

### DIFF
--- a/packages/portal-proto/src/components/Modals/SummaryModal/SummaryModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SummaryModal/SummaryModal.tsx
@@ -78,6 +78,7 @@ export const SummaryModal = ({
       }}
       padding={0}
       overlayOpacity={0.5}
+      closeButtonLabel="button-close-modal"
     >
       {SummaryPage}
     </Modal>


### PR DESCRIPTION
## Description
- Added an aria-label for the close modal button

Pari says that the current version of the library used for the button does not support data-testid. So I made an aria-label in the same format as our IDs. 
