### PR TITLE
PEAR-1519: Fix a11y for table sorting

### DIFF
--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -319,9 +319,6 @@ function VerticalTable<TData>({
                           onClick={() =>
                             handleSorting(header, headerName, isColumnSorted)
                           }
-                          onKeyDown={createKeyboardAccessibleFunction(() =>
-                            handleSorting(header, headerName, isColumnSorted),
-                          )}
                         >
                           {headerName}
                           {isColumnSortable && (


### PR DESCRIPTION
## Description
Made a few changes to make sure that sorting status is announced by the screen readers.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
