### PR TITLE
Clean up test console noise

### DIFF
--- a/packages/core/src/features/cart/updateCartSlice.ts
+++ b/packages/core/src/features/cart/updateCartSlice.ts
@@ -29,7 +29,6 @@ const slice = createSlice({
       return state;
     },
   },
-  extraReducers: {},
 });
 
 export const updateCartReducer = slice.reducer;

--- a/packages/core/src/features/cohort/cohortBuilderConfigSlice.ts
+++ b/packages/core/src/features/cohort/cohortBuilderConfigSlice.ts
@@ -48,7 +48,6 @@ const slice = createSlice({
     },
     resetCohortBuilderToDefault: () => initialState,
   },
-  extraReducers: {},
 });
 
 export const cohortBuilderConfigReducer = slice.reducer;

--- a/packages/core/src/features/genomic/genomicFilters.ts
+++ b/packages/core/src/features/genomic/genomicFilters.ts
@@ -47,7 +47,6 @@ const slice = createSlice({
       return { ...state, root: initialState.root };
     },
   },
-  extraReducers: {},
 });
 
 export const genomicFilterReducer = slice.reducer;

--- a/packages/core/src/features/sets/setsSlice.ts
+++ b/packages/core/src/features/sets/setsSlice.ts
@@ -67,7 +67,6 @@ const slice = createSlice({
       return state;
     },
   },
-  extraReducers: {},
 });
 
 export const setsReducer = slice.reducer;

--- a/packages/portal-proto/__mocks__/svg.ts
+++ b/packages/portal-proto/__mocks__/svg.ts
@@ -1,2 +1,2 @@
-export default "SvgrUrl";
+export default "svgr-url";
 export const ReactComponent = "div";

--- a/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.unit.test.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.unit.test.tsx
@@ -3,17 +3,16 @@ import * as router from "next/router";
 import * as core from "@gff/core";
 import ClinicalSurvivalPlot from "./ClinicalSurvivalPlot";
 
-const mockSurvivalImplementation = () =>
-  ({
-    data: {
-      overallStats: {
-        pValue: 0,
-      },
-      survivalData: {},
+const mockSurvivalValue = {
+  data: {
+    overallStats: {
+      pValue: 0,
     },
-    isLoading: false,
-    isError: false,
-  } as any);
+    survivalData: {},
+  },
+  isLoading: false,
+  isError: false,
+} as any;
 
 describe("ClinicalSurvivalPlot", () => {
   beforeEach(() => {
@@ -29,7 +28,7 @@ describe("ClinicalSurvivalPlot", () => {
   it("creates filters for categorical data", () => {
     const survivalQuerySpy = jest
       .spyOn(core, "useGetSurvivalPlotQuery")
-      .mockImplementation(mockSurvivalImplementation);
+      .mockReturnValue(mockSurvivalValue);
 
     render(
       <ClinicalSurvivalPlot
@@ -85,7 +84,7 @@ describe("ClinicalSurvivalPlot", () => {
       }));
     const survivalQuerySpy = jest
       .spyOn(core, "useGetSurvivalPlotQuery")
-      .mockImplementation(mockSurvivalImplementation);
+      .mockReturnValue(mockSurvivalValue);
 
     render(
       <ClinicalSurvivalPlot
@@ -161,7 +160,7 @@ describe("ClinicalSurvivalPlot", () => {
 
     const survivalQuerySpy = jest
       .spyOn(core, "useGetSurvivalPlotQuery")
-      .mockImplementation(mockSurvivalImplementation);
+      .mockReturnValue(mockSurvivalValue);
 
     render(
       <ClinicalSurvivalPlot
@@ -229,7 +228,7 @@ describe("ClinicalSurvivalPlot", () => {
   it("creates filters for custom binned data", () => {
     const survivalQuerySpy = jest
       .spyOn(core, "useGetSurvivalPlotQuery")
-      .mockImplementation(mockSurvivalImplementation);
+      .mockReturnValue(mockSurvivalValue);
 
     render(
       <ClinicalSurvivalPlot
@@ -273,7 +272,7 @@ describe("ClinicalSurvivalPlot", () => {
   it("creates filters for named from to", () => {
     const survivalQuerySpy = jest
       .spyOn(core, "useGetSurvivalPlotQuery")
-      .mockImplementation(mockSurvivalImplementation);
+      .mockReturnValue(mockSurvivalValue);
 
     render(
       <ClinicalSurvivalPlot
@@ -335,7 +334,7 @@ describe("ClinicalSurvivalPlot", () => {
   it("parses selected negative values", () => {
     const survivalQuerySpy = jest
       .spyOn(core, "useGetSurvivalPlotQuery")
-      .mockImplementation(mockSurvivalImplementation);
+      .mockReturnValue(mockSurvivalValue);
 
     render(
       <ClinicalSurvivalPlot

--- a/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.unit.test.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.unit.test.tsx
@@ -3,6 +3,18 @@ import * as router from "next/router";
 import * as core from "@gff/core";
 import ClinicalSurvivalPlot from "./ClinicalSurvivalPlot";
 
+const mockSurvivalImplementation = () =>
+  ({
+    data: {
+      overallStats: {
+        pValue: 0,
+      },
+      survivalData: {},
+    },
+    isLoading: false,
+    isError: false,
+  } as any);
+
 describe("ClinicalSurvivalPlot", () => {
   beforeEach(() => {
     jest.spyOn(router, "useRouter").mockImplementation(
@@ -15,7 +27,9 @@ describe("ClinicalSurvivalPlot", () => {
   });
 
   it("creates filters for categorical data", () => {
-    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+    const survivalQuerySpy = jest
+      .spyOn(core, "useGetSurvivalPlotQuery")
+      .mockImplementation(mockSurvivalImplementation);
 
     render(
       <ClinicalSurvivalPlot
@@ -69,7 +83,9 @@ describe("ClinicalSurvivalPlot", () => {
           },
         },
       }));
-    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+    const survivalQuerySpy = jest
+      .spyOn(core, "useGetSurvivalPlotQuery")
+      .mockImplementation(mockSurvivalImplementation);
 
     render(
       <ClinicalSurvivalPlot
@@ -143,7 +159,9 @@ describe("ClinicalSurvivalPlot", () => {
         } as any),
     );
 
-    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+    const survivalQuerySpy = jest
+      .spyOn(core, "useGetSurvivalPlotQuery")
+      .mockImplementation(mockSurvivalImplementation);
 
     render(
       <ClinicalSurvivalPlot
@@ -209,7 +227,9 @@ describe("ClinicalSurvivalPlot", () => {
   });
 
   it("creates filters for custom binned data", () => {
-    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+    const survivalQuerySpy = jest
+      .spyOn(core, "useGetSurvivalPlotQuery")
+      .mockImplementation(mockSurvivalImplementation);
 
     render(
       <ClinicalSurvivalPlot
@@ -251,7 +271,9 @@ describe("ClinicalSurvivalPlot", () => {
   });
 
   it("creates filters for named from to", () => {
-    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+    const survivalQuerySpy = jest
+      .spyOn(core, "useGetSurvivalPlotQuery")
+      .mockImplementation(mockSurvivalImplementation);
 
     render(
       <ClinicalSurvivalPlot
@@ -311,7 +333,9 @@ describe("ClinicalSurvivalPlot", () => {
   });
 
   it("parses selected negative values", () => {
-    const survivalQuerySpy = jest.spyOn(core, "useGetSurvivalPlotQuery");
+    const survivalQuerySpy = jest
+      .spyOn(core, "useGetSurvivalPlotQuery")
+      .mockImplementation(mockSurvivalImplementation);
 
     render(
       <ClinicalSurvivalPlot

--- a/packages/portal-proto/src/features/genomic/geneAndSSMFiltersSlice.ts
+++ b/packages/portal-proto/src/features/genomic/geneAndSSMFiltersSlice.ts
@@ -41,7 +41,6 @@ const slice = createSlice({
       return { mode: "and", root: initialState.root };
     },
   },
-  extraReducers: {},
 });
 
 export const geneFrequencyFiltersReducer = slice.reducer;

--- a/packages/portal-proto/src/features/layout/Header.unit.test.tsx
+++ b/packages/portal-proto/src/features/layout/Header.unit.test.tsx
@@ -35,6 +35,10 @@ describe("<Header />", () => {
       isUninitialized: false,
     });
 
+    jest.spyOn(core, "useQuickSearch").mockReturnValue({
+      data: { searchList: [], query: "" },
+    } as any);
+
     jest.spyOn(router, "useRouter").mockImplementation(
       () =>
         ({

--- a/packages/portal-proto/src/features/projectsCenter/projectCenterFiltersSlice.ts
+++ b/packages/portal-proto/src/features/projectsCenter/projectCenterFiltersSlice.ts
@@ -44,7 +44,6 @@ const slice = createSlice({
       return { filters: { mode: "and", root: {} } };
     },
   },
-  extraReducers: {},
 });
 
 export const projectCenterFiltersReducer = slice.reducer;

--- a/packages/portal-proto/src/features/repositoryApp/repositoryConfigSlice.ts
+++ b/packages/portal-proto/src/features/repositoryApp/repositoryConfigSlice.ts
@@ -28,7 +28,6 @@ const slice = createSlice({
     },
     resetToDefault: () => initialState,
   },
-  extraReducers: {},
 });
 
 export const repositoryConfigReducer = slice.reducer;

--- a/packages/portal-proto/src/features/repositoryApp/repositoryFiltersSlice.ts
+++ b/packages/portal-proto/src/features/repositoryApp/repositoryFiltersSlice.ts
@@ -44,7 +44,6 @@ const slice = createSlice({
       return { filters: { mode: "and", root: {} } };
     },
   },
-  extraReducers: {},
 });
 
 export const repositoryFiltersReducer = slice.reducer;


### PR DESCRIPTION
## Description
Cleans up warnings when running tests to make it easier to see failing test messages. Some were caused by unmocked requests which would have been easier to catch with less noise. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
Before:
![Screenshot 2023-12-06 at 9 19 59 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/dd4404c9-5c25-4f7c-8b15-39d52ea855a4)
![Screenshot 2023-12-06 at 9 20 41 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/b51e37bd-d8c3-44af-b8db-34fded50b963)
![Screenshot 2023-12-06 at 9 21 10 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/251bc7a2-6066-48a8-b8ea-a6886b1a38b8)

After (wow!):
![Screenshot 2023-12-06 at 9 23 31 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/af3d585e-ffa6-4e23-a3aa-83ad0c74d955)
