### PR TITLE
PEAR-1595 - cDAVE: years-days toggle - Starting download then toggle changes units in the download 

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
@@ -15,6 +15,7 @@ import {
   GqlOperation,
 } from "@gff/core";
 import SegmentedControl from "@/components/SegmentedControl";
+import { DownloadProgressContext } from "@/utils/contexts";
 import ContinuousData from "./ContinuousData";
 import CategoricalData from "./CategoricalData";
 import { ChartTypes, DataDimension } from "../types";
@@ -42,6 +43,7 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
   cohortFilters,
 }: CDaveCardProps) => {
   const [chartType, setChartType] = useState<ChartTypes>("histogram");
+  const [downloadInProgress, setDownloadInProgress] = useState(false);
   const { scrollIntoView, targetRef } = useScrollIntoView();
   const displayDataDimension = useDataDimension(field);
   const facet = useCoreSelector((state) =>
@@ -141,13 +143,13 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
                 DATA_DIMENSIONS?.[field]?.unit,
               ]}
               onChange={(d) => setDataDimension(d as DataDimension)}
-              disabled={noData}
+              disabled={noData || downloadInProgress}
             />
           )}
           <SegmentedControl
             data={chartButtons}
             onChange={(c) => setChartType(c as ChartTypes)}
-            disabled={noData}
+            disabled={noData || downloadInProgress}
           />
           <Tooltip
             label={"Remove Card"}
@@ -166,29 +168,33 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
           </Tooltip>
         </div>
       </div>
-      {noData ? (
-        <div className="h-[32.1rem] w-full flex flex-col justify-start">
-          <p className="mx-auto my-2">No data for this property</p>
-        </div>
-      ) : continuous ? (
-        <ContinuousData
-          initialData={(data as Stats)?.stats}
-          field={field}
-          fieldName={fieldName}
-          chartType={chartType}
-          noData={noData}
-          cohortFilters={cohortFilters}
-          dataDimension={dataDimension}
-        />
-      ) : (
-        <CategoricalData
-          initialData={(data as Buckets)?.buckets}
-          field={field}
-          fieldName={fieldName}
-          chartType={chartType}
-          noData={noData}
-        />
-      )}
+      <DownloadProgressContext.Provider
+        value={{ downloadInProgress, setDownloadInProgress }}
+      >
+        {noData ? (
+          <div className="h-[32.1rem] w-full flex flex-col justify-start">
+            <p className="mx-auto my-2">No data for this property</p>
+          </div>
+        ) : continuous ? (
+          <ContinuousData
+            initialData={(data as Stats)?.stats}
+            field={field}
+            fieldName={fieldName}
+            chartType={chartType}
+            noData={noData}
+            cohortFilters={cohortFilters}
+            dataDimension={dataDimension}
+          />
+        ) : (
+          <CategoricalData
+            initialData={(data as Buckets)?.buckets}
+            field={field}
+            fieldName={fieldName}
+            chartType={chartType}
+            noData={noData}
+          />
+        )}
+      </DownloadProgressContext.Provider>
     </Card>
   );
 };

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
@@ -5,7 +5,10 @@ import tailwindConfig from "tailwind.config";
 import OffscreenWrapper from "@/components/OffscreenWrapper";
 import { handleDownloadPNG, handleDownloadSVG } from "@/features/charts/utils";
 import { convertDateToString } from "@/utils/date";
-import { DashboardDownloadContext } from "@/utils/contexts";
+import {
+  DashboardDownloadContext,
+  DownloadProgressContext,
+} from "@/utils/contexts";
 import VictoryBarChart from "../../charts/VictoryBarChart";
 import { COLOR_MAP } from "../constants";
 import { toDisplayName } from "../utils";
@@ -47,6 +50,9 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
 }: HistogramProps) => {
   const [displayPercent, setDisplayPercent] = useState(false);
   const downloadChartRef = useRef<HTMLElement>();
+  const { downloadInProgress, setDownloadInProgress } = useContext(
+    DownloadProgressContext,
+  );
 
   const barChartData = formatBarChartData(data, yTotal, displayPercent);
 
@@ -114,29 +120,37 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
                     className="bg-base-max border-primary"
                     aria-label="Download image or data"
                   >
-                    <DownloadIcon className="text-primary" />
+                    {downloadInProgress ? (
+                      <Loader size={16} />
+                    ) : (
+                      <DownloadIcon className="text-primary" />
+                    )}
                   </ActionIcon>
                 </Tooltip>
               </Menu.Target>
 
               <Menu.Dropdown>
                 <Menu.Item
-                  onClick={() =>
-                    handleDownloadSVG(
+                  onClick={async () => {
+                    setDownloadInProgress(true);
+                    await handleDownloadSVG(
                       downloadChartRef,
                       `${downloadFileName}.svg`,
-                    )
-                  }
+                    );
+                    setDownloadInProgress(false);
+                  }}
                 >
                   SVG
                 </Menu.Item>
                 <Menu.Item
-                  onClick={() =>
-                    handleDownloadPNG(
+                  onClick={async () => {
+                    setDownloadInProgress(true);
+                    await handleDownloadPNG(
                       downloadChartRef,
                       `${downloadFileName}.png`,
-                    )
-                  }
+                    );
+                    setDownloadInProgress(false);
+                  }}
                 >
                   PNG
                 </Menu.Item>

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveTable.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveTable.tsx
@@ -139,6 +139,7 @@ const CDaveTable: React.FC<CDaveTableProps> = ({
                               : "bg-base-lightest text-base-contrast-lightest"
                           } ml-2`}
                           disabled={survivalDisabled}
+                          aria-label={`Toggle survival plot for ${displayName}`}
                           onClick={() =>
                             survivalSelected
                               ? setSelectedSurvivalPlots(

--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -12,12 +12,16 @@ import { Survival, SurvivalElement } from "@gff/core";
 import { renderPlot } from "@oncojs/survivalplot";
 import { MdRestartAlt as ResetIcon } from "react-icons/md";
 import { FiDownload as DownloadIcon } from "react-icons/fi";
-import { Box, Menu, Tooltip } from "@mantine/core";
+import { Box, Menu, Tooltip, Loader } from "@mantine/core";
 import isNumber from "lodash/isNumber";
 import { useMouse, useResizeObserver } from "@mantine/hooks";
 import saveAs from "file-saver";
 import { handleDownloadSVG, handleDownloadPNG } from "./utils";
-import { entityMetadataType, SummaryModalContext } from "src/utils/contexts";
+import {
+  entityMetadataType,
+  SummaryModalContext,
+  DownloadProgressContext,
+} from "src/utils/contexts";
 import { DashboardDownloadContext } from "@/utils/contexts";
 import { DownloadButton } from "@/components/tailwindComponents";
 import OffscreenWrapper from "@/components/OffscreenWrapper";
@@ -480,6 +484,10 @@ const SurvivalPlot: React.FC<SurvivalPlotProps> = ({
     return () => dispatch({ type: "remove", payload: charts });
   }, [dispatch, downloadFileName]);
 
+  const { downloadInProgress, setDownloadInProgress } = useContext(
+    DownloadProgressContext,
+  );
+
   return (
     <div className="flex flex-col">
       <div className="flex w-100 items-center justify-center flex-wrap">
@@ -496,22 +504,36 @@ const SurvivalPlot: React.FC<SurvivalPlotProps> = ({
                   data-testid="button-download-survival-plot"
                   aria-label="Download button with an icon"
                 >
-                  <DownloadIcon size="1.25em" />
+                  {downloadInProgress ? (
+                    <Loader size={16} />
+                  ) : (
+                    <DownloadIcon size="1.25em" />
+                  )}
                 </DownloadButton>
               </Tooltip>
             </Menu.Target>
             <Menu.Dropdown data-testid="list-download-survival-plot-dropdown">
               <Menu.Item
-                onClick={() =>
-                  handleDownloadSVG(downloadRef, `${downloadFileName}.svg`)
-                }
+                onClick={async () => {
+                  setDownloadInProgress(true);
+                  await handleDownloadSVG(
+                    downloadRef,
+                    `${downloadFileName}.svg`,
+                  );
+                  setDownloadInProgress(false);
+                }}
               >
                 SVG
               </Menu.Item>
               <Menu.Item
-                onClick={() =>
-                  handleDownloadPNG(downloadRef, `${downloadFileName}.png`)
-                }
+                onClick={async () => {
+                  setDownloadInProgress(true);
+                  await handleDownloadPNG(
+                    downloadRef,
+                    `${downloadFileName}.png`,
+                  );
+                  setDownloadInProgress(false);
+                }}
               >
                 PNG
               </Menu.Item>

--- a/packages/portal-proto/src/utils/contexts.ts
+++ b/packages/portal-proto/src/utils/contexts.ts
@@ -41,3 +41,8 @@ export const DashboardDownloadContext = createContext<{
   state: ChartDownloadInfo[];
   dispatch: Dispatch<{ type: "add" | "remove"; payload: ChartDownloadInfo[] }>;
 }>(undefined);
+
+export const DownloadProgressContext = createContext({
+  downloadInProgress: false,
+  setDownloadInProgress: undefined,
+});


### PR DESCRIPTION
## Description
+ PEAR-1596 - cDAVE - Starting download and then switching graph view cancels the download 
Disable toggling units/chart types when chart is downloading 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
