### PR TITLE
Update the proteinpaint-client version to 2.38.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.38.0.tgz",
-      "integrity": "sha512-a6xh6GVyk6ZnPsq/4OLNWHmwy7hsq6x5Z0zKewFrbqg2Tkt2gOxwujfv6BI970gyFU32zL+ZqFJJ53vjQ/R9PA=="
+      "version": "2.38.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.38.1.tgz",
+      "integrity": "sha512-FcsEKtPwUhsDRig8ecZT84vVbep0ZtJh7+VCXI1666wPzsdYyAFjlKtGIhJVE1o0dT7wn5xtLSCfGIQWWoA1Xg=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.38.0",
+        "@sjcrh/proteinpaint-client": "^2.38.1",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.38.0.tgz",
-      "integrity": "sha512-a6xh6GVyk6ZnPsq/4OLNWHmwy7hsq6x5Z0zKewFrbqg2Tkt2gOxwujfv6BI970gyFU32zL+ZqFJJ53vjQ/R9PA=="
+      "version": "2.38.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.38.1.tgz",
+      "integrity": "sha512-FcsEKtPwUhsDRig8ecZT84vVbep0ZtJh7+VCXI1666wPzsdYyAFjlKtGIhJVE1o0dT7wn5xtLSCfGIQWWoA1Xg=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.38.0",
+        "@sjcrh/proteinpaint-client": "^2.38.1",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.38.0",
+    "@sjcrh/proteinpaint-client": "^2.38.1",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -229,7 +229,7 @@ export const REGISTERED_APPS = [
       />
     ),
     tags: ["variantAnalysis", "cnv", "ssm"],
-    hasDemo: false,
+    hasDemo: true,
     description:
       "Visualize the top most variably expressed genes in your cohort.",
     id: "GeneExpression",


### PR DESCRIPTION
## Description

Features:
- Enable the demo mode in the Gene Expression card

Fixes:
- For hierCluster, nodejs always transform to zscore; use scaleLinear for improved heatmap rendering
- Fix the handling of multi-valued samples and group overlaps
- GDC gene exp clustering bug fix on querying data for dictionary variables and leads to speeding up


## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
