### PR TITLE
update the proteinpaint-client-version to 2.30.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6526,9 +6526,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.0.tgz",
-      "integrity": "sha512-Ty0bHLUYpvFa/A4ihZQ7/NebBRBSptjQXoDiz5zzgZivn+fXYps6hmUVo5wf72TLH9TI9YxuaTELMn0+s+BJnw=="
+      "version": "2.30.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.2.tgz",
+      "integrity": "sha512-DHaDYH7hMdZQwi7IqOuTGOEyzr5gZBIqzQNC6gawV0jgDkwQ0vdB/vliv3zoxMpQBaC1OkXUJ5Qn4AYV9grUSA=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26574,7 +26574,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.30.0",
+        "@sjcrh/proteinpaint-client": "^2.30.2",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -31820,9 +31820,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.0.tgz",
-      "integrity": "sha512-Ty0bHLUYpvFa/A4ihZQ7/NebBRBSptjQXoDiz5zzgZivn+fXYps6hmUVo5wf72TLH9TI9YxuaTELMn0+s+BJnw=="
+      "version": "2.30.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.2.tgz",
+      "integrity": "sha512-DHaDYH7hMdZQwi7IqOuTGOEyzr5gZBIqzQNC6gawV0jgDkwQ0vdB/vliv3zoxMpQBaC1OkXUJ5Qn4AYV9grUSA=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41430,7 +41430,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.30.0",
+        "@sjcrh/proteinpaint-client": "^2.30.2",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.30.0",
+    "@sjcrh/proteinpaint-client": "^2.30.2",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description
- Disco: file name of downloaded svg preserves context including sample name and gene.
- Disco: by default it now prioritize CGC genes in hg38.

@craigrbarnes We'd like to release the updates from the last 3 PRs, including this PR, for portal v2.10.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
