### PR TITLE
PEAR-1462: Fix for runtime error in SM Table

### DIFF
--- a/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
@@ -360,7 +360,7 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
     <>
       {caseFilter && searchTerm.length === 0 && data?.ssmsTotal === 0 ? null : (
         <>
-          {searchTermsForGene.geneSymbol && (
+          {searchTermsForGene?.geneSymbol && (
             <div id="announce" aria-live="polite">
               <p>
                 You are now viewing the Mutations table filtered by{" "}


### PR DESCRIPTION
## Description
`searchTermsForGene` is undefined.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
