### PR TITLE
update the proteinpaint-client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.25.0.tgz",
-      "integrity": "sha512-H1eHJM84yeShjw+6274f33bFDayqGS/0TL+muJS/CZCf5I/QiKLOMMAETXdfZ03gKhcnbzb3iu5EEbmUcNrsAw=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.26.1.tgz",
+      "integrity": "sha512-MpFqbl5O4dCX8Z862vD0LdyrVcYPDF0eRU2C2kge79qd7cIHcvUCC+K8pennx0hsfguJkchq3jrTXYpWW5SAlQ=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26507,7 +26507,7 @@
         "@mantine/notifications": "^5.10.5",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.25.0",
+        "@sjcrh/proteinpaint-client": "^2.26.1",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "html-to-image": "^1.11.4",
@@ -31618,9 +31618,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.25.0.tgz",
-      "integrity": "sha512-H1eHJM84yeShjw+6274f33bFDayqGS/0TL+muJS/CZCf5I/QiKLOMMAETXdfZ03gKhcnbzb3iu5EEbmUcNrsAw=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.26.1.tgz",
+      "integrity": "sha512-MpFqbl5O4dCX8Z862vD0LdyrVcYPDF0eRU2C2kge79qd7cIHcvUCC+K8pennx0hsfguJkchq3jrTXYpWW5SAlQ=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41100,7 +41100,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.25.0",
+        "@sjcrh/proteinpaint-client": "^2.26.1",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -27,7 +27,7 @@
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
     "@tanstack/react-table": "^8.9.3",
-    "@sjcrh/proteinpaint-client": "^2.25.0",
+    "@sjcrh/proteinpaint-client": "^2.26.1",
     "filesize": "^8.0.7",
     "html-to-image": "^1.11.4",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

GDC-related changelog

Features:
- For hg38-based datasets, Disco plot may prioritize gene labels by Cancer Gene Census genes.
- Numeric termsetting edit UI shows density curve at mode=continuous.
- Update gene filter to restrict filtering for multiple alteration groups.
- Mds3 numeric axis (e.g. occurrence) y scale can be edited.
- GDC "Age at diagnosis" value by day is shown as "X years, Y days" in mds3 sample table.
- Prototype a hierarchical cluster plot using the matrix plot
- Display sample and catergory numbers in each subgroup when hovering over term label in matrix plot

Fixes:
- Do not force a matrix barplot min scale to 0;
- Fix the missing tooltip when mousing over second+ continuous matrix barplot rows
- For matrix plot, when the "Group Samples By" variable has a predefined order, use that order for subgroups. 
- Fix the sessionid handling to allow more OncoMatrix data to be shown for a signed-in user.
- For SSM from GDC API, use consequence from canonical transcript designated by GDC.
- GDC SSM range query by graphql appropriately accounts for sample filtering from a subtrack.
- In GDC bam slicing block display, clicking on a transcript from native gene tk will disable the "View in protein" option.
- Improve the hierarchical clustering R script to include the scaling step.
- Add CNV information to label tooltips in disco plot

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
