### PR TITLE
Pear 1528 add download icons

### DIFF
--- a/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
@@ -408,7 +408,7 @@ export const ContextualCasesView: React.FC = () => {
                     {pickedCases.length}
                   </CountsIcon>
                 ) : (
-                  <DownloadIcon size="1rem" aria-label="Biospecimen dropdown" />
+                  <DownloadIcon size="1rem" aria-label="Clinical dropdown" />
                 )
               }
             />


### PR DESCRIPTION
## Description
Adds download icons to the Clinical and Biospecimen button.
Main download icons are displayed by default, but will be replaced by spinner if the download is processing and replaced by counts tag if there are items selected in the table.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="738" alt="Screenshot 2023-09-26 at 11 13 26 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/25139d82-cecf-4865-ace7-5ac13eebe238">
<img width="808" alt="Screenshot 2023-09-26 at 11 13 29 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/fef07ced-34a5-498a-8c5e-3548508a5075">
<img width="788" alt="Screenshot 2023-09-26 at 11 13 44 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/b2b44eb7-2afa-4356-a9a6-5c01f529aede">
<img width="244" alt="Screenshot 2023-09-26 at 11 14 51 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/aa29b1c2-32a7-4aa6-beab-2d59b1097f0f">
