### PR TITLE
Use the LoadingOverlay component for OncoMatrix

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/sjpp-types.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/sjpp-types.tsx
@@ -44,3 +44,7 @@ export function getFilters(arg: SelectSamplesCallBackArg): FilterSet {
     },
   };
 }
+
+export type RxComponentCallbacks = {
+  [eventName: string]: () => void;
+};


### PR DESCRIPTION
## Description
The OncoMatrix tool will trigger the display and hiding of the mantine loading overlay on app.dispatch and postRender events, respectively. NOTE: Another PR will be opened soon to update the proteinpaint-client version for other JIRA-related fixes.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
