### PR TITLE
PEAR-1328 - Improve performance of Cohort Comparison

### DIFF
--- a/packages/portal-proto/src/features/cohortComparison/CohortComparison.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/CohortComparison.tsx
@@ -61,7 +61,7 @@ const CohortComparison: React.FC<CohortComparisonProps> = ({
   const [createComparisonCaseSet, comparisonSetResponse] =
     useCreateCaseSetFromFiltersMutation();
 
-  const { data, isFetching, isUninitialized } = useCohortFacetsQuery(
+  const { data, isFetching } = useCohortFacetsQuery(
     {
       facetFields: fieldsToQuery,
       primaryCohortSetId: primarySetResponse.data,
@@ -91,8 +91,6 @@ const CohortComparison: React.FC<CohortComparisonProps> = ({
   ]);
 
   const loading =
-    isFetching ||
-    isUninitialized ||
     primarySetResponse.isUninitialized ||
     primarySetResponse.isLoading ||
     comparisonSetResponse.isUninitialized ||


### PR DESCRIPTION
## Description
Faster survival plot load time on Cohort Comparison by removing dependence on aggregation query finishing

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
Before, survival plot request waited until aggregation request returned:
<img width="378" alt="Screenshot 2023-10-26 at 1 51 59 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/1f2a3392-b3aa-4276-9036-0e5079064240">
After, all requests kick off after case sets are created:
<img width="701" alt="Screenshot 2023-10-26 at 1 50 31 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/24d36878-132e-4115-9490-d311a16a4b30">
