### PR TITLE
PEAR-1576: add timeout to portal jest config so test pass when run locally

### DIFF
--- a/packages/portal-proto/jest.config.ts
+++ b/packages/portal-proto/jest.config.ts
@@ -31,6 +31,7 @@ const config: InitialOptionsTsJest = {
     "node_modules/(?!@sjcrh|react-dnd|dnd-core|@react-dnd|react-dnd-html5-backend)/",
     "!proteinpaint",
   ],
+  testTimeout: 10000,
 };
 
 export default config;


### PR DESCRIPTION
## Description
adds a timeout to prevent the portal unit test from timing out
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
