### PR TITLE
update the proteinpaint-client version to 2.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6526,9 +6526,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.27.0.tgz",
-      "integrity": "sha512-Yw+YlefylHbhTMgiwKSKmo9pdF5U2e+HS0XmSJBabLfAl3+l62saJzvB22Y6r2/2aNdGSV6p9DC0PfOSOpqWZA=="
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.0.tgz",
+      "integrity": "sha512-Ty0bHLUYpvFa/A4ihZQ7/NebBRBSptjQXoDiz5zzgZivn+fXYps6hmUVo5wf72TLH9TI9YxuaTELMn0+s+BJnw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26579,7 +26579,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.27.0",
+        "@sjcrh/proteinpaint-client": "^2.30.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "html-to-image": "^1.11.4",
@@ -31826,9 +31826,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.27.0.tgz",
-      "integrity": "sha512-Yw+YlefylHbhTMgiwKSKmo9pdF5U2e+HS0XmSJBabLfAl3+l62saJzvB22Y6r2/2aNdGSV6p9DC0PfOSOpqWZA=="
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.0.tgz",
+      "integrity": "sha512-Ty0bHLUYpvFa/A4ihZQ7/NebBRBSptjQXoDiz5zzgZivn+fXYps6hmUVo5wf72TLH9TI9YxuaTELMn0+s+BJnw=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41441,7 +41441,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.27.0",
+        "@sjcrh/proteinpaint-client": "^2.30.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.27.0",
+    "@sjcrh/proteinpaint-client": "^2.30.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "html-to-image": "^1.11.4",


### PR DESCRIPTION
## Description

NOTE: I will open a separate PR today to show a Gene Expression Prototype card in the Analysis Tools page.

ProteinPaint changes relevant to the GDC portal

Features:
- Support clicking OncoMatrix legends entries and group names to use as filters.

Fixes:
- Restore yellow highlight line when moving cursor over a genome browser block
- In GDC disco and bam slicing UI, detect when total number of SSM exceeds view limit and indicate such
- Supply the svg element as argument to the disco plot download handler
- Search term with space character for genomic-equipped dataset should not break by gene search message

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented flagged issues: will address Section 508 issues in a separate branch or the next release.

## Screenshots/Screen Recordings (if Appropriate)
