### PR TITLE
PEAR-1590 + PEAR-1592 - CDave QA fixes 

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
@@ -159,7 +159,7 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
               color={color}
               yLabel={displayPercent ? "% of Cases" : "# of Cases"}
               width={900}
-              height={500}
+              height={400}
               hideXTicks={hideXTicks}
               hideYTicks={hideYTicks}
               xLabel={
@@ -167,6 +167,7 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
                   ? "Mouse over the histogram to see x-axis labels"
                   : undefined
               }
+              truncateLabels
             />
           </div>
           <OffscreenWrapper>

--- a/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.tsx
@@ -12,7 +12,7 @@ import SurvivalPlot, {
   SurvivalPlotTypes,
 } from "@/features/charts/SurvivalPlot";
 import { convertDateToString } from "@/utils/date";
-import { isInterval } from "../utils";
+import { isInterval, parseContinuousBucket } from "../utils";
 import { CategoricalBins, CustomInterval, NamedFromTo } from "../types";
 import { DEMO_COHORT_FILTERS } from "../constants";
 
@@ -79,7 +79,7 @@ const ClinicalSurvivalPlot: React.FC<ClinicalSurvivalPlotProps> = ({
                 });
               }
             } else {
-              const [fromValue, toValue] = value.split("-");
+              const [fromValue, toValue] = parseContinuousBucket(value);
 
               content.push({
                 op: ">=",

--- a/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.unit.test.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.unit.test.tsx
@@ -1,0 +1,368 @@
+import { render } from "test-utils";
+import * as router from "next/router";
+import * as core from "@gff/core";
+import ClinicalSurvivalPlot from "./ClinicalSurvivalPlot";
+
+describe("ClinicalSurvivalPlot", () => {
+  beforeEach(() => {
+    jest.spyOn(router, "useRouter").mockImplementation(
+      () =>
+        ({
+          pathname: "",
+          query: {},
+        } as any),
+    );
+  });
+
+  it("creates filters for categorical data", () => {
+    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+
+    render(
+      <ClinicalSurvivalPlot
+        field={"demographic.gender"}
+        continuous={false}
+        customBinnedData={null}
+        selectedSurvivalPlots={["male", "female"]}
+      />,
+    );
+
+    expect(survivalQuerySpy).toBeCalledWith({
+      filters: [
+        {
+          op: "and",
+          content: [
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: "male",
+              },
+            },
+          ],
+        },
+        {
+          op: "and",
+          content: [
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: "female",
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("adds cohort filters", () => {
+    jest
+      .spyOn(core, "selectCurrentCohortFilters")
+      .mockImplementationOnce(() => ({
+        mode: "and",
+        root: {
+          "cases.project.project_id": {
+            operator: "includes",
+            field: "cases.project.project_id",
+            operands: ["FM-AD"],
+          },
+        },
+      }));
+    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+
+    render(
+      <ClinicalSurvivalPlot
+        field={"demographic.gender"}
+        continuous={false}
+        customBinnedData={null}
+        selectedSurvivalPlots={["male", "female"]}
+      />,
+    );
+
+    expect(survivalQuerySpy).toBeCalledWith({
+      filters: [
+        {
+          op: "and",
+          content: [
+            {
+              op: "and",
+              content: [
+                {
+                  op: "in",
+                  content: {
+                    value: ["FM-AD"],
+                    field: "cases.project.project_id",
+                  },
+                },
+              ],
+            },
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: "male",
+              },
+            },
+          ],
+        },
+        {
+          op: "and",
+          content: [
+            {
+              op: "and",
+              content: [
+                {
+                  op: "in",
+                  content: {
+                    value: ["FM-AD"],
+                    field: "cases.project.project_id",
+                  },
+                },
+              ],
+            },
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: "female",
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("adds demo filters", () => {
+    jest.spyOn(router, "useRouter").mockImplementation(
+      () =>
+        ({
+          pathname: "",
+          query: { demoMode: "true" },
+        } as any),
+    );
+
+    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+
+    render(
+      <ClinicalSurvivalPlot
+        field={"demographic.gender"}
+        continuous={false}
+        customBinnedData={null}
+        selectedSurvivalPlots={["male", "female"]}
+      />,
+    );
+
+    expect(survivalQuerySpy).toBeCalledWith({
+      filters: [
+        {
+          op: "and",
+          content: [
+            {
+              op: "and",
+              content: [
+                {
+                  op: "in",
+                  content: {
+                    value: ["TCGA-LGG"],
+                    field: "cases.project.project_id",
+                  },
+                },
+              ],
+            },
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: "male",
+              },
+            },
+          ],
+        },
+        {
+          op: "and",
+          content: [
+            {
+              op: "and",
+              content: [
+                {
+                  op: "in",
+                  content: {
+                    value: ["TCGA-LGG"],
+                    field: "cases.project.project_id",
+                  },
+                },
+              ],
+            },
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: "female",
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("creates filters for custom binned data", () => {
+    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+
+    render(
+      <ClinicalSurvivalPlot
+        field={"demographic.gender"}
+        continuous={false}
+        customBinnedData={{ bucket1: { male: 20, female: 80 }, missing: 100 }}
+        selectedSurvivalPlots={["bucket1", "missing"]}
+      />,
+    );
+
+    expect(survivalQuerySpy).toBeCalledWith({
+      filters: [
+        {
+          op: "and",
+          content: [
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: ["male", "female"],
+              },
+            },
+          ],
+        },
+        {
+          op: "and",
+          content: [
+            {
+              op: "=",
+              content: {
+                field: "demographic.gender",
+                value: "missing",
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("creates filters for named from to", () => {
+    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+
+    render(
+      <ClinicalSurvivalPlot
+        field={"demographic.days_to_death"}
+        continuous
+        customBinnedData={[
+          { name: "bin a", from: 0, to: 10 },
+          { name: "bin b", from: 10, to: 20 },
+          { name: "bin c", from: 20, to: 30 },
+        ]}
+        selectedSurvivalPlots={["bin a", "bin c"]}
+      />,
+    );
+
+    expect(survivalQuerySpy).toBeCalledWith({
+      filters: [
+        {
+          op: "and",
+          content: [
+            {
+              op: ">=",
+              content: {
+                field: "demographic.days_to_death",
+                value: [0],
+              },
+            },
+            {
+              op: "<",
+              content: {
+                field: "demographic.days_to_death",
+                value: [10],
+              },
+            },
+          ],
+        },
+        {
+          op: "and",
+          content: [
+            {
+              op: ">=",
+              content: {
+                field: "demographic.days_to_death",
+                value: [20],
+              },
+            },
+            {
+              op: "<",
+              content: {
+                field: "demographic.days_to_death",
+                value: [30],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses selected negative values", () => {
+    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+
+    render(
+      <ClinicalSurvivalPlot
+        field={"demographic.days_to_death"}
+        continuous
+        customBinnedData={null}
+        selectedSurvivalPlots={["-10.0-10.0", "10.0-20.0"]}
+      />,
+    );
+
+    expect(survivalQuerySpy).toBeCalledWith({
+      filters: [
+        {
+          op: "and",
+          content: [
+            {
+              op: ">=",
+              content: {
+                field: "demographic.days_to_death",
+                value: ["-10.0"],
+              },
+            },
+            {
+              op: "<",
+              content: {
+                field: "demographic.days_to_death",
+                value: ["10.0"],
+              },
+            },
+          ],
+        },
+        {
+          op: "and",
+          content: [
+            {
+              op: ">=",
+              content: {
+                field: "demographic.days_to_death",
+                value: ["10.0"],
+              },
+            },
+            {
+              op: "<",
+              content: {
+                field: "demographic.days_to_death",
+                value: ["20.0"],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
+++ b/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
@@ -48,15 +48,19 @@ const BarChartTooltip: React.FC<BarChartTooltipProps> = ({
   );
 };
 
-const BarChartLabel: React.FC<VictoryLabelProps & { index?: number }> = ({
+const BarChartLabel: React.FC<
+  VictoryLabelProps & { index?: number; truncateLabels?: boolean }
+> = ({
   x,
   y,
   style,
   angle,
   data,
   index,
-}: VictoryLabelProps & { index?: number }) => {
+  truncateLabels,
+}: VictoryLabelProps & { index?: number; truncateLabels?: boolean }) => {
   const [showTooltip, setShowTooltip] = useState(false);
+  const label = data?.[index]?.fullName || "";
 
   return (
     <g>
@@ -69,7 +73,7 @@ const BarChartLabel: React.FC<VictoryLabelProps & { index?: number }> = ({
         onMouseOver={() => setShowTooltip(true)}
         onMouseOut={() => setShowTooltip(false)}
       >
-        {truncateString(data?.[index]?.fullName || "", 8)}
+        {truncateLabels ? truncateString(label, 8) : label}
       </text>
       {showTooltip && (
         <BarChartTooltip x={x + 20} y={y - 20} datum={data[index]} />
@@ -96,6 +100,7 @@ interface VictoryBarChartProps {
   readonly hideYTicks?: boolean;
   readonly hideXTicks?: boolean;
   readonly chartRef?: React.MutableRefObject<HTMLElement>;
+  readonly truncateLabels?: boolean;
 }
 
 const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
@@ -111,6 +116,7 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
   hideYTicks = false,
   hideXTicks = false,
   chartRef = undefined,
+  truncateLabels = false,
 }: VictoryBarChartProps) => {
   return (
     <VictoryChart
@@ -150,7 +156,13 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
           tickLabels: { angle: 45, fontSize: 25, fontFamily: "Noto Sans" },
           axisLabel: { fontSize: 25, fontFamily: "Noto Sans" },
         }}
-        tickLabelComponent={hideXTicks ? <></> : <BarChartLabel data={data} />}
+        tickLabelComponent={
+          hideXTicks ? (
+            <></>
+          ) : (
+            <BarChartLabel data={data} truncateLabels={truncateLabels} />
+          )
+        }
         label={xLabel}
       />
       <VictoryBar


### PR DESCRIPTION
## Description
- PEAR-1590 - cDAVE: years-days toggle, some survival plot graphs show "something's gone wrong"
    - This was causing by buckets with negative values getting parsed incorrectly. I added tests around the filter creation for this component.
- PEAR-1592 - cDAVE histogram image downloads have truncated x-axis labels

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
