### PR TITLE
PEAR-1637 - Clinical Data Analysis - 508 Compliance issues

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/BoxPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/BoxPlot.tsx
@@ -77,6 +77,7 @@ interface BoxPlotProps {
     readonly q1: number;
     readonly q3: number;
   };
+  readonly field: string;
   readonly color: string;
   readonly height: number;
   readonly width: number;
@@ -92,6 +93,7 @@ interface BoxPlotProps {
 
 const BoxPlot: React.FC<BoxPlotProps> = ({
   data,
+  field,
   color,
   height,
   width,
@@ -118,9 +120,12 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       minDomain={{ x: 1, y: data.min }}
       maxDomain={{ x: 1, y: data.max }}
       containerComponent={
-        chartRef ? (
-          <VictoryContainer containerRef={(ref) => (chartRef.current = ref)} />
-        ) : undefined
+        <VictoryContainer
+          containerRef={
+            chartRef ? (ref) => (chartRef.current = ref) : undefined
+          }
+          aria-labelledby={`${field}-box-plot-label`}
+        />
       }
     >
       <VictoryLabel
@@ -129,6 +134,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         text={label}
         style={{ fontSize: 16, fontFamily: "Noto Sans" }}
         textAnchor="middle"
+        id={`${field}-box-plot-label`}
       />
       <VictoryAxis
         dependentAxis

--- a/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
@@ -267,6 +267,7 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
         <div className="w-full h-72 basis-1/3" ref={boxPlotRef}>
           <BoxPlot
             data={formattedData}
+            field={fieldName}
             color={color}
             width={boundingRectBox.width}
             height={boundingRectBox.height}
@@ -275,6 +276,7 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
         <div className="w-full h-72 basis-2/3" ref={qqPlotRef}>
           <QQPlot
             chartValues={formattedQQValues}
+            field={fieldName}
             isLoading={isLoading}
             color={color}
             width={boundingRectQQ.width}
@@ -284,6 +286,7 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
         <OffscreenWrapper>
           <BoxPlot
             data={formattedData}
+            field={fieldName}
             color={color}
             width={boundingRectBox.width}
             height={boundingRectBox.height}
@@ -295,6 +298,7 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
         <OffscreenWrapper>
           <QQPlot
             chartValues={formattedQQValues}
+            field={fieldName}
             isLoading={isLoading}
             color={color}
             chartRef={qqDownloadChartRef}

--- a/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
@@ -52,6 +52,7 @@ export const getQ1Q3Line = (
 
 interface QQPlotProps {
   readonly chartValues: { id: string; x: number; y: number }[];
+  readonly field: string;
   readonly isLoading: boolean;
   readonly color: string;
   readonly height: number;
@@ -68,6 +69,7 @@ interface QQPlotProps {
 
 const QQPlot: React.FC<QQPlotProps> = ({
   chartValues,
+  field,
   isLoading,
   height,
   width,
@@ -100,9 +102,12 @@ const QQPlot: React.FC<QQPlotProps> = ({
       minDomain={{ x: xMin, y: yMin < 0 ? yMin : 0 }}
       maxDomain={{ x: xMax, y: yMax }}
       containerComponent={
-        chartRef ? (
-          <VictoryContainer containerRef={(ref) => (chartRef.current = ref)} />
-        ) : undefined
+        <VictoryContainer
+          containerRef={
+            chartRef ? (ref) => (chartRef.current = ref) : undefined
+          }
+          aria-labelledby={`${field}-qq-plot-label`}
+        />
       }
     >
       <VictoryLabel
@@ -111,6 +116,7 @@ const QQPlot: React.FC<QQPlotProps> = ({
         text={label}
         style={{ fontSize: 16, fontFamily: "Noto Sans" }}
         textAnchor="middle"
+        id={`${field}-qq-plot-label`}
       />
       <VictoryAxis
         label="Theoretical Normal Quantiles"

--- a/packages/portal-proto/src/features/cDave/Controls.tsx
+++ b/packages/portal-proto/src/features/cDave/Controls.tsx
@@ -282,7 +282,6 @@ const Controls: React.FC<ControlPanelProps> = ({
       className={`${
         controlsExpanded ? "w-80 bg-base-max shadow-md overflow-y-scroll" : ""
       } pl-4 pt-2 flex flex-col min-h-[560px] max-h-screen`}
-      role="complementary"
     >
       <Tooltip
         withArrow

--- a/packages/portal-proto/src/features/cDave/Controls.tsx
+++ b/packages/portal-proto/src/features/cDave/Controls.tsx
@@ -282,6 +282,7 @@ const Controls: React.FC<ControlPanelProps> = ({
       className={`${
         controlsExpanded ? "w-80 bg-base-max shadow-md overflow-y-scroll" : ""
       } pl-4 pt-2 flex flex-col min-h-[560px] max-h-screen`}
+      role="complementary"
     >
       <Tooltip
         withArrow
@@ -317,6 +318,7 @@ const Controls: React.FC<ControlPanelProps> = ({
               <CloseIcon onClick={() => setSearchTerm("")}></CloseIcon>
             )
           }
+          aria-label="Search fields"
         />
         <p
           data-testid="text-fields-with-values"


### PR DESCRIPTION
## Description
All issues fixed except:
* `Certain ARIA roles must contain particular children | Customize Bins -> Dropdown menu`

It's an issue with the mantine Dropdown component's ARIA roles and applies to all places we are using it. I opened up an issue so hopefully they fix it on their side: https://github.com/mantinedev/mantine/issues/5372

## Checklist

- [N/A] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
