### PR TITLE
PEAR-1433: Add a save cohort error modal

### DIFF
--- a/packages/core/src/features/modals/modalsSlice.ts
+++ b/packages/core/src/features/modals/modalsSlice.ts
@@ -19,6 +19,7 @@ export enum Modals {
   "LocalGeneSetModal" = "LocalGeneSetModal",
   "LocalMutationSetModal" = "LocalMutationSetModal",
   "ImportCohortModal" = "ImportCohortModal",
+  "SaveCohortErrorModal" = "SaveCohortErrorModal",
 }
 
 export interface ModalState {

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
@@ -21,6 +21,8 @@ import {
   useGetCohortsByContextIdQuery,
   useLazyGetCohortByIdQuery,
   discardCohortChanges,
+  showModal,
+  Modals,
 } from "@gff/core";
 import { SaveOrCreateEntityBody } from "./SaveOrCreateEntityModal";
 import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
@@ -55,6 +57,7 @@ const SaveCohortModal = ({
   const [enteredName, setEnteredName] = useState<string>();
   const [addCohort, { isLoading }] = useAddCohortMutation();
   const cohorts = useCoreSelector((state) => selectAvailableCohorts(state));
+
   const {
     data: cohortsListData,
     isSuccess: cohortListSuccess,
@@ -190,7 +193,7 @@ const SaveCohortModal = ({
         ) {
           setShowReplaceCohort(true);
         } else {
-          coreDispatch(setCohortMessage(["error|saving|allId"]));
+          coreDispatch(showModal({ modal: Modals.SaveCohortErrorModal }));
         }
       });
   };

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { LoadingOverlay, Select, Loader, Tooltip } from "@mantine/core";
+import { LoadingOverlay, Select, Loader, Tooltip, Modal } from "@mantine/core";
 import { NextRouter, useRouter } from "next/router";
 import {
   MdAdd as AddIcon,
@@ -45,6 +45,7 @@ import {
   useCurrentCohortCounts,
   fetchCohortCaseCounts,
   selectHasUnsavedCohorts,
+  hideModal,
 } from "@gff/core";
 import { useCohortFacetFilters } from "./utils";
 import SaveCohortModal from "@/components/Modals/SaveCohortModal";
@@ -56,6 +57,8 @@ import { convertDateToString } from "src/utils/date";
 import ImportCohortModal from "./Modals/ImportCohortModal";
 import { CustomCohortSelectItem, UnsavedIcon } from "./CustomCohortSelectItem";
 import { DropdownWithIcon } from "@/components/DropdownWithIcon/DropdownWithIcon";
+import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
+import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
 
 const exportCohort = (
   caseIds: readonly Record<string, any>[],
@@ -384,6 +387,20 @@ const CohortManager: React.FC = () => {
           filters={filters}
           saveAs
         />
+      )}
+      {modal === Modals.SaveCohortErrorModal && (
+        <Modal
+          opened
+          onClose={() => coreDispatch(hideModal())}
+          title="Save Cohort Error"
+        >
+          <p className="py-2 px-4">There was a problem saving the cohort.</p>
+          <ModalButtonContainer data-testid="modal-button-container">
+            <DarkFunctionButton onClick={() => coreDispatch(hideModal())}>
+              OK
+            </DarkFunctionButton>
+          </ModalButtonContainer>
+        </Modal>
       )}
       {modal === Modals.ImportCohortModal && <ImportCohortModal />}
       {modal === Modals.GlobalCaseSetModal && (

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -365,7 +365,7 @@ const CohortManager: React.FC = () => {
                 coreDispatch(setCohort(cohort));
               })
               .catch(() =>
-                coreDispatch(setCohortMessage(["error|saving|allId"])),
+                coreDispatch(showModal({ modal: Modals.SaveCohortErrorModal })),
               );
           }}
         />


### PR DESCRIPTION
## Description
Added a new modal to be shown when there's a problem saving a cohort. I also got rid of the notification we were showing before after verifying it with @wteouchicago.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/e6775c89-8bc4-4a0f-9a90-947ffd3afb80

