### PR TITLE
(PEAR-1333): allow data_type, fileType, data_category, experimental_strategy, data_format to have a looser type check

### DIFF
--- a/packages/core/src/features/cases/types.ts
+++ b/packages/core/src/features/cases/types.ts
@@ -1,5 +1,3 @@
-import { DataFormat } from "../files/filesSlice";
-
 export interface caseFileType {
   readonly access: "open" | "controlled";
   readonly acl: Array<string>;
@@ -9,7 +7,7 @@ export interface caseFileType {
   readonly file_size: number;
   readonly state: string;
   readonly project_id: string;
-  readonly data_format: DataFormat;
+  readonly data_format: string;
   readonly created_datetime: string;
   readonly submitter_id: string;
   readonly updated_datetime: string;

--- a/packages/core/src/features/files/filesSlice.ts
+++ b/packages/core/src/features/files/filesSlice.ts
@@ -25,53 +25,12 @@ const asAccessType = (x: unknown): AccessType => {
   }
 };
 
-const dataFormats = [
-  "TXT",
-  "VCF",
-  "BAM",
-  "MAF",
-  "SVS",
-  "IDAT",
-  "BCR XML",
-  "TSV",
-  "BCR SSF XML",
-  "BEDPE",
-  "BCR AUXILIARY XML",
-  "BCR Auxiliary XML",
-  "BCR OMF XML",
-  "BCR BIOTAB",
-  "BCR Biotab",
-  "BCR PPS XML",
-  "CDC JSON",
-  "XLSX",
-  "MEX",
-  "HDF5",
-  "PDF",
-  "BAI",
-  "TBI",
-  "CEL",
-] as const;
-
-export type DataFormat = typeof dataFormats[number];
-
-const isDataFormat = (x: unknown): x is DataFormat => {
-  return dataFormats.some((t) => t === x);
-};
-
-const asDataFormat = (x: unknown): DataFormat => {
-  if (isDataFormat(x)) {
-    return x;
-  } else {
-    throw new Error(`${x} is not a valid data format`);
-  }
-};
-
 // TODO use CartFile instead and combine anything that submits to cart
 export interface GdcCartFile {
   readonly file_name: string;
   readonly data_category: string;
   readonly data_type: string;
-  readonly data_format: DataFormat;
+  readonly data_format: string;
   readonly state: string;
   readonly file_size: number;
   readonly file_id: string;
@@ -157,7 +116,7 @@ export interface GdcFile {
   readonly createdDatetime: string;
   readonly updatedDatetime: string;
   readonly data_category: string;
-  readonly data_format: DataFormat;
+  readonly data_format: string;
   readonly dataRelease?: string;
   readonly data_type: string;
   readonly file_id: string;
@@ -202,7 +161,7 @@ export interface GdcFile {
     readonly createdDatetime: string;
     readonly updatedDatetime: string;
     readonly data_category: string;
-    readonly data_format: DataFormat;
+    readonly data_format: string;
     readonly data_type: string;
     readonly file_id: string;
     readonly file_name: string;
@@ -221,7 +180,7 @@ export const mapFileData = (files: ReadonlyArray<FileDefaults>): GdcFile[] => {
     createdDatetime: hit.created_datetime,
     updatedDatetime: hit.updated_datetime,
     data_category: hit.data_category,
-    data_format: asDataFormat(hit.data_format),
+    data_format: hit.data_format,
     dataRelease: hit.data_release,
     data_type: hit.data_type,
     file_id: hit.file_id,
@@ -326,7 +285,7 @@ export const mapFileData = (files: ReadonlyArray<FileDefaults>): GdcFile[] => {
               file_name: file.file_name,
               data_category: file.data_category,
               data_type: file.data_type,
-              data_format: asDataFormat(file.data_format),
+              data_format: file.data_format,
               file_size: file.file_size,
               file_id: file.file_id,
               acl: hit.acl,
@@ -363,7 +322,7 @@ export const mapFileData = (files: ReadonlyArray<FileDefaults>): GdcFile[] => {
             file_name: file.file_name,
             data_category: file.data_category,
             data_type: file.data_type,
-            data_format: asDataFormat(file.data_format),
+            data_format: file.data_format,
             file_size: file.file_size,
             file_id: file.file_id,
             acl: hit.acl,
@@ -383,7 +342,7 @@ export const mapFileData = (files: ReadonlyArray<FileDefaults>): GdcFile[] => {
       createdDatetime: idx.created_datetime,
       updatedDatetime: idx.updated_datetime,
       data_category: idx.data_category,
-      data_format: asDataFormat(idx.data_format),
+      data_format: idx.data_format,
       data_type: idx.data_type,
       file_id: idx.file_id,
       file_name: idx.file_name,

--- a/packages/portal-proto/src/features/cases/CaseView.tsx
+++ b/packages/portal-proto/src/features/cases/CaseView.tsx
@@ -10,7 +10,6 @@ import {
   Demographic,
   caseSummaryDefaults,
   FilterSet,
-  DataFormat,
   AccessType,
 } from "@gff/core";
 import { SummaryCard } from "@/components/Summary/SummaryCard";
@@ -210,7 +209,7 @@ export const CaseView: React.FC<CaseViewProps> = ({
       access: AccessType;
       file_id: string;
       file_name: string;
-      data_format: DataFormat;
+      data_format: string;
       file_size: string;
       file: caseFileType;
     };

--- a/packages/portal-proto/src/features/files/DownstreamAnalyses.tsx
+++ b/packages/portal-proto/src/features/files/DownstreamAnalyses.tsx
@@ -1,6 +1,6 @@
 import GenericLink from "@/components/GenericLink";
 import { fileInCart } from "@/utils/index";
-import { GdcFile, DataFormat, GdcCartFile, CartFile } from "@gff/core";
+import { GdcFile, GdcCartFile, CartFile } from "@gff/core";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import fileSize from "filesize";
 import { Dispatch, SetStateAction, useMemo } from "react";
@@ -22,7 +22,7 @@ const DownstreamAnalyses = ({
     file_id: string;
     data_category: string;
     data_type: string;
-    data_format: DataFormat;
+    data_format: string;
     analysis_workflow: string;
     size: string;
     outputFile: GdcCartFile;

--- a/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
@@ -17,7 +17,6 @@ import {
   SortBy,
   AccessType,
   FileCaseType,
-  DataFormat,
   FileAnnontationsType,
 } from "@gff/core";
 import { MdSave, MdPerson } from "react-icons/md";
@@ -57,7 +56,7 @@ export type FilesTableDataType = {
   cases: FileCaseType;
   data_category: string;
   data_type: string;
-  data_format: DataFormat;
+  data_format: string;
   experimental_strategy?: string;
   platform: string;
   file_size: string;


### PR DESCRIPTION
Jira: [PEAR-1333](https://gdc-ctds.atlassian.net/browse/PEAR-1333)

## Description

- allow data_type to just be a string
- allow fileType to just be a string
- allow data_category to just be a string
- allow experimental_strategy to just be a string
- allow data_format to just be a string