### PR TITLE
(PEAR-1458): Add download icons for Clinical and Biospecimen buttons in Cohort Bar

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -333,8 +333,16 @@ const ContextBar = ({
               <>
                 <DropdownWithIcon
                   dropdownElements={[
-                    { title: "JSON ", onClick: handleBiospeciemenJSONDownload },
-                    { title: "TSV", onClick: handleBiospeciemenTSVDownload },
+                    {
+                      title: "JSON ",
+                      onClick: handleBiospeciemenJSONDownload,
+                      icon: <DownloadIcon aria-label="Download" />,
+                    },
+                    {
+                      title: "TSV",
+                      onClick: handleBiospeciemenTSVDownload,
+                      icon: <DownloadIcon aria-label="Download" />,
+                    },
                   ]}
                   TargetButtonChildren={
                     biospecimenDownloadActive ? "Processing" : "Biospecimen"
@@ -353,8 +361,16 @@ const ContextBar = ({
 
                 <DropdownWithIcon
                   dropdownElements={[
-                    { title: "JSON", onClick: handleClinicalJSONDownload },
-                    { title: "TSV", onClick: handleClinicalTSVDownload },
+                    {
+                      title: "JSON",
+                      onClick: handleClinicalJSONDownload,
+                      icon: <DownloadIcon aria-label="Download" />,
+                    },
+                    {
+                      title: "TSV",
+                      onClick: handleClinicalTSVDownload,
+                      icon: <DownloadIcon aria-label="Download" />,
+                    },
                   ]}
                   TargetButtonChildren={
                     clinicalDownloadActive ? "Processing" : "Clinical"


### PR DESCRIPTION
## Description
- Add download icons for Clinical and Biospecimen buttons in Cohort Bar
- Also add the download icon to the left of the TSV and JSON labels in the dropdown
## Checklist

- [ ] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot from 2023-09-14 10-37-28](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1020732/846d58b7-99e3-4676-bf9d-8425f5af30a9)
