### PR TITLE
PEAR-1479: MF app crash on cohort with no genes/ssms

### DIFF
--- a/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
+++ b/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
@@ -180,7 +180,13 @@ const GenesAndMutationFrequencyAnalysisTool: React.FC = () => {
    *  which will update the survival plot
    */
   useEffect(() => {
-    if (topGeneSSMSSuccess && comparativeSurvival === undefined) {
+    // if we have a top gene and no comparative survival set, and there is a gene or ssm symbol
+    // set the comparative survival to the top gene
+    if (
+      topGeneSSMSSuccess &&
+      comparativeSurvival === undefined &&
+      topGeneSSMS[0][appMode].symbol
+    ) {
       setComparativeSurvival({
         symbol: topGeneSSMS[0][appMode].symbol,
         name:


### PR DESCRIPTION
## Description
Fixes the app crash when the cohort changes to one with no genes/mutations. In general the MF code handles cohorts with 0 genes/ssms well, except for the comparative survival plot.  This PR adds a guard to prevent the execution of the comparative survival plot code. 
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
