### PR TITLE
Pear 1575 v2 banners support

### DIFF
--- a/packages/core/src/features/bannerNotification/bannerNotificationSlice.ts
+++ b/packages/core/src/features/bannerNotification/bannerNotificationSlice.ts
@@ -62,7 +62,7 @@ const slice = createSlice({
       const newNotifications = action.payload
         .filter(
           (notification) =>
-            notification.components.includes("PORTAL") ||
+            notification.components.includes("PORTAL_V2") ||
             notification.components.includes("API") ||
             notification.components.includes("LOGIN"),
         )

--- a/packages/core/src/features/bannerNotification/bannerNotificationSlice.unit.test.ts
+++ b/packages/core/src/features/bannerNotification/bannerNotificationSlice.unit.test.ts
@@ -25,7 +25,7 @@ describe("banner notfication reducer", () => {
   test("adds new notifications", () => {
     const state = bannerReducer(
       [
-        { id: 1, dismissed: false, components: ["PORTAL"] },
+        { id: 1, dismissed: false, components: ["PORTAL_V2"] },
       ] as BannerNotification[],
       {
         type: fetchNotifications.fulfilled,
@@ -38,37 +38,43 @@ describe("banner notfication reducer", () => {
   test("excludes irrelevant notifications", () => {
     const state = bannerReducer(
       [
-        { id: 1, dismissed: false, components: ["PORTAL"] },
+        { id: 1, dismissed: false, components: ["PORTAL_V2"] },
       ] as BannerNotification[],
       {
         type: fetchNotifications.fulfilled,
         payload: [
-          { id: 1, dismissed: false, components: ["PORTAL"] },
+          { id: 1, dismissed: false, components: ["PORTAL_V2"] },
           { id: 2, components: ["OTHER"] },
+          { id: 3, components: ["PORTAL"] },
+          { id: 4, components: ["LEGACY_API"] },
+          { id: 5, components: ["LEGACY_PORTAL"] },
+          { id: 6, components: ["SUBMISSION"] },
+          { id: 7, components: ["SUBMISSION_API"] },
+          { id: 8, components: ["DOCUMENTATION"] },
         ],
       },
     );
     expect(state).toEqual([
-      { id: 1, dismissed: false, components: ["PORTAL"] },
+      { id: 1, dismissed: false, components: ["PORTAL_V2"] },
     ]);
   });
 
   test("keeps notifications as dismissed", () => {
     const state = bannerReducer(
       [
-        { id: 1, dismissed: true, components: ["PORTAL"] },
+        { id: 1, dismissed: true, components: ["PORTAL_V2"] },
       ] as BannerNotification[],
       {
         type: fetchNotifications.fulfilled,
         payload: [
           { id: 2, components: ["API"] },
-          { id: 1, components: ["PORTAL"] },
+          { id: 1, components: ["PORTAL_V2"] },
         ],
       },
     );
     expect(state).toEqual([
       { id: 2, dismissed: false, components: ["API"] },
-      { id: 1, dismissed: true, components: ["PORTAL"] },
+      { id: 1, dismissed: true, components: ["PORTAL_V2"] },
     ]);
   });
 });


### PR DESCRIPTION
## Description
Adds support for V2 notifications and disregards V1 notifications so we can have different notifications specific to each portal.

## Checklist

- [/] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

<img width="924" alt="Screenshot 2023-12-07 at 9 28 21 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/974a4e03-ad7d-432e-9e6f-b1124c9a3ed5">

based on:

```
{
    "notifications": {
    "data": [
      {
        "components": [
          "PORTAL_V2"
        ],
        "dismissible": false,
        "id": 0,
        "level": "INFO",
        "message": "This notification should show up for V2",
        "start_date": null,
        "end_date": null
      },
      {
        "components": [
          "API",
          "LOGIN"
        ],
        "dismissible": true,
        "id": 1,
        "level": "WARNING",
        "message": "This is for login and api and should show up",
        "start_date": null,
        "end_date": null
      },
      {
        "components": [
          "LEGACY_API",
          "SUBMISSION_API",
          "OTHER",
          "PORTAL",
          "AWG_PORTAL",
          "SUBMISSION",
          "LEGACY_PORTAL",
          "DOCUMENTATION"
        ],
        "dismissible": true,
        "id": 2,
        "level": "WARNING",
        "message": "This should not show up in V2",
        "start_date": null,
        "end_date": null
      }
    ]
  }
}

``` 