### PR TITLE
PEAR-1601+1602: Fix facet sort panel a11y and same id issue for live region

### DIFF
--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -334,6 +334,7 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
                 sortType={sortType}
                 valueLabel={valueLabel}
                 setSort={setSortType}
+                field={facetName ? facetName : fieldNameToTitle(field)}
               />
 
               <div className={facetChartData.cardStyle}>

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -69,7 +69,7 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [sortType, setSortType] = useState<SortType>({
     type: "alpha",
-    direction: "dsc",
+    direction: "asc",
   });
   const [sortedData, setSortedData] = useState(undefined);
   const [isFacetView, setIsFacetView] = useState(startShowingData);
@@ -220,11 +220,11 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
             .sort(
               sortType.type === "value"
                 ? ([, a], [, b]) =>
-                    sortType.direction === "dsc" ? a - b : b - a
+                    sortType.direction === "dsc" ? b - a : a - b
                 : ([a], [b]) =>
                     sortType.direction === "dsc"
-                      ? a.localeCompare(b)
-                      : b.localeCompare(a),
+                      ? b.localeCompare(a)
+                      : a.localeCompare(b),
             )
             .slice(0, !isGroupExpanded ? maxValuesToDisplay : undefined),
         ),

--- a/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
@@ -26,6 +26,7 @@ interface FacetSortPanelProps {
   sortType: SortType;
   valueLabel: string;
   setSort: (sort: SortType) => void;
+  field: string;
 }
 
 /**
@@ -39,6 +40,7 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
   sortType,
   valueLabel,
   setSort,
+  field,
 }: FacetSortPanelProps) => {
   const liveRegionRef = useRef(null);
   const [sortingStatus, setSortingStatus] = useState("");
@@ -115,14 +117,14 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
       >
         {valueLabel}
       </Button>
-      <span className="Offscreen">
-        <span
-          id={`${valueLabel}-liveRegion`}
-          aria-live="polite"
-          ref={liveRegionRef}
-        >
-          {sortingStatus}
-        </span>
+
+      <span
+        id={`${field}-liveRegion`}
+        aria-live="polite"
+        ref={liveRegionRef}
+        className="sr-only"
+      >
+        {sortingStatus}
       </span>
     </div>
   );

--- a/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
@@ -4,10 +4,13 @@ import {
   PiCaretDownFill as SortDesIcon,
   PiCaretUpFill as SortAscIcon,
 } from "react-icons/pi";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { SortType } from "./types";
 
-const sortTypeToAriaDescription = (sortTypeAndDirection, valueLabel) => {
+const sortTypeToAriaDescription = (
+  sortTypeAndDirection: SortType,
+  valueLabel: string,
+) => {
   if (sortTypeAndDirection.type === "alpha") {
     return sortTypeAndDirection.direction === "asc"
       ? "Name is now sorted alphabetically ascending"
@@ -37,6 +40,14 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
   valueLabel,
   setSort,
 }: FacetSortPanelProps) => {
+  const liveRegionRef = useRef(null);
+  const [sortingStatus, setSortingStatus] = useState("");
+  useEffect(() => {
+    if (sortingStatus) {
+      liveRegionRef.current.textContent = sortingStatus;
+    }
+  }, [sortingStatus]);
+
   const [NameSortIcon, nameIconSize] =
     sortType.type === "alpha"
       ? sortType.direction === "asc"
@@ -49,6 +60,7 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
         ? [SortAscIcon, "0.75rem"]
         : [SortDesIcon, "0.75rem"]
       : [Selector, "1rem"];
+
   return (
     <div className="flex flex-row items-center justify-between flex-wrap py-1 px-2 mb-1 border-b-2">
       <Button
@@ -57,12 +69,21 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
         size="xs"
         compact
         color="primary.9"
-        onClick={() =>
+        onClick={() => {
           setSort({
             type: "alpha",
             direction: sortType.direction === "asc" ? "dsc" : "asc",
-          })
-        }
+          });
+          setSortingStatus(
+            sortTypeToAriaDescription(
+              {
+                type: "alpha",
+                direction: sortType.direction === "asc" ? "dsc" : "asc",
+              },
+              "Name",
+            ),
+          );
+        }}
         rightIcon={<NameSortIcon size={nameIconSize} />}
         aria-label="Sort name alphabetically"
       >
@@ -74,20 +95,33 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
         size="xs"
         compact
         color="primary.9"
-        onClick={() =>
+        onClick={() => {
           setSort({
             type: "value",
             direction: sortType.direction === "asc" ? "dsc" : "asc",
-          })
-        }
+          });
+          setSortingStatus(
+            sortTypeToAriaDescription(
+              {
+                type: "value",
+                direction: sortType.direction === "asc" ? "dsc" : "asc",
+              },
+              valueLabel,
+            ),
+          );
+        }}
         rightIcon={<ValueSortIcon size={valueIconSize} />}
         aria-label={`Sort ${valueLabel} numerically`}
       >
         {valueLabel}
       </Button>
       <span className="Offscreen">
-        <span id="liveRegion" aria-live="polite">
-          {sortTypeToAriaDescription(sortType, valueLabel)}
+        <span
+          id={`${valueLabel}-liveRegion`}
+          aria-live="polite"
+          ref={liveRegionRef}
+        >
+          {sortingStatus}
         </span>
       </span>
     </div>

--- a/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
@@ -19,7 +19,6 @@ const sortTypeToAriaDescription = (
   valueLabel: string,
   field: string,
 ) => {
-  console.log({ sortTypeAndDirection });
   if (sortTypeAndDirection.type === "alpha") {
     return sortTypeAndDirection.direction === "asc"
       ? `The ${field} names are now sorted alphabetically ascending`

--- a/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
@@ -7,21 +7,6 @@ import {
 import React, { useEffect, useRef, useState } from "react";
 import { SortType } from "./types";
 
-const sortTypeToAriaDescription = (
-  sortTypeAndDirection: SortType,
-  valueLabel: string,
-) => {
-  if (sortTypeAndDirection.type === "alpha") {
-    return sortTypeAndDirection.direction === "asc"
-      ? "Name is now sorted alphabetically ascending"
-      : "Name is now sorted alphabetically descending";
-  } else {
-    return sortTypeAndDirection.direction === "asc"
-      ? `${valueLabel} is now sorted numerically ascending`
-      : `${valueLabel} is now sorted numerically descending`;
-  }
-};
-
 interface FacetSortPanelProps {
   sortType: SortType;
   valueLabel: string;
@@ -29,13 +14,30 @@ interface FacetSortPanelProps {
   field: string;
 }
 
+const sortTypeToAriaDescription = (
+  sortTypeAndDirection: SortType,
+  valueLabel: string,
+  field: string,
+) => {
+  console.log({ sortTypeAndDirection });
+  if (sortTypeAndDirection.type === "alpha") {
+    return sortTypeAndDirection.direction === "asc"
+      ? `The ${field} names are now sorted alphabetically ascending`
+      : `The ${field} names are now sorted alphabetically descending`;
+  } else {
+    return sortTypeAndDirection.direction === "asc"
+      ? `The ${field} ${valueLabel} are now sorted numerically ascending`
+      : `The ${field} ${valueLabel} are now sorted numerically descending`;
+  }
+};
+
 /**
  * FacetCards "sort" header supporting sort by A-Z or by Value both ascending and descending
  * @param sortType - current sort type
- * @param setSort - sets the sort type and direction
  * @param valueLabel - Value labels, typically "case" "file"
+ * @param setSort - sets the sort type and direction
+ * @param field - specifies the facet table name
  */
-
 const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
   sortType,
   valueLabel,
@@ -56,6 +58,7 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
         ? [SortAscIcon, "0.75rem"]
         : [SortDesIcon, "0.75rem"]
       : [Selector, "1rem"];
+
   const [ValueSortIcon, valueIconSize] =
     sortType.type === "value"
       ? sortType.direction === "asc"
@@ -72,19 +75,16 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
         compact
         color="primary.9"
         onClick={() => {
-          setSort({
+          const direction =
+            sortType.type === "alpha" && sortType.direction === "asc"
+              ? "dsc"
+              : "asc";
+          const sortObj: SortType = {
             type: "alpha",
-            direction: sortType.direction === "asc" ? "dsc" : "asc",
-          });
-          setSortingStatus(
-            sortTypeToAriaDescription(
-              {
-                type: "alpha",
-                direction: sortType.direction === "asc" ? "dsc" : "asc",
-              },
-              "Name",
-            ),
-          );
+            direction,
+          };
+          setSort(sortObj);
+          setSortingStatus(sortTypeToAriaDescription(sortObj, "Name", field));
         }}
         rightIcon={<NameSortIcon size={nameIconSize} />}
         aria-label="Sort name alphabetically"
@@ -98,18 +98,17 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
         compact
         color="primary.9"
         onClick={() => {
-          setSort({
+          const direction =
+            sortType.type === "value" && sortType.direction === "asc"
+              ? "dsc"
+              : "asc";
+          const sortObj: SortType = {
             type: "value",
-            direction: sortType.direction === "asc" ? "dsc" : "asc",
-          });
+            direction,
+          };
+          setSort(sortObj);
           setSortingStatus(
-            sortTypeToAriaDescription(
-              {
-                type: "value",
-                direction: sortType.direction === "asc" ? "dsc" : "asc",
-              },
-              valueLabel,
-            ),
+            sortTypeToAriaDescription(sortObj, valueLabel, field),
           );
         }}
         rightIcon={<ValueSortIcon size={valueIconSize} />}
@@ -123,9 +122,7 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
         aria-live="polite"
         ref={liveRegionRef}
         className="sr-only"
-      >
-        {sortingStatus}
-      </span>
+      />
     </div>
   );
 };

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -170,6 +170,7 @@ const RangeValueSelector: React.FC<RangeValueSelectorProps> = ({
             sortType={sortType}
             valueLabel={valueLabel}
             setSort={setSortType}
+            field={field}
           />
         </>
       ) : null}
@@ -186,10 +187,10 @@ const RangeValueSelector: React.FC<RangeValueSelectorProps> = ({
                       rangeLabelsAndValues[b].value
               : (a, b) =>
                   sortType.direction === "dsc"
-                    ? rangeLabelsAndValues[a].from -
-                      rangeLabelsAndValues[b].from
-                    : rangeLabelsAndValues[b].from -
-                      rangeLabelsAndValues[a].from,
+                    ? rangeLabelsAndValues[b].from -
+                      rangeLabelsAndValues[a].from
+                    : rangeLabelsAndValues[a].from -
+                      rangeLabelsAndValues[b].from,
           )
           .map((rangeKey, i) => {
             return (


### PR DESCRIPTION
## Description
Changes include:
1. correct use of icons
2. correct use of initial sorting direction
3. aria live just announces once after the sorting has been done

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/43b0fa89-4dd0-4af2-9c4b-660cb5d0f927



