### PR TITLE
PEAR-1688 Save cohorts as dynamic

### DIFF
--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
@@ -109,7 +109,7 @@ const SaveCohortModal = ({
 
     const addBody = {
       name: newName,
-      type: "static",
+      type: "dynamic",
       filters:
         Object.keys(filters.root).length > 0
           ? buildCohortGqlOperator(filters)

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.unit.test.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.unit.test.tsx
@@ -148,7 +148,7 @@ describe("SaveCohortModal", () => {
     expect(mockMutation).toBeCalledWith({
       cohort: {
         name: "my new cohort",
-        type: "static",
+        type: "dynamic",
         filters: {
           op: "and",
           content: [

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -333,7 +333,7 @@ const CohortManager: React.FC = () => {
             const updateBody = {
               id: cohortId,
               name: cohortName,
-              type: "static",
+              type: "dynamic",
               filters:
                 Object.keys(filters.root).length > 0
                   ? buildCohortGqlOperator(filters)

--- a/packages/portal-proto/src/features/projectsCenter/ProjectsCohortButton.unit.test.tsx
+++ b/packages/portal-proto/src/features/projectsCenter/ProjectsCohortButton.unit.test.tsx
@@ -75,7 +75,7 @@ describe("<ProjectCohortButton />", () => {
             },
           ],
         },
-        type: "static",
+        type: "dynamic",
         name: "New Cohort",
       },
       delete_existing: false,


### PR DESCRIPTION
## Description
Changes cohorts from being saved as static to being saved as dynamic. 

Tested the following areas/situations (see screenshots for example responses after changes):
- saving cohorts for the first time
- subsequent saves of previously saved cohorts
- replacing preexisting saved cohorts
- cohorts saved via Save and Save-As button on cohort bar; cases and cDAVE tables, projects table, case-count buttons in tables, project summary page.

## Checklist

- [Edited tests] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
Some example responses after saving:

<img width="987" alt="Screenshot 2023-12-20 at 11 11 16 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/cbef0daa-e140-4926-835a-e6214f73a89d">

<img width="797" alt="Screenshot 2023-12-20 at 11 11 40 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/29588e1f-c223-4f75-baff-a8405bbc31f2">
