### PR TITLE
PEAR-1473: Fix for search input trim for table

### DIFF
--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -126,7 +126,7 @@ function VerticalTable<TData>({
   };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const newSearchTerm = e.target.value.trim();
+    const newSearchTerm = e.target.value;
     setSearchTerm(newSearchTerm);
 
     // Clear the previous timeout
@@ -134,7 +134,7 @@ function VerticalTable<TData>({
 
     // Set a new timeout to perform the search after 400ms
     timeoutRef.current = setTimeout(() => {
-      handleChange({ newSearch: newSearchTerm });
+      handleChange({ newSearch: newSearchTerm.trim() });
     }, 400);
   };
 

--- a/packages/portal-proto/src/features/GenomicTables/GenesTable/GTableContainer.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/GenesTable/GTableContainer.tsx
@@ -89,7 +89,7 @@ export const GTableContainer: React.FC<GTableContainerProps> = ({
   const { data, isSuccess, isFetching, isError } = useGenesTable({
     pageSize: pageSize,
     offset: (page - 1) * pageSize,
-    searchTerm: searchTerm.length > 0 ? searchTerm.trim() : undefined,
+    searchTerm: searchTerm.length > 0 ? searchTerm : undefined,
     genomicFilters: genomicFilters,
     cohortFilters: cohortFilters,
   });

--- a/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
@@ -129,7 +129,7 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
   const { data, isSuccess, isFetching, isError } = useGetSssmTableDataQuery({
     pageSize: pageSize,
     offset: pageSize * (page - 1),
-    searchTerm: searchTerm.length > 0 ? searchTerm.trim() : undefined,
+    searchTerm: searchTerm.length > 0 ? searchTerm : undefined,
     geneSymbol: geneSymbol,
     genomicFilters: genomicFilters,
     cohortFilters: cohortFilters,


### PR DESCRIPTION
## Description
Solution: Trim the result being sent to the search and not the value in the search box.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot 2023-08-29 at 12 08 20 PM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/3802acff-12b2-421e-9df8-40b97a38510d)
