### PR TITLE
PEAR-1480C: case counts spin after deleting last cohort

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -162,7 +162,7 @@ const CohortManager: React.FC = () => {
     coreDispatch(removeCohort({ shouldShowMessage: true }));
     if (lastCohort) {
       // deleted the last cohort., so a new one is created and requires needs counts
-      coreDispatch(fetchCohortCaseCounts());
+      coreDispatch(fetchCohortCaseCounts(undefined));
     }
   };
 


### PR DESCRIPTION
## Description
Fixes case counts spinning where the last cohort deleted requires caseCounts to be fetched for the new cohort
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
