### PR TITLE
(PEAR-1232): Add Manage Sets link from Set Operations to Manage Sets.

### DIFF
--- a/packages/portal-proto/src/features/set-operations/SelectionPanel.tsx
+++ b/packages/portal-proto/src/features/set-operations/SelectionPanel.tsx
@@ -392,12 +392,14 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
           the same type.
         </p>
         <p className="pb-2 font-content">
-          Create cohorts in the Analysis Center. Create gene/mutation sets in
-          Manage Sets or in analysis tools (e.g.{" "}
-          <Link
-            className="text-utility-link"
-            href="/analysis_page?app=MutationFrequencyApp"
-          >
+          Create cohorts in the Analysis Center. Create gene/mutation sets in{" "}
+          <Link href="/manage-sets">
+            <a className="text-utility-link font-content underline">
+              Manage Sets
+            </a>
+          </Link>{" "}
+          or in analysis tools (e.g.{" "}
+          <Link href="/analysis_page?app=MutationFrequencyApp">
             <a className="text-utility-link font-content underline">
               Mutation Frequency
             </a>


### PR DESCRIPTION
## Description
- Add Manage Sets link from Set Operations to Manage Sets.
## Checklist

- [ ] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot from 2023-09-14 12-05-11](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1020732/b36b15fc-4075-40f9-81a9-54bf1b562915)
