### PR TITLE
Attempt to upgrade version of python SNYK tests with QA-2089

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,2 +1,0 @@
-language-settings:
-  python: '3.9'

--- a/holmes-py/.snyk
+++ b/holmes-py/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.0.0
+language-settings:
+  python: "3.9.4"


### PR DESCRIPTION
## Description
- I updated the .snyk file, and put it in the directory with the holmes-py requirement file

It may not honor the fact we want Python version 3.9. If it does not, I will have to talk to security and come up with a new way to upgrade the version of python. 