### PR TITLE
PEAR-1471: Fix for Mutation Frequency - Clicking create cohort with "# CNV Loss" ends with filter "CNV CHANGE = GAIN"

### DIFF
--- a/packages/portal-proto/src/features/GenomicTables/GenesTable/utils.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/GenesTable/utils.tsx
@@ -290,7 +290,7 @@ export const useGenerateGenesTableColumns = ({
               }
               numCases={numerator}
               handleClick={() => {
-                setColumnType("cnvgain");
+                setColumnType("cnvloss");
                 setGeneID(row.original.gene_id);
                 setShowCreateCohort(true);
               }}


### PR DESCRIPTION
## Description
There was a typo. `cnvgain` should have been `cnvloss`.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1433" alt="Screenshot 2023-08-29 at 11 14 45 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/980c039e-519d-4f5c-8012-c24a275c64fd">
