### PR TITLE
PEAR-1588: increase test.timeout

### DIFF
--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -6,5 +6,5 @@ module.exports = {
     "^@/core/(.*)$": "<rootDir>/src/core/$1",
   },
   modulePaths: ["<rootDir>"],
-  testTimeout: 20000,
+  testTimeout: 50000,
 };

--- a/packages/portal-proto/jest.config.ts
+++ b/packages/portal-proto/jest.config.ts
@@ -31,7 +31,7 @@ const config: InitialOptionsTsJest = {
     "node_modules/(?!@sjcrh|react-dnd|dnd-core|@react-dnd|react-dnd-html5-backend)/",
     "!proteinpaint",
   ],
-  testTimeout: 20000,
+  testTimeout: 50000,
 };
 
 export default config;


### PR DESCRIPTION
## Description
Increase `testTimeout` again to ensure all test pass when run locally.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
