### PR TITLE
Qa 2122 test automation update 2.12.0 round 2

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/analysis_center/navigation.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/analysis_center/navigation.spec
@@ -12,5 +12,5 @@ tags: gdc-data-portal-v2, navigation, analysis-center
 * Navigate to "Analysis" from "Header" "section"
 * Wait for cohort bar case count loading spinner
 
-## Validate featured tools navigation
-* Validate featured tools navigation
+## Validate Core Tools Navigation
+* Validate Core Tools Navigation

--- a/holmes-py/specs/gdc_data_portal_v2/repository/add_a_file_filter.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/add_a_file_filter.spec
@@ -20,11 +20,12 @@ tags: regression, smoke
 * Verify that the following default filters are displayed in order
    |default_filters      |
    |---------------------|
+   |Experimental Strategy|
+   |Wgs Coverage         |
    |Data Category        |
    |Data Type            |
-   |Experimental Strategy|
-   |Workflow Type        |
    |Data Format          |
+   |Workflow Type        |
    |Platform             |
    |Access               |
 
@@ -38,10 +39,10 @@ tags: regression, smoke
 * Verify that the "Search for a property" text is displayed on "Add a Custom Filter" "modal"
 
 ## File properties on Add a Custom Filter modal
-* Verify that the "303 properties" text is displayed on "Add a Custom Filter" "modal"
+* Verify that the "302 properties" text is displayed on "Add a Custom Filter" "modal"
 
 ## File counts listed on Add a Custom Filter modal
-* Verify "303" items on Add a Custom Filter filter list
+* Verify "302" items on Add a Custom Filter filter list
 
 ## File filter list does not start with 'files.' on Add a Custom Filter modal
 * Verify file filter names do not start with "files."

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -12,11 +12,11 @@ class AnalysisCenterLocators:
     TEXT_DESCRIPTION_TOOL = lambda tool_name: f'[data-testid="{tool_name}-tool"] >> [data-testid="text-description-tool"]'
     TOOLTIP_ZERO_CASES_ON_TOOL_CARD = lambda tool_name: f'[data-testid="{tool_name}-tool"] [data-testid="text-case-count-tool"] svg'
 
-    FEATURED_TOOL_PROJECTS = 'button[aria-label="Navigate to Projects"]'
-    FEATURED_TOOL_COHORT_BUILDER = 'button[aria-label="Navigate to Cohort Builder"]'
-    FEATURED_TOOL_REPOSITORY = 'button[aria-label="Navigate to Repository"]'
+    FEATURED_TOOL_PROJECTS = '[aria-label="Navigate to Projects"]'
+    FEATURED_TOOL_COHORT_BUILDER = '[aria-label="Navigate to Cohort Builder"]'
+    FEATURED_TOOL_REPOSITORY = '[aria-label="Navigate to Repository"]'
 
-    ANALYSIS_CENTER_HEADER = 'a[data-testid="button-header-analysis"]'
+    ANALYSIS_CENTER_HEADER = '[data-testid="button-header-analysis"]'
 
 class AnalysisCenterPage(BasePage):
     def __init__(self, driver: Page, url:str) -> None:

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -12,9 +12,9 @@ class AnalysisCenterLocators:
     TEXT_DESCRIPTION_TOOL = lambda tool_name: f'[data-testid="{tool_name}-tool"] >> [data-testid="text-description-tool"]'
     TOOLTIP_ZERO_CASES_ON_TOOL_CARD = lambda tool_name: f'[data-testid="{tool_name}-tool"] [data-testid="text-case-count-tool"] svg'
 
-    FEATURED_TOOL_PROJECTS = '[aria-label="Navigate to Projects"]'
-    FEATURED_TOOL_COHORT_BUILDER = '[aria-label="Navigate to Cohort Builder"]'
-    FEATURED_TOOL_REPOSITORY = '[aria-label="Navigate to Repository"]'
+    CORE_TOOL_PROJECTS = '[data-testid="button-core-tools-Projects"]'
+    CORE_TOOL_COHORT_BUILDER = '[data-testid="button-core-tools-Cohort Builder"]'
+    CORE_TOOL_REPOSITORY = '[data-testid="button-core-tools-Repository"]'
 
     ANALYSIS_CENTER_HEADER = '[data-testid="button-header-analysis"]'
 
@@ -27,7 +27,7 @@ class AnalysisCenterPage(BasePage):
         self.driver.goto(self.URL)
 
     def is_analysis_center_page_present(self):
-        locator = AnalysisCenterLocators.FEATURED_TOOL_REPOSITORY
+        locator = AnalysisCenterLocators.CORE_TOOL_REPOSITORY
         return self.is_visible(locator)
 
     def navigate_to_app(self, app_name: str):
@@ -58,20 +58,20 @@ class AnalysisCenterPage(BasePage):
         is_tooltip_text_present = self.is_text_present(tooltip_text)
         return is_tooltip_text_present
 
-    def featured_tools_navigation_check(self):
+    def core_tools_navigation_check(self):
         # First element in the set: a featured tool navigate button
         # Second element in the set: an element to check if user landed on correct page
         nav_and_location = [
             (
-                AnalysisCenterLocators.FEATURED_TOOL_PROJECTS,
+                AnalysisCenterLocators.CORE_TOOL_PROJECTS,
                 HeaderSectionLocators.PROJECTS_WAIT_FOR_ELEMENT,
             ),
             (
-                AnalysisCenterLocators.FEATURED_TOOL_COHORT_BUILDER,
+                AnalysisCenterLocators.CORE_TOOL_COHORT_BUILDER,
                 HeaderSectionLocators.COHORT_BUILDER_WAIT_FOR_ELEMENT,
             ),
             (
-                AnalysisCenterLocators.FEATURED_TOOL_REPOSITORY,
+                AnalysisCenterLocators.CORE_TOOL_REPOSITORY,
                 HeaderSectionLocators.REPOSITORY_WAIT_FOR_ELEMENT,
             ),
         ]

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/header_section.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/header_section.py
@@ -6,10 +6,10 @@ class HeaderSectionLocators:
     BUTTON_IDENT = lambda button_name: f"[data-testid='button-header-{button_name}']"
 
     # These are all locators that only appear when the respective page has fully loaded
-    ANALYSIS_CENTER_WAIT_FOR_ELEMENT = "button[aria-label='Navigate to Clinical Data Analysis tool']"
+    ANALYSIS_CENTER_WAIT_FOR_ELEMENT = "[data-testid='Clinical Data Analysis-tool']"
     PROJECTS_WAIT_FOR_ELEMENT = "[data-testid='button-json-projects-table']"
-    COHORT_BUILDER_WAIT_FOR_ELEMENT = "button[data-testid='button-cohort-builder-general']"
-    REPOSITORY_WAIT_FOR_ELEMENT = "button[data-testid='button-json-files-table']"
+    COHORT_BUILDER_WAIT_FOR_ELEMENT = "[data-testid='button-cohort-builder-general']"
+    REPOSITORY_WAIT_FOR_ELEMENT = "[data-testid='button-json-files-table']"
     REPOSITORY_ADDITIONAL_WAIT_FOR_ELEMENT = "[data-testid='text-showing-count']"
     HOME_WAIT_FOR_ELEMENT = "[data-testid='homepage-live-statistics']"
     MANAGE_SETS_WAIT_FOR_ELEMENT = "[data-testid='button-create-set']"

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/repository_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/repository_page.py
@@ -90,14 +90,12 @@ class RepositoryPage(BasePage):
     def get_text_on_add_custom_filter_modal(self, text):
         result = None
         try:
-            result = self.get_text(
-                f"{RepositoryPageLocators.MODAL_ADD_CUSTOM_FILTER_IDENT} >> text='{text}'"
-            )
-        except Exception as exc:
-            result = self.get_text(
-                f"{RepositoryPageLocators.MODAL_ADD_CUSTOM_FILTER_IDENT}//*[contains(.,'{text}')]"
-            )
-        result = result.replace("\n", " ")
+            locator = f"{RepositoryPageLocators.MODAL_ADD_CUSTOM_FILTER_IDENT} >> text='{text}'"
+            self.wait_until_locator_is_visible(locator)
+            result = self.get_text(locator)
+            result = result.replace("\n", " ")
+        except:
+            return result
         return result
 
     def get_file_filter_list_count(self):

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/analysis_center_page_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/analysis_center_page_steps.py
@@ -9,9 +9,9 @@ def start_app():
     global APP
     APP = GDCDataPortalV2App(WebDriver.page)
 
-@step("Validate featured tools navigation")
+@step("Validate Core Tools Navigation")
 def navigation_bar_icon_check():
-    Result = APP.analysis_center_page.featured_tools_navigation_check()
+    Result = APP.analysis_center_page.core_tools_navigation_check()
     assert Result, f"FAILED: featured tools did not navigate correctly"
 
 @step("Validate analysis tool description <table>")

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -103,11 +103,7 @@ def verify_text_on_page(text, source, target_type):
         "Repository": {"app": APP.repository_page.get_title},
         "Add a Custom Filter": {"modal": APP.repository_page.get_text_on_add_custom_filter_modal},
     }
-    first_text = text.split(" ")[0]
-    try:
-        text_value = sources.get(source)[target_type](text)
-    except:
-        text_value = sources.get(source)[target_type](first_text)
+    text_value = sources.get(source)[target_type](text)
     assert (
         text == text_value
     ), f"Unexpected title detected: looking for {text}, but got {text_value}"

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -17,7 +17,7 @@ class GenericLocators:
     LOADING_SPINNER_TABLE = '[data-testid="loading-spinner-table"] >> nth=0'
 
     # This locator allows you to send in a specific case count and check if it is there
-    COHORT_BAR_CASE_COUNT = lambda case_count: f'[aria-label="expand or collapse container"] >> text="{case_count}"'
+    COHORT_BAR_CASE_COUNT = lambda case_count: f'[data-testid="expandcollapseButton"] >> text="{case_count}"'
     # This locator allows you to grab the case count text for further testing
     TEXT_COHORT_BAR_CASE_COUNT = f'[data-testid="expandcollapseButton"] >> span[class="pr-1 font-bold"]'
     CART_IDENT = '[data-testid="cartLink"]'


### PR DESCRIPTION
## Description
- Updated core tool navigation test
- Removed some aria-labels and replaced with data-testid locators
- Updated repository page filter test

Note: Some of the fixes only work with the ID updates found in https://github.com/NCI-GDC/gdc-frontend-framework/pull/891
