### PR TITLE
PEAR-1703 fixes primary sites search tooltip in modal

### DIFF
--- a/packages/portal-proto/src/features/projects/PrimarySiteTable.tsx
+++ b/packages/portal-proto/src/features/projects/PrimarySiteTable.tsx
@@ -225,6 +225,7 @@ const PrimarySiteTable: React.FC<PrimarySiteTableProps> = ({
       }}
       showControls={true}
       handleChange={handleChange}
+      baseZIndex={300}
       getRowId={getRowId}
     />
   );


### PR DESCRIPTION
## Description
Small fix so that the search bar tooltip in the primary sites table shows up when projects page is viewed in modal.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1424" alt="Screenshot 2023-12-20 at 7 14 28 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/06319994-f04b-4616-bc0d-fe40a5c9ac28">
<img width="1664" alt="Screenshot 2023-12-20 at 7 14 48 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/9028df72-4f40-4776-a2b5-0e05c3fc9163">
