### PR TITLE
PEAR-1491: update match redos remediation

### DIFF
--- a/packages/portal-proto/src/features/biospecimen/Biospecimen.tsx
+++ b/packages/portal-proto/src/features/biospecimen/Biospecimen.tsx
@@ -10,7 +10,7 @@ import {
   selectCart,
 } from "@gff/core";
 import { HorizontalTable } from "@/components/HorizontalTable";
-import { formatEntityInfo, search } from "./utils";
+import { formatEntityInfo, searchForStringInNode } from "./utils";
 import { trimEnd, find, flatten, escapeRegExp } from "lodash";
 import { useRouter } from "next/router";
 import { entityTypes, overrideMessage } from "@/components/BioTree/types";
@@ -67,7 +67,7 @@ export const Biospecimen = ({
     ) {
       const escapedSearchText = escapeRegExp(searchText);
       const founds = bioSpecimenData?.samples?.hits?.edges.map((e) => {
-        return search(escapedSearchText, e);
+        return searchForStringInNode(escapedSearchText, e);
       });
       const flattened = flatten(founds);
       const foundNode = flattened[0]?.node;
@@ -275,7 +275,7 @@ export const Biospecimen = ({
                     setTotalNodeCount={setTotalNodeCount}
                     setExpandedCount={setExpandedCount}
                     query={searchText.toLocaleLowerCase().trim()}
-                    search={search}
+                    search={searchForStringInNode}
                   />
                 )}
             </div>

--- a/packages/portal-proto/src/features/biospecimen/utils.tsx
+++ b/packages/portal-proto/src/features/biospecimen/utils.tsx
@@ -28,7 +28,7 @@ export const match = (query: string, entity: Record<string, any>): boolean =>
     );
   });
 
-export const search = (
+export const searchForStringInNode = (
   query: string,
   entity: { node: Record<string, any> },
 ): any[] => {


### PR DESCRIPTION
## Description
synk still flagging the use of match in Biospecimen as a High Vulnerability. This should resolve the issue.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
