### PR TITLE
PEAR-1684: update GeneExpressionWrapper unit test to mock useGetCohortsByContextIdQuery

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.unit.test.tsx
@@ -23,6 +23,7 @@ jest.mock("@gff/core", () => ({
     resultsCreateCaseSet,
   ],
   useLazyGetCohortByIdQuery: jest.fn().mockReturnValue([jest.fn()]),
+  useGetCohortsByContextIdQuery: jest.fn().mockReturnValue([jest.fn()]),
 }));
 
 jest.mock("@/hooks/useIsDemoApp", () => ({


### PR DESCRIPTION
## Description
Updates GeneExpressionWrapper unit test to mock useGetCohortsByContextIdQuery
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
