### PR TITLE
PEAR-1685: Add default {focused : true} default prop to Tooltip

### DIFF
--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -178,6 +178,9 @@ const PortalApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
                       "bg-base-min bg-opacity-90 text-base-max shadow-lg font-content font-medium text-sm",
                     arrow: "bg-base-min bg-opacity-90",
                   },
+                  events: {
+                    focused: true,
+                  },
                   withinPortal: true,
                   position: "bottom",
                 },


### PR DESCRIPTION
## Description

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot 2024-01-02 at 1 26 56 PM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/831fdbb4-dc1c-41e0-ad41-6558fd764abc)
