### PR TITLE
PEAR-1712 fixes og title typo for analysis center

### DIFF
--- a/packages/portal-proto/src/pages/analysis_page.tsx
+++ b/packages/portal-proto/src/pages/analysis_page.tsx
@@ -49,7 +49,7 @@ const SingleAppsPage: NextPage = () => {
         <title>GDC Analysis Center</title>
         <meta
           property="og:title"
-          content="GDC Analysis Centere"
+          content="GDC Analysis Center"
           key="gdc-analysis-center"
         />
       </Head>


### PR DESCRIPTION
## Description

- Fixes an og:title typo in "Analysis Center" to improve our engagement rates on social media.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="924" alt="Screenshot 2024-01-02 at 6 20 08 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/0171d7c9-0d80-4003-affb-ccd37eb21022">
