### PR TITLE
Change default sort on primary sites table

### DIFF
--- a/packages/portal-proto/src/features/projects/PrimarySiteTable.tsx
+++ b/packages/portal-proto/src/features/projects/PrimarySiteTable.tsx
@@ -147,7 +147,7 @@ const PrimarySiteTable: React.FC<PrimarySiteTableProps> = ({
   const [sorting, setSorting] = useState<SortingState>([
     {
       id: "primary_site",
-      desc: true,
+      desc: false,
     },
   ]);
 


### PR DESCRIPTION
## Description
Changes the default sort on the primary sites table so that it's ascending rather than descending.
## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1658" alt="Screenshot 2023-10-26 at 11 18 39 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/227962a8-7797-4351-ae56-75bfc16e89fd">
