### PR TITLE
PEAR-1526: Fix for Matched/Unmatched number tags becoming too wide; number selected tags too narrow

### DIFF
--- a/packages/portal-proto/src/components/StyledComponents/Tabs.tsx
+++ b/packages/portal-proto/src/components/StyledComponents/Tabs.tsx
@@ -8,8 +8,8 @@ data-[active]:font-bold
 data-[active]:border-4
 data-[active]:border-accent
 data-[active]:text-base-content-darkest
-[&_div]:flex
-[&_div]:items-center
+[&_span]:flex
+[&_span]:items-center
 `;
 
 export const StyledTabsList = tw(Tabs.List)`

--- a/packages/portal-proto/src/components/tailwindComponents.ts
+++ b/packages/portal-proto/src/components/tailwindComponents.ts
@@ -68,7 +68,7 @@ export const CountsIcon = tw.div<CountsIconProps>`
   text-accent-contrast
   font-heading
   rounded-md
-  p-1
+  p-2
   `;
 
 export const DemoText = tw.span`

--- a/packages/portal-proto/src/features/user-flow/workflow/navigation-utils.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/navigation-utils.tsx
@@ -25,28 +25,30 @@ export const headerElements = [
     multiline
     width={220}
   >
-    <Link
-      href={{
-        pathname: "/analysis_page",
-        query: { app: undefined },
-      }}
-      className="cursor-pointer"
-      passHref
-    >
-      <NavLink
-        data-testid="button-header-analysis"
-        aria-label="analysis center button"
+    <span>
+      <Link
+        href={{
+          pathname: "/analysis_page",
+          query: { app: undefined },
+        }}
+        className="cursor-pointer"
+        passHref
       >
-        <AnalysisCenterIcon
-          aria-label="Analysis logo"
-          width={24}
-          height={24}
-          viewBox="0 0 500 500"
-          role="img"
-        />
-        Analysis Center
-      </NavLink>
-    </Link>
+        <NavLink
+          data-testid="button-header-analysis"
+          aria-label="analysis center button"
+        >
+          <AnalysisCenterIcon
+            aria-label="Analysis logo"
+            width={24}
+            height={24}
+            viewBox="0 0 500 500"
+            role="img"
+          />
+          Analysis Center
+        </NavLink>
+      </Link>
+    </span>
   </Tooltip>,
   <Tooltip
     key="Studies"
@@ -55,28 +57,30 @@ export const headerElements = [
     multiline
     width={220}
   >
-    <Link
-      href={{
-        pathname: "/analysis_page",
-        query: { app: "Projects" },
-      }}
-      className="cursor-pointer"
-      passHref
-    >
-      <NavLink
-        data-testid="button-header-projects"
-        aria-label="project/studies center button"
+    <span>
+      <Link
+        href={{
+          pathname: "/analysis_page",
+          query: { app: "Projects" },
+        }}
+        className="cursor-pointer"
+        passHref
       >
-        <ProjectsIcon
-          aria-label="Studies logo"
-          width={24}
-          height={24}
-          viewBox="0 -15 100 100"
-          role="img"
-        />
-        Projects
-      </NavLink>
-    </Link>
+        <NavLink
+          data-testid="button-header-projects"
+          aria-label="project/studies center button"
+        >
+          <ProjectsIcon
+            aria-label="Studies logo"
+            width={24}
+            height={24}
+            viewBox="0 -15 100 100"
+            role="img"
+          />
+          Projects
+        </NavLink>
+      </Link>
+    </span>
   </Tooltip>,
   <Tooltip
     key="Cohort"
@@ -85,28 +89,30 @@ export const headerElements = [
     multiline
     width={220}
   >
-    <Link
-      href={{
-        pathname: "/analysis_page",
-        query: { app: "CohortBuilder" },
-      }}
-      className="cursor-pointer"
-      passHref
-    >
-      <NavLink
-        data-testid="button-header-cohort"
-        aria-label="cohort builder button"
+    <span>
+      <Link
+        href={{
+          pathname: "/analysis_page",
+          query: { app: "CohortBuilder" },
+        }}
+        className="cursor-pointer"
+        passHref
       >
-        <CohortBuilderIcon
-          aria-label="Cohort logo"
-          width={24}
-          height={24}
-          viewBox="0 0 50 50"
-          role="img"
-        />
-        Cohort Builder
-      </NavLink>
-    </Link>
+        <NavLink
+          data-testid="button-header-cohort"
+          aria-label="cohort builder button"
+        >
+          <CohortBuilderIcon
+            aria-label="Cohort logo"
+            width={24}
+            height={24}
+            viewBox="0 0 50 50"
+            role="img"
+          />
+          Cohort Builder
+        </NavLink>
+      </Link>
+    </span>
   </Tooltip>,
   <Tooltip
     key="Download"
@@ -115,27 +121,29 @@ export const headerElements = [
     multiline
     width={220}
   >
-    <Link
-      href={{
-        pathname: "/analysis_page",
-        query: { app: "Downloads" },
-      }}
-      className="cursor-pointer"
-      passHref
-    >
-      <NavLink
-        data-testid="button-header-downloads"
-        aria-label="download center button"
+    <span>
+      <Link
+        href={{
+          pathname: "/analysis_page",
+          query: { app: "Downloads" },
+        }}
+        className="cursor-pointer"
+        passHref
       >
-        <DownloadIcon
-          aria-label="Downloads logo"
-          width={24}
-          height={24}
-          viewBox="0 0 50 50"
-          role="img"
-        />
-        Repository
-      </NavLink>
-    </Link>
+        <NavLink
+          data-testid="button-header-downloads"
+          aria-label="download center button"
+        >
+          <DownloadIcon
+            aria-label="Downloads logo"
+            width={24}
+            height={24}
+            viewBox="0 0 50 50"
+            role="img"
+          />
+          Repository
+        </NavLink>
+      </Link>
+    </span>
   </Tooltip>,
 ];


### PR DESCRIPTION
## Description
Apparently Tab was changed from `div` -> `span`.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot 2023-09-27 at 4 12 01 PM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/a6007d27-20f7-48e2-9deb-35f11625ef64)
