### PR TITLE
PEAR-1472: change docker base image to node 16.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:16-alpine3.15 as dep
+FROM node:16.20.2-alpine3.17 as dep
 WORKDIR /app
 
 #==================================================================
 
 # ==================================================================
-FROM node:16-alpine3.15 AS builder
+FROM node:16.20.2-alpine3.17 AS builder
 ARG NPM_REGISTRY="https://registry.npmjs.org/"
 
 ARG BUILD_SHORT_SHA
@@ -27,7 +27,7 @@ RUN lerna run --scope @nci-gdc/sapien build
 RUN lerna run --scope portal-proto build
 # ==================================================================
 
-FROM node:16-alpine3.15 AS runner
+FROM node:16.20.2-alpine3.17 AS runner
 WORKDIR /app
 ENV NODE_ENV=production \
     PORT=3000


### PR DESCRIPTION
## Description
Resolves Synk High issues in Dockerfile by using recommended versions for alpine/node (node:16.20.2-alpine3.17). 
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
