### PR TITLE
Sjpp client 2.31.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6564,9 +6564,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.5.tgz",
-      "integrity": "sha512-4ymnXOvmXaPWi8/hSh0TfgSY69wB2OjCd1+t/JXDo5dTraGVSYU0KeQUA/odPefEckP+7u+AApyFkLpWxLjSeA=="
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.33.1.tgz",
+      "integrity": "sha512-Vr/Oo6h79Ss82iY93BVaKBV7VOuU64IE9gZgBOc06o5KSj8t1bWvTXzelR2E9urS0GW+k0JcYrXitJa5owdZNQ=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26726,7 +26726,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.30.5",
+        "@sjcrh/proteinpaint-client": "^2.33.1",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32011,9 +32011,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.30.5.tgz",
-      "integrity": "sha512-4ymnXOvmXaPWi8/hSh0TfgSY69wB2OjCd1+t/JXDo5dTraGVSYU0KeQUA/odPefEckP+7u+AApyFkLpWxLjSeA=="
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.33.1.tgz",
+      "integrity": "sha512-Vr/Oo6h79Ss82iY93BVaKBV7VOuU64IE9gZgBOc06o5KSj8t1bWvTXzelR2E9urS0GW+k0JcYrXitJa5owdZNQ=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41654,7 +41654,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.30.5",
+        "@sjcrh/proteinpaint-client": "^2.33.1",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.30.5",
+    "@sjcrh/proteinpaint-client": "^2.33.1",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/apps/BamDownloadApp.tsx
+++ b/packages/portal-proto/src/features/apps/BamDownloadApp.tsx
@@ -1,0 +1,20 @@
+import { useIsDemoApp } from "@/hooks/useIsDemoApp";
+import { FC } from "react";
+import { SequenceReadWrapper } from "../proteinpaint/SequenceReadWrapper";
+import { DemoUtil } from "./DemoUtil";
+
+const BamDownloadApp: FC = () => {
+  const isDemoMode = useIsDemoApp();
+
+  return (
+    <>
+      {isDemoMode ? (
+        <DemoUtil text="Demo mode is not available for this app" />
+      ) : (
+        <SequenceReadWrapper stream2download={true} />
+      )}
+    </>
+  );
+};
+
+export default BamDownloadApp;

--- a/packages/portal-proto/src/features/proteinpaint/BamDownloadWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/BamDownloadWrapper.tsx
@@ -16,7 +16,7 @@ interface PpProps {
   basepath?: string;
 }
 
-export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
+export const BamDownloadWrapper: FC<PpProps> = (props: PpProps) => {
   const filter0 = buildCohortGqlOperator(
     useCoreSelector(selectCurrentCohortFilters),
   );
@@ -100,6 +100,7 @@ interface BamArg {
   host: string;
   gdcbamslice: GdcBamSlice;
   filter0: FilterSet;
+  stream2download?: boolean;
 }
 
 type GdcBamSlice = {
@@ -113,7 +114,6 @@ function getBamTrack(props: PpProps, filter0: any) {
     host: props.basepath || (basepath as string),
     gdcbamslice: {
       hideTokenInput: true,
-      stream2download: props.stream2download || false,
     },
     filter0,
   };

--- a/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
@@ -14,6 +14,7 @@ const basepath = PROTEINPAINT_API;
 
 interface PpProps {
   basepath?: string;
+  stream2download?: boolean;
 }
 
 export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
@@ -104,6 +105,7 @@ interface BamArg {
 
 type GdcBamSlice = {
   hideTokenInput: boolean;
+  stream2download?: boolean;
 };
 
 function getBamTrack(props: PpProps, filter0: any) {

--- a/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.unit.test.tsx
@@ -29,7 +29,10 @@ test("Sequence Read arguments - logged in", () => {
   expect(runpparg.nobox).toEqual(true);
   expect(runpparg.hide_dsHandles).toEqual(true);
   expect(runpparg.holder instanceof HTMLElement).toBe(true);
-  expect(runpparg.gdcbamslice).toEqual({ hideTokenInput: true });
+  expect(runpparg.gdcbamslice).toEqual({
+    hideTokenInput: true,
+    stream2download: false,
+  });
   expect(runpparg.filter0).toEqual({ test: 1 });
   expect(container.querySelector(".sjpp-wrapper-alert-div")).toHaveStyle(
     `display: none`,

--- a/packages/portal-proto/src/features/proteinpaint/sjpp-types.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/sjpp-types.tsx
@@ -44,3 +44,7 @@ export function getFilters(arg: SelectSamplesCallBackArg): FilterSet {
     },
   };
 }
+
+export type RxComponentCallbacks = {
+  [eventName: string]: () => void;
+};

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -162,6 +162,17 @@ export const REGISTERED_APPS = [
     optimizeRules: ["data format = BAM"],
   },
   {
+    name: "BAM Download Prototype",
+    icon: <SequenceReadsIcon role="img" aria-label="Sequence Reads icon" />,
+    tags: ["sequenceAnalysis"],
+    hasDemo: false,
+    countsField: "sequenceReadCaseCount",
+    description: "Download a BAM slice.",
+    id: "BamDownloadApp",
+    noDataTooltip: "Current cohort does not have available BAMs for download.",
+    optimizeRules: ["data format = BAM"],
+  },
+  {
     name: "ProteinPaint",
     icon: (
       <ProteinPaintIcon


### PR DESCRIPTION
## Description

Updated the `proteinpaint-client` version to `2.31.1`. In order to be fully testable in qa-pink, the following are requied: 
- the `2.33.0-abc70d02a` tag in the ppgdc repo will also need to be deployed
- the updated `anno/msigdb/db_2023.2.Hs` data file will need to be [downloaded](https://proteinpaint.stjude.org/ppSupport/msigdb/db_2023.2.Hs) and saved to the mounted "tpdir"

Features:
- Created a BAM Download Prototype app/card in the ATF: The GDC BAM slicing UI supports new "download mode", will directly download BAM slice to client, including unmapped reads.
- Click matrix cell to launch gene summary and case summary page, click row label to launch gene summary page, click case id to launch case summary
- Highlight the row and column of the matrix cell when hovering over it, allow the users to select color for the highlighter
- Use the GDC gene expression API to request top variably expressed genes
- In mds3 track, new option allows to show/hide variant labels
- Support optional preDispatch, postRender and error callbacks from the embedded wrapper code: these are used to display and hide the embedder loading overlay

Fixes:
- Use a urlTemplates.gene.defaultText option to make a gene external link more intuitive
- Bug fix to allow mds3 track variant download to work again
- Bug fix that creating mds3 subtrack with long filter name breaks

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
