### PR TITLE
PEAR-1642 - Cohort Comparison - Clicking on "Open Venn Diagram" causes unexpected error and user is stuck in loop

### DIFF
--- a/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
+++ b/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
@@ -1,14 +1,20 @@
 import React, { Component, ReactNode } from "react";
-import { persistor } from "@gff/core";
+import { NextRouter, withRouter } from "next/router";
 import { Modal } from "@mantine/core";
-import DarkFunctionButton from "./StyledComponents/DarkFunctionButton";
-import ModalButtonContainer from "./StyledComponents/ModalButtonContainer";
+import { persistor } from "@gff/core";
+import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
+import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
+
+interface ClearStoreErrorBoundaryProps {
+  children: ReactNode;
+  router: NextRouter;
+}
 
 class ClearStoreErrorBoundary extends Component<
-  { children: ReactNode },
+  ClearStoreErrorBoundaryProps,
   { hasError: boolean }
 > {
-  constructor(props) {
+  constructor(props: ClearStoreErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
   }
@@ -19,28 +25,42 @@ class ClearStoreErrorBoundary extends Component<
 
   render() {
     if (this.state.hasError) {
-      return (
-        <Modal opened onClose={undefined} title="Unexpected Error">
-          <p className="py-2 px-4">
-            An unexpected error has occurred. Your saved cohorts are being
-            recovered, but your cart and sets may be lost.
-          </p>
-          <ModalButtonContainer data-testid="modal-button-container">
-            <DarkFunctionButton
-              onClick={async () => {
-                await persistor.purge();
-                location.reload();
-              }}
-            >
-              OK
-            </DarkFunctionButton>
-          </ModalButtonContainer>
-        </Modal>
-      );
+      const { encounteredError } = this.props.router.query;
+      // If the user has already encountered this error on the page and clearing the store didn't fix it,
+      // push them to the homepage
+      if (encounteredError) {
+        this.props.router.push("/");
+      } else {
+        return (
+          <Modal opened onClose={undefined} title="Unexpected Error">
+            <p className="py-2 px-4">
+              An unexpected error has occurred. Your saved cohorts are being
+              recovered, but your cart and sets may be lost.
+            </p>
+            <ModalButtonContainer data-testid="modal-button-container">
+              <DarkFunctionButton
+                onClick={async () => {
+                  await persistor.purge();
+                  this.props.router
+                    .replace({
+                      query: {
+                        ...this.props.router.query,
+                        encounteredError: true,
+                      },
+                    })
+                    .then(() => this.props.router.reload());
+                }}
+              >
+                OK
+              </DarkFunctionButton>
+            </ModalButtonContainer>
+          </Modal>
+        );
+      }
     }
 
     return this.props.children;
   }
 }
 
-export default ClearStoreErrorBoundary;
+export default withRouter(ClearStoreErrorBoundary);

--- a/packages/portal-proto/src/features/set-operations/CountButtonWrapperForSetsAndCases.tsx
+++ b/packages/portal-proto/src/features/set-operations/CountButtonWrapperForSetsAndCases.tsx
@@ -149,7 +149,7 @@ const CountButtonWrapperForSetsAndCases: React.FC<
     return (
       <CohortCreationButton
         numCases={count}
-        label={count.toLocaleString()}
+        label={count?.toLocaleString()}
         filtersCallback={createCohort}
       />
     );


### PR DESCRIPTION
## Description
\+ error boundary will redirect user to homepage if the store clear and refresh doesn't fix their issue rather than sticking them in an infinite loop 😅 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
