### PR TITLE
PEAR-1469: add clearCohort to listener to invoke recompute caseCount

### DIFF
--- a/packages/core/src/listeners.ts
+++ b/packages/core/src/listeners.ts
@@ -15,6 +15,7 @@ import {
   addNewCohort,
   createCaseSetsIfNeeded,
   createCaseSet,
+  clearCohortFilters,
 } from "./features/cohort/availableCohortsSlice";
 import { fetchCohortCaseCounts } from "./features/cohort/cohortCountsQuery";
 import { resetSelectedCases } from "./features/cases/selectedCasesSlice";
@@ -44,7 +45,7 @@ startCoreListening({
 });
 
 startCoreListening({
-  matcher: isAnyOf(updateCohortFilter, removeCohortFilter),
+  matcher: isAnyOf(updateCohortFilter, removeCohortFilter, clearCohortFilters),
   effect: async (_, listenerApi) => {
     listenerApi.dispatch(fetchCohortCaseCounts());
   },


### PR DESCRIPTION
## Description
Fixes a bug introduced in PEAR-1356; the counts are not updated when the cohort is Cleared.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
