### PR TITLE
PEAR-1517 adjusts custom filters text

### DIFF
--- a/packages/portal-proto/src/components/FacetSelection.tsx
+++ b/packages/portal-proto/src/components/FacetSelection.tsx
@@ -101,7 +101,6 @@ const FacetSelectionPanel = ({
   title,
   handleFilterSelected,
   handleFilteredWithValuesChanged,
-  facetType,
 }: FacetSelectionProps) => {
   const [searchString, setSearchString] = useState("");
   const [filteredData, setFilteredData] = useState(undefined);
@@ -125,13 +124,11 @@ const FacetSelectionPanel = ({
     }
   }, [facets, searchString]);
 
-  const facetTypeTrimmed = facetType.slice(0, -1);
-
   return (
     <div className="flex flex-col" data-testid="section-file-filter-search">
       <Title order={3}>{title}</Title>
       <TextInput
-        label={`Search for a ${facetTypeTrimmed} property`}
+        label="Search for a property"
         placeholder="search"
         value={searchString}
         rightSection={
@@ -145,12 +142,11 @@ const FacetSelectionPanel = ({
           ) : null
         }
         onChange={(evt) => setSearchString(evt.target.value)}
-        aria-label={`Search for a ${facetTypeTrimmed} property`}
+        aria-label="Search for a property"
       />
       <Group position="apart">
         <p>
-          {filteredData ? Object.values(filteredData).length : ""}{" "}
-          {facetTypeTrimmed} properties
+          {filteredData ? Object.values(filteredData).length : ""} properties
         </p>
         <Checkbox
           label="Only show properties with values"

--- a/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
@@ -194,7 +194,7 @@ const CustomFacetGroup = (): JSX.Element => {
         zIndex={400}
       >
         <FacetSelection
-          title={"Add a Case Filter"}
+          title="Add a Custom Filter"
           facetType="cases"
           handleFilterSelected={handleFilterSelected}
           usedFacets={cohortBuilderFilters}

--- a/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
@@ -126,7 +126,7 @@ export const FileFacetPanel = (): JSX.Element => {
       </Group>
       <Button
         variant="outline"
-        aria-label="Add a file filter"
+        aria-label="Add a custom filter"
         data-testid="button-add-a-file-filter"
         className="mx-1 bg-primary-lightest flex flex-row justify-center align-middle items-center border-primary-darker b-2"
         onClick={() => setOpened(true)}
@@ -134,7 +134,7 @@ export const FileFacetPanel = (): JSX.Element => {
         <AddAdditionalIcon className="text-primary-content" size="2em" />
         <Text size="md" weight={700} className="text-primary-content-darker">
           {" "}
-          Add a File Filter
+          Add a Custom Filter
         </Text>
       </Button>
       <div className="flex flex-col gap-y-4" data-testid="filters-facets">
@@ -146,7 +146,7 @@ export const FileFacetPanel = (): JSX.Element => {
           zIndex={400}
         >
           <FacetSelection
-            title={"Add a File Filter"}
+            title="Add a Custom Filter"
             facetType="files"
             handleFilterSelected={handleFilterSelected}
             usedFacets={config.facets}


### PR DESCRIPTION
## Description
Basically adjusts text for custom filters so that mentions of "file" or "case" are removed or replaced by "custom"

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

<img width="684" alt="Screenshot 2023-09-20 at 1 48 35 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/969901fe-8c3d-410d-87f8-ac9de38d8771">
<img width="653" alt="Screenshot 2023-09-20 at 1 48 25 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/d014cc13-5f5b-47cd-8ca7-afd78dddc53e">
<img width="496" alt="Screenshot 2023-09-20 at 1 48 17 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/77fe092e-0a02-4a70-b1ed-a6e9bf2ad576">

