### PR TITLE
update the pp client version to 2.35.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6565,9 +6565,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.33.1.tgz",
-      "integrity": "sha512-Vr/Oo6h79Ss82iY93BVaKBV7VOuU64IE9gZgBOc06o5KSj8t1bWvTXzelR2E9urS0GW+k0JcYrXitJa5owdZNQ=="
+      "version": "2.35.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.35.1.tgz",
+      "integrity": "sha512-XnvnrUkaShNTQqH5j9BK9r/tS6sU3sCA3GMK16hscojXMsfycMxdtFAEe3Y7TNmOYNNnM158SQFNsUjTea5Utw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26950,7 +26950,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.33.1",
+        "@sjcrh/proteinpaint-client": "^2.35.1",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32235,9 +32235,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.33.1.tgz",
-      "integrity": "sha512-Vr/Oo6h79Ss82iY93BVaKBV7VOuU64IE9gZgBOc06o5KSj8t1bWvTXzelR2E9urS0GW+k0JcYrXitJa5owdZNQ=="
+      "version": "2.35.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.35.1.tgz",
+      "integrity": "sha512-XnvnrUkaShNTQqH5j9BK9r/tS6sU3sCA3GMK16hscojXMsfycMxdtFAEe3Y7TNmOYNNnM158SQFNsUjTea5Utw=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41909,7 +41909,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.33.1",
+        "@sjcrh/proteinpaint-client": "^2.35.1",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.33.1",
+    "@sjcrh/proteinpaint-client": "^2.35.1",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2324
Fixes https://gdc-ctds.atlassian.net/browse/SV-2312

Features:
- Click dendrogram to highlight sub-branches, zoom in and select cases underneath
- Change the topVariablyExpressedGenes route from a GDC-specific to general purpose

Fixes:
- Fix the toFixed error that randomly occurs when zoom on OncoMatrix
- Fix the processing of Gene Expression overrides
- GDC BAM slicing UI 
		- reject non-BAM files
		- now works with submitter or UUID of samples and aliquots, in addition to cases
		- use a common route to retrieve ssm by case, reducing code duplication
		- handle cases with no ssm
		- use a radio input in the BAM listing to force single-selection
		- force a unique input name in the BAM listing

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
