### PR TITLE
PEAR-1542: Fix for re-render on cohort builder facet tab

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
@@ -281,6 +281,8 @@ export const FacetTabs = (): JSX.Element => {
     isEqual,
   );
   const router = useRouter();
+  const routerTab = router?.query?.tab;
+  const prevRouterTab = usePrevious(routerTab);
   const facets =
     useCoreSelector((state) => selectFacetDefinition(state)).data || {};
   const [activeTab, setActiveTab] = useState(
@@ -290,24 +292,21 @@ export const FacetTabs = (): JSX.Element => {
   );
 
   useEffect(() => {
-    if (
-      router !== null &&
-      activeTab !== undefined &&
-      activeTab !== router?.query?.tab
-    ) {
+    if (router !== null && activeTab !== undefined && activeTab !== routerTab) {
       router.push({ query: { ...Router.query, tab: activeTab } }, undefined, {
         scroll: false,
       });
     }
     // https://github.com/vercel/next.js/discussions/29403#discussioncomment-1908563
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab]);
+  }, [activeTab, routerTab]);
 
+  // This can change from SearchInput component
   useEffect(() => {
-    if (router?.query?.tab && activeTab !== router.query.tab) {
-      setActiveTab(router.query.tab as string);
+    if (routerTab !== prevRouterTab) {
+      setActiveTab(routerTab as string);
     }
-  }, [router?.query?.tab, activeTab, setActiveTab]);
+  }, [routerTab, prevRouterTab, setActiveTab]);
 
   return (
     <div className="w-100 mt-2">


### PR DESCRIPTION
## Description
Fixes the re-render issue of cohort builder facet tabs on change.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
