### PR TITLE
PEAR-1263 - App crashes in random areas

### DIFF
--- a/packages/core/src/provider.tsx
+++ b/packages/core/src/provider.tsx
@@ -19,3 +19,5 @@ export const CoreProvider: React.FC<unknown> = ({
     </Provider>
   );
 };
+
+export { persistor };

--- a/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
+++ b/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React, { Component, ReactNode } from "react";
+import { persistor } from "@gff/core";
+import { Modal } from "@mantine/core";
+import DarkFunctionButton from "./StyledComponents/DarkFunctionButton";
+import ModalButtonContainer from "./StyledComponents/ModalButtonContainer";
+
+class ClearStoreErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Modal opened onClose={undefined} title="Unexpected Error">
+          <p className="py-2 px-4">
+            An unexpected error has occurred. Your saved cohorts are being
+            recovered, but your cart and sets may be lost.
+          </p>
+          <ModalButtonContainer>
+            <DarkFunctionButton
+              onClick={async () => {
+                await persistor.purge();
+                location.reload();
+              }}
+            >
+              OK
+            </DarkFunctionButton>
+          </ModalButtonContainer>
+        </Modal>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ClearStoreErrorBoundary;

--- a/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
+++ b/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
@@ -24,6 +24,7 @@ import {
 import { Header } from "./Header";
 import { Footer } from "./Footer";
 import { useElementSize } from "@mantine/hooks";
+import ClearStoreErrorBoundary from "@/components/ClearStoreErrorBoundary";
 
 interface UserFlowVariedPagesProps {
   readonly headerElements: ReadonlyArray<ReactNode>;
@@ -154,21 +155,23 @@ export const UserFlowVariedPages: React.FC<UserFlowVariedPagesProps> = ({
         ))}
         <Header {...{ headerElements, indexPath, Options }} />
       </header>
-      <div
-        className={`${isContextBarSticky ? `sticky z-[299] shadow-lg` : ""}`}
-        style={{
-          top: `${isContextBarSticky && `${Math.round(headerHeight)}px`}`, // switching this to tailwind does not work
-        }}
-      >
-        {ContextBar ? ContextBar : null}
-      </div>
-      <main
-        data-tour="full_page_content"
-        className="flex flex-grow flex-col overflow-x-clip overflow-y-clip"
-        id="main"
-      >
-        {children}
-      </main>
+      <ClearStoreErrorBoundary>
+        <div
+          className={`${isContextBarSticky ? `sticky z-[299] shadow-lg` : ""}`}
+          style={{
+            top: `${isContextBarSticky && `${Math.round(headerHeight)}px`}`, // switching this to tailwind does not work
+          }}
+        >
+          {ContextBar ? ContextBar : null}
+        </div>
+        <main
+          data-tour="full_page_content"
+          className="flex flex-grow flex-col overflow-x-clip overflow-y-clip"
+          id="main"
+        >
+          {children}
+        </main>
+      </ClearStoreErrorBoundary>
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Description
Adds an error boundary around everything that allows a user to clear their persisted state. I've found the easiest way to test this is to remove the genes or ssms key from your persisted state and then go to the saved sets tab of the custom filters. This will cause a crash you can recover from by wiping your store. If you're testing with a dev build, the exceptions will appear as well but they won't be there for the production build. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="723" alt="Screenshot 2023-10-23 at 2 35 31 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/7535a318-45c7-4720-88ea-d3b2d2ccedc6">
