### PR TITLE
PEAR-1607 - Overall Survival Plot - PNG and SVG will not download 

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.tsx
@@ -8,7 +8,8 @@ import {
   useGetSurvivalPlotQuery,
 } from "@gff/core";
 import { useIsDemoApp } from "@/hooks/useIsDemoApp";
-import SurvivalPlot, {
+import {
+  ExternalDownloadStateSurvivalPlot,
   SurvivalPlotTypes,
 } from "@/features/charts/SurvivalPlot";
 import { convertDateToString } from "@/utils/date";
@@ -121,7 +122,7 @@ const ClinicalSurvivalPlot: React.FC<ClinicalSurvivalPlotProps> = ({
         ) : isError ? (
           <Alert color={"red"}>{"Something's gone wrong"}</Alert>
         ) : (
-          <SurvivalPlot
+          <ExternalDownloadStateSurvivalPlot
             data={data}
             height={150}
             title={""}

--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -329,7 +329,7 @@ export interface SurvivalPlotProps {
   readonly tableTooltip?: boolean;
 }
 
-const SurvivalPlot: React.FC<SurvivalPlotProps> = ({
+const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
   data,
   names = [],
   plotType = SurvivalPlotTypes.mutation,
@@ -659,4 +659,16 @@ const SurvivalPlot: React.FC<SurvivalPlotProps> = ({
   );
 };
 
+const SurvivalPlot = (props: SurvivalPlotProps) => {
+  const [downloadInProgress, setDownloadInProgress] = useState(false);
+  return (
+    <DownloadProgressContext.Provider
+      value={{ downloadInProgress, setDownloadInProgress }}
+    >
+      <ExternalDownloadStateSurvivalPlot {...props} />
+    </DownloadProgressContext.Provider>
+  );
+};
+
+export { ExternalDownloadStateSurvivalPlot };
 export default SurvivalPlot;


### PR DESCRIPTION
## Description
Fixes overall survival plot not downloading because they didn't have the download progress state defined

## Checklist

- [ ] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
