### PR TITLE
PEAR-1695 - 508 compliance, hide images not conveying content from screenreader

### DIFF
--- a/packages/portal-proto/src/components/Banner.tsx
+++ b/packages/portal-proto/src/components/Banner.tsx
@@ -73,7 +73,9 @@ const Banner: React.FC<BannerProps> = ({
         <div className="flex items-center pl-1">
           <Button
             onClick={() => dispatch(dismissNotification(id))}
-            rightIcon={<MdClose className={`${textColor[level]}`} />}
+            rightIcon={
+              <MdClose className={`${textColor[level]}`} aria-hidden="true" />
+            }
             styles={{
               root: {
                 background: "transparent",

--- a/packages/portal-proto/src/components/CollapsibleContainer.tsx
+++ b/packages/portal-proto/src/components/CollapsibleContainer.tsx
@@ -58,9 +58,9 @@ export const CollapsibleContainer = (
                   <div className="flex gap-1 items-center">
                     <>
                       {isCollapsed ? (
-                        <ExpandMoreIcon size="1.75em" />
+                        <ExpandMoreIcon size="1.75em" aria-hidden="true" />
                       ) : (
-                        <ExpandLessIcon size="1.75em" />
+                        <ExpandLessIcon size="1.75em" aria-hidden="true" />
                       )}
                     </>
 
@@ -73,9 +73,9 @@ export const CollapsibleContainer = (
                     </>
                   </div>
                 ) : isCollapsed ? (
-                  <ExpandMoreIcon size="1.75em" />
+                  <ExpandMoreIcon size="1.75em" aria-hidden="true" />
                 ) : (
-                  <ExpandLessIcon size="1.75em" />
+                  <ExpandLessIcon size="1.75em" aria-hidden="true" />
                 )}
               </button>
             </span>

--- a/packages/portal-proto/src/components/DropdownWithIcon/DropdownWithIcon.tsx
+++ b/packages/portal-proto/src/components/DropdownWithIcon/DropdownWithIcon.tsx
@@ -63,12 +63,19 @@ interface DropdownWithIconProps {
     tooltip
    */
   tooltip?: string;
+
+  /**
+   * aria-label for the button
+   */
+  buttonAriaLabel?: string;
 }
 
 export const DropdownWithIcon = ({
   disableTargetWidth,
   LeftIcon,
-  RightIcon = <Dropdown size="1.25em" aria-label="dropdown icon" />,
+  RightIcon = (
+    <Dropdown size="1.25em" aria-hidden="true" data-testid="dropdown icon" />
+  ),
   TargetButtonChildren,
   targetButtonDisabled,
   dropdownElements,
@@ -79,6 +86,7 @@ export const DropdownWithIcon = ({
   zIndex = undefined,
   customDataTestId = undefined,
   tooltip = undefined,
+  buttonAriaLabel = undefined,
 }: DropdownWithIconProps): JSX.Element => {
   return (
     <Menu
@@ -99,6 +107,7 @@ export const DropdownWithIcon = ({
             rightIcon: "border-l pl-1 -mr-2",
             root: fullHeight ? "h-full" : undefined,
           }}
+          aria-label={buttonAriaLabel}
         >
           <div>
             {tooltip?.length && !targetButtonDisabled ? (

--- a/packages/portal-proto/src/components/DropdownWithIcon/DropdownWithIcon.unit.test.tsx
+++ b/packages/portal-proto/src/components/DropdownWithIcon/DropdownWithIcon.unit.test.tsx
@@ -4,14 +4,14 @@ import userEvent from "@testing-library/user-event";
 
 describe("<DropdownWithIcon />", () => {
   it("if right icon is NOT provided, dropdown icon should be a default", () => {
-    const { getByLabelText } = render(
+    const { getByTestId } = render(
       <DropdownWithIcon
         TargetButtonChildren="test"
         dropdownElements={[{ title: "test" }, { title: "test2" }]}
       />,
     );
 
-    expect(getByLabelText("dropdown icon")).toBeDefined();
+    expect(getByTestId("dropdown icon")).toBeDefined();
   });
 
   it("if right icon is provided, provided icon should render", () => {

--- a/packages/portal-proto/src/components/LoginButton.tsx
+++ b/packages/portal-proto/src/components/LoginButton.tsx
@@ -35,6 +35,7 @@ export const LoginButton = ({
             className="m-0"
             size="24px"
             color={theme.extend.colors["nci-blue"].darkest}
+            aria-hidden="true"
           />
         ) : undefined
       }

--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -136,7 +136,13 @@ export const QuickSearch = (): JSX.Element => {
 
   return (
     <Select
-      icon={loading ? <Loader size={24} /> : <SearchIcon size={24} />}
+      icon={
+        loading ? (
+          <Loader size={24} />
+        ) : (
+          <SearchIcon size={24} aria-hidden="true" />
+        )
+      }
       placeholder="e.g. BRAF, Breast, TCGA-BLCA, TCGA-A5-A0G2"
       data-testid="textbox-quick-search-bar"
       aria-label="Quick Search Input"

--- a/packages/portal-proto/src/components/SearchInput.tsx
+++ b/packages/portal-proto/src/components/SearchInput.tsx
@@ -234,7 +234,7 @@ export const SearchInput: React.FC = () => {
             ? null
             : `${comboboxItemId}${activedescendant}`
         }
-        icon={<SearchIcon size={24} />}
+        icon={<SearchIcon size={24} aria-hidden="true" />}
         placeholder="Search"
         data-testid="textbox-search-bar"
         aria-label="App Search Input"

--- a/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
+++ b/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
@@ -97,7 +97,11 @@ function ColumnOrdering<TData>({
               showColumnMenu && "border-2 border-primary"
             } hover:bg-primary hover:text-base-max`}
           >
-            {!showColumnMenu ? <BsList size="1.5rem" /> : <BsX size="2rem" />}
+            {!showColumnMenu ? (
+              <BsList size="1.5rem" aria-hidden="true" />
+            ) : (
+              <BsX size="2rem" aria-hidden="true" />
+            )}
           </ActionIcon>
         </span>
       </Tooltip>

--- a/packages/portal-proto/src/components/WarningBanner.tsx
+++ b/packages/portal-proto/src/components/WarningBanner.tsx
@@ -3,7 +3,11 @@ import { FaExclamationCircle } from "react-icons/fa";
 export const WarningBanner = ({ text }: { text: string }): JSX.Element => (
   <div className="flex h-12 border border-warningColor">
     <div className="flex h-full w-12 bg-warningColor justify-center items-center">
-      <FaExclamationCircle color="white" className="h-6 w-6" />
+      <FaExclamationCircle
+        color="white"
+        className="h-6 w-6"
+        aria-label="Warning"
+      />
     </div>
     <div className="bg-[#FFAD0D33] h-full w-full flex items-center pl-4">
       <span data-testid="text-warning-banner" className="text-sm">

--- a/packages/portal-proto/src/features/biospecimen/Biospecimen.tsx
+++ b/packages/portal-proto/src/features/biospecimen/Biospecimen.tsx
@@ -181,12 +181,12 @@ export const Biospecimen = ({
             dropdownElements={[
               {
                 title: "TSV",
-                icon: <DownloadIcon size={16} aria-label="download icon" />,
+                icon: <DownloadIcon size={16} aria-hidden="true" />,
                 onClick: handleBiospeciemenTSVDownload,
               },
               {
                 title: "JSON",
-                icon: <DownloadIcon size={16} aria-label="download icon" />,
+                icon: <DownloadIcon size={16} aria-hidden="true" />,
                 onClick: handleBiospeciemenJSONDownload,
               },
             ]}
@@ -197,7 +197,7 @@ export const Biospecimen = ({
               biospecimenDownloadActive ? (
                 <Loader size={20} />
               ) : (
-                <DownloadIcon size="1rem" aria-label="download icon" />
+                <DownloadIcon size="1rem" aria-hidden="true" />
               )
             }
             zIndex={5}

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
@@ -86,7 +86,7 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
             role="button"
             aria-label={`Select ${fieldName} histogram plot`}
           >
-            <BarChartIcon size={20} />
+            <BarChartIcon size={20} aria-hidden="true" />
           </div>
         </Tooltip>
       ),
@@ -100,7 +100,7 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
             role={"button"}
             aria-label={`Select ${fieldName} survival plot`}
           >
-            <SurvivalChartIcon size={20} />
+            <SurvivalChartIcon size={20} aria-hidden="true" />
           </div>
         </Tooltip>
       ),
@@ -117,7 +117,7 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
             role="button"
             aria-label={`Select ${fieldName} Box/QQ Plot`}
           >
-            <BoxPlotIcon size={20} className={"rotate-90"} />
+            <BoxPlotIcon size={20} className={"rotate-90"} aria-hidden="true" />
           </div>
         </Tooltip>
       ),
@@ -163,7 +163,7 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
               className="border-primary text-primary-content"
               aria-label={`Remove ${fieldName} card`}
             >
-              <CloseIcon className="text-primary" />
+              <CloseIcon className="text-primary" aria-hidden="true" />
             </ActionIcon>
           </Tooltip>
         </div>

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveTable.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveTable.tsx
@@ -185,7 +185,7 @@ const CDaveTable: React.FC<CDaveTableProps> = ({
                                 ])
                           }
                         >
-                          <SurvivalChartIcon />
+                          <SurvivalChartIcon aria-hidden="true" />
                         </ActionIcon>
                       </div>
                     </Tooltip>

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CardControls.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CardControls.tsx
@@ -119,7 +119,7 @@ const CardControls: React.FC<CardControlsProps> = ({
         <div className="flex items-end">
           <DropdownWithIcon
             customDataTestId="button-customize-bins"
-            RightIcon={<DownIcon size={20} />}
+            RightIcon={<DownIcon size={20} aria-hidden="true" />}
             TargetButtonChildren={"Customize Bins"}
             disableTargetWidth={true}
             dropdownElements={[

--- a/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
+++ b/packages/portal-proto/src/features/cDave/CategoricalBinningModal.tsx
@@ -218,7 +218,7 @@ const CategoricalBinningModal: React.FC<CategoricalBinningModalProps> = ({
                     : selectedValues?.[k],
                 ).length < 2
               }
-              leftIcon={<GroupIcon />}
+              leftIcon={<GroupIcon aria-hidden="true" />}
             >
               Group
             </FunctionButton>
@@ -241,7 +241,7 @@ const CategoricalBinningModal: React.FC<CategoricalBinningModalProps> = ({
                     ),
                 )
               }
-              leftIcon={<UngroupIcon />}
+              leftIcon={<UngroupIcon aria-hidden="true" />}
             >
               Ungroup
             </FunctionButton>
@@ -249,7 +249,7 @@ const CategoricalBinningModal: React.FC<CategoricalBinningModalProps> = ({
               data-testid="button-custom-bins-hide-values"
               onClick={hideValues}
               disabled={Object.keys(selectedValues).length === 0}
-              leftIcon={<HideIcon />}
+              leftIcon={<HideIcon aria-hidden="true" />}
             >
               Hide
             </FunctionButton>
@@ -307,7 +307,7 @@ const CategoricalBinningModal: React.FC<CategoricalBinningModalProps> = ({
               );
               setSelectedHiddenValues({});
             }}
-            leftIcon={<ShowIcon />}
+            leftIcon={<ShowIcon aria-hidden="true" />}
           >
             Show
           </FunctionButton>

--- a/packages/portal-proto/src/features/cDave/ContinuousBinningModal/ContinuousBinningModal.tsx
+++ b/packages/portal-proto/src/features/cDave/ContinuousBinningModal/ContinuousBinningModal.tsx
@@ -468,7 +468,7 @@ const ContinuousBinningModal: React.FC<ContinuousBinningModalProps> = ({
                     {idx === rangeForm.values.ranges.length - 1 ? (
                       <FunctionButton
                         data-testid="button-range-add"
-                        leftIcon={<PlusIcon />}
+                        leftIcon={<PlusIcon aria-hidden="true" />}
                         onClick={() => {
                           const result = rangeForm.validate();
                           if (!result.hasErrors) {

--- a/packages/portal-proto/src/features/cDave/Controls.tsx
+++ b/packages/portal-proto/src/features/cDave/Controls.tsx
@@ -87,7 +87,12 @@ const ControlGroup: React.FC<ControlGroupProps> = ({
         aria-controls={`cdave-control-group-${name}`}
         aria-expanded={groupOpen}
       >
-        {groupOpen ? <DownIcon /> : <RightIcon />} {name}
+        {groupOpen ? (
+          <DownIcon aria-hidden="true" />
+        ) : (
+          <RightIcon aria-hidden="true" />
+        )}{" "}
+        {name}
       </span>
       <Collapse in={groupOpen} id={`cdave-control-group-${name}`}>
         <div className="flex flex-col">
@@ -296,7 +301,11 @@ const Controls: React.FC<ControlPanelProps> = ({
           aria-expanded={controlsExpanded}
           className="text-base"
         >
-          {controlsExpanded ? <DoubleLeftIcon /> : <DoubleRightIcon />}
+          {controlsExpanded ? (
+            <DoubleLeftIcon aria-hidden="true" />
+          ) : (
+            <DoubleRightIcon aria-hidden="true" />
+          )}
         </ActionIcon>
       </Tooltip>
       <div
@@ -314,7 +323,12 @@ const Controls: React.FC<ControlPanelProps> = ({
           }
           rightSection={
             searchTerm && (
-              <CloseIcon onClick={() => setSearchTerm("")}></CloseIcon>
+              <ActionIcon
+                onClick={() => setSearchTerm("")}
+                aria-label="Clear search"
+              >
+                <CloseIcon aria-hidden="true" />
+              </ActionIcon>
             )
           }
           aria-label="Search fields"

--- a/packages/portal-proto/src/features/cDave/DownloadAllButton.tsx
+++ b/packages/portal-proto/src/features/cDave/DownloadAllButton.tsx
@@ -25,7 +25,7 @@ const DownloadAllButton: React.FC = () => {
         { title: "PNG", onClick: downloadAllPng },
       ]}
       TargetButtonChildren={"Download All Images"}
-      LeftIcon={<DownloadIcon />}
+      LeftIcon={<DownloadIcon aria-hidden="true" />}
     />
   );
 };

--- a/packages/portal-proto/src/features/cart/Cart.tsx
+++ b/packages/portal-proto/src/features/cart/Cart.tsx
@@ -74,7 +74,11 @@ const Cart: React.FC = () => {
           } flex border border-cartDarkerOrange text-secondary-contrast-lighter`}
         >
           <div className="flex w-12 bg-cartDarkerOrange justify-center p-2">
-            <FaExclamationCircle color="white" className="h-6 w-6" />
+            <FaExclamationCircle
+              color="white"
+              className="h-6 w-6"
+              aria-label="Warning"
+            />
           </div>
           <div
             className={`bg-cartLighterOrange w-full h-full pl-4 ${

--- a/packages/portal-proto/src/features/cart/CartHeader.tsx
+++ b/packages/portal-proto/src/features/cart/CartHeader.tsx
@@ -141,9 +141,13 @@ const CartHeader: React.FC<CartHeaderProps> = ({
                 rightIcon: "border-l pl-1 -mr-2",
               }}
               leftIcon={
-                downloadActive ? <Loader size={15} /> : <DownloadIcon />
+                downloadActive ? (
+                  <Loader size={15} />
+                ) : (
+                  <DownloadIcon aria-hidden="true" />
+                )
               }
-              rightIcon={<DropdownIcon size={20} />}
+              rightIcon={<DropdownIcon size={20} aria-hidden="true" />}
             >
               Download Cart
             </Button>
@@ -182,9 +186,13 @@ const CartHeader: React.FC<CartHeaderProps> = ({
                 rightIcon: "border-l pl-1 -mr-2",
               }}
               leftIcon={
-                downloadActive ? <Loader size={15} /> : <DownloadIcon />
+                downloadActive ? (
+                  <Loader size={15} />
+                ) : (
+                  <DownloadIcon aria-hidden="true" />
+                )
               }
-              rightIcon={<DropdownIcon size={20} />}
+              rightIcon={<DropdownIcon size={20} aria-hidden="true" />}
             >
               Download Associated Data
             </Button>
@@ -443,8 +451,8 @@ const CartHeader: React.FC<CartHeaderProps> = ({
         <Menu>
           <Menu.Target>
             <Button
-              leftIcon={<TrashIcon />}
-              rightIcon={<DropdownIcon size={20} />}
+              leftIcon={<TrashIcon aria-hidden="true" />}
+              rightIcon={<DropdownIcon size={20} aria-hidden="true" />}
               classNames={{
                 root: "bg-nci-red-darker font-medium text-base-max", //TODO: find good color theme for this
                 rightIcon: "border-l pl-1 -mr-2",
@@ -468,15 +476,16 @@ const CartHeader: React.FC<CartHeaderProps> = ({
         </Menu>
 
         <h1 className="uppercase ml-auto mr-4 flex items-center truncate text-2xl">
-          Total of <FileIcon size={25} className="ml-2 mr-1" />{" "}
+          Total of{" "}
+          <FileIcon size={25} className="ml-2 mr-1" aria-hidden="true" />{" "}
           <b className="mr-1">{summaryData.total_doc_count.toLocaleString()}</b>{" "}
           {summaryData.total_doc_count === 1 ? "File" : "Files"}
-          <PersonIcon size={25} className="ml-2 mr-1" />{" "}
+          <PersonIcon size={25} className="ml-2 mr-1" aria-hidden="true" />{" "}
           <b className="mr-1">
             {summaryData.total_case_count.toLocaleString()}
           </b>{" "}
           {summaryData.total_case_count === 1 ? "Case" : "Cases"}{" "}
-          <SaveIcon size={25} className="ml-2 mr-1" />{" "}
+          <SaveIcon size={25} className="ml-2 mr-1" aria-hidden="true" />{" "}
           {fileSize(summaryData.total_file_size)}
         </h1>
       </div>

--- a/packages/portal-proto/src/features/cart/updateCart.tsx
+++ b/packages/portal-proto/src/features/cart/updateCart.tsx
@@ -39,7 +39,11 @@ interface UndoButtonProps {
 }
 const UndoButton: React.FC<UndoButtonProps> = ({ action }: UndoButtonProps) => {
   return (
-    <Button variant={"white"} onClick={action} leftIcon={<UndoIcon />}>
+    <Button
+      variant={"white"}
+      onClick={action}
+      leftIcon={<UndoIcon aria-hidden="true" />}
+    >
       <span className="underline">Undo</span>
     </Button>
   );

--- a/packages/portal-proto/src/features/cases/CaseView.tsx
+++ b/packages/portal-proto/src/features/cases/CaseView.tsx
@@ -361,7 +361,7 @@ export const CaseView: React.FC<CaseViewProps> = ({
         headerTitle={headerTitle}
         leftElement={
           <Button
-            leftIcon={<FaShoppingCart />}
+            leftIcon={<FaShoppingCart aria-hidden="true" />}
             className="text-primary bg-base-max hover:bg-primary-darkest hover:text-base-max"
             onClick={() =>
               isAllFilesInCart

--- a/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
@@ -415,7 +415,7 @@ export const ContextualCasesView: React.FC = () => {
                     {pickedCases.length}
                   </CountsIcon>
                 ) : (
-                  <DownloadIcon size="1rem" aria-label="Biospecimen dropdown" />
+                  <DownloadIcon size="1rem" aria-hidden="true" />
                 )
               }
             />
@@ -444,7 +444,7 @@ export const ContextualCasesView: React.FC = () => {
                     {pickedCases.length}
                   </CountsIcon>
                 ) : (
-                  <DownloadIcon size="1rem" aria-label="Clinical dropdown" />
+                  <DownloadIcon size="1rem" aria-hidden="true" />
                 )
               }
             />

--- a/packages/portal-proto/src/features/cases/CasesView/utils.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/utils.tsx
@@ -112,6 +112,7 @@ export const useGenerateCasesTableColumns = ({
                       className={
                         isAllFilesInCart && "text-primary-contrast-darkest"
                       }
+                      aria-hidden="true"
                     />
                   }
                   rightIcon={
@@ -120,6 +121,7 @@ export const useGenerateCasesTableColumns = ({
                         isAllFilesInCart && "text-primary-contrast-darkest"
                       }
                       size={18}
+                      aria-hidden="true"
                     />
                   }
                   variant="outline"

--- a/packages/portal-proto/src/features/cases/ClinicalSummary/ClinicalSummary.tsx
+++ b/packages/portal-proto/src/features/cases/ClinicalSummary/ClinicalSummary.tsx
@@ -143,12 +143,12 @@ export const ClinicalSummary = ({
         dropdownElements={[
           {
             title: "TSV",
-            icon: <DownloadIcon size={16} aria-label="download icon" />,
+            icon: <DownloadIcon size={16} aria-hidden="true" />,
             onClick: handleClinicalTSVDownload,
           },
           {
             title: "JSON",
-            icon: <DownloadIcon size={16} aria-label="download icon" />,
+            icon: <DownloadIcon size={16} aria-hidden="true" />,
             onClick: handleClinicalJSONDownload,
           },
         ]}
@@ -159,7 +159,7 @@ export const ClinicalSummary = ({
           clinicalDownloadActive ? (
             <Loader size={20} />
           ) : (
-            <DownloadIcon size="1rem" aria-label="download icon" />
+            <DownloadIcon size="1rem" aria-hidden="true" />
           )
         }
       />

--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -505,12 +505,12 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
               <Tooltip label="Download Survival Plot data or image">
                 <DownloadButton
                   data-testid="button-download-survival-plot"
-                  aria-label="Download button with an icon"
+                  aria-label="Download Survival Plot data or image"
                 >
                   {downloadInProgress ? (
                     <Loader size={16} />
                   ) : (
-                    <DownloadIcon size="1.25em" />
+                    <DownloadIcon size="1.25em" aria-hidden="true" />
                   )}
                 </DownloadButton>
               </Tooltip>
@@ -548,9 +548,9 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
             <DownloadButton
               onClick={() => setXDomain(undefined)}
               data-testid="button-reset-survival-plot"
-              aria-label="reset button with an icon"
+              aria-label="Reset Survival Plot Zoom"
             >
-              <ResetIcon size="1.15rem"></ResetIcon>
+              <ResetIcon size="1.15rem" aria-hidden="true"></ResetIcon>
             </DownloadButton>
           </Tooltip>
         </div>

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -443,8 +443,9 @@ const CohortManager: React.FC = () => {
                   }}
                   disabled={!cohortModified}
                   $isDiscard={true}
+                  aria-label="Discard cohort changes"
                 >
-                  <DiscardIcon aria-label="discard cohort changes" />
+                  <DiscardIcon aria-hidden="true" />
                 </CohortGroupButton>
               </span>
             </Tooltip>
@@ -514,13 +515,14 @@ const CohortManager: React.FC = () => {
                   LeftIcon={
                     <SaveIcon
                       size="1.5em"
-                      aria-label="Save cohort"
                       className="-mr-2.5"
+                      aria-hidden="true"
                     />
                   }
                   TargetButtonChildren=""
                   fullHeight
                   disableTargetWidth
+                  buttonAriaLabel="Save cohort"
                 />
               </span>
             </Tooltip>
@@ -537,8 +539,9 @@ const CohortManager: React.FC = () => {
                 onClick={() => coreDispatch(addNewDefaultUnsavedCohort())}
                 data-testid="addButton"
                 disabled={hasUnsavedCohorts}
+                aria-label="Add cohort"
               >
-                <AddIcon size="1.5em" aria-label="Add cohort" />
+                <AddIcon size="1.5em" aria-hidden="true" />
               </CohortGroupButton>
             </Tooltip>
             <Tooltip label="Delete Cohort" position="bottom" withArrow>
@@ -547,8 +550,9 @@ const CohortManager: React.FC = () => {
                 onClick={() => {
                   setShowDelete(true);
                 }}
+                aria-label="Delete cohort"
               >
-                <DeleteIcon size="1.5em" aria-label="Delete cohort" />
+                <DeleteIcon size="1.5em" aria-hidden="true" />
               </CohortGroupButton>
             </Tooltip>
             <Tooltip label="Import New Cohort" position="bottom" withArrow>
@@ -557,8 +561,9 @@ const CohortManager: React.FC = () => {
                 onClick={() =>
                   coreDispatch(showModal({ modal: Modals.ImportCohortModal }))
                 }
+                aria-label="Upload cohort"
               >
-                <UploadIcon size="1.5em" aria-label="Upload cohort" />
+                <UploadIcon size="1.5em" aria-hidden="true" />
               </CohortGroupButton>
             </Tooltip>
 
@@ -574,11 +579,12 @@ const CohortManager: React.FC = () => {
                       exportCohort(caseIds, cohortName);
                     }
                   }}
+                  aria-label="Download cohort"
                 >
                   {exportCohortPending ? (
                     <Loader />
                   ) : (
-                    <DownloadIcon size="1.5em" aria-label="Download cohort" />
+                    <DownloadIcon size="1.5em" aria-hidden="true" />
                   )}
                 </CohortGroupButton>
               </span>

--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -287,9 +287,7 @@ const ContextBar = ({
               TargetButtonChildren={
                 <CohortCountButton countName="fileCount" label="Files" />
               }
-              LeftIcon={
-                <DownloadIcon size="1rem" aria-label="Files dropdown" />
-              }
+              LeftIcon={<DownloadIcon size="1rem" aria-hidden="true" />}
             />
 
             <DropdownWithIcon
@@ -317,12 +315,7 @@ const ContextBar = ({
                 },
               ]}
               TargetButtonChildren="Custom Filters"
-              LeftIcon={
-                <CohortFilterIcon
-                  size="1rem"
-                  aria-label="Custom cohort filters"
-                />
-              }
+              LeftIcon={<CohortFilterIcon size="1rem" aria-hidden="true" />}
               menuLabelText="Filter your cohort by:"
               menuLabelCustomClass="font-bold text-primary"
             />
@@ -349,10 +342,7 @@ const ContextBar = ({
                     biospecimenDownloadActive ? (
                       <Loader size={20} />
                     ) : (
-                      <DownloadIcon
-                        size="1rem"
-                        aria-label="Biospecimen dropdown"
-                      />
+                      <DownloadIcon size="1rem" aria-hidden="true" />
                     )
                   }
                 />
@@ -377,10 +367,7 @@ const ContextBar = ({
                     clinicalDownloadActive ? (
                       <Loader size={20} />
                     ) : (
-                      <DownloadIcon
-                        size="1rem"
-                        aria-label="Clinical dropdown"
-                      />
+                      <DownloadIcon size="1rem" aria-hidden="true" />
                     )
                   }
                 />

--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -390,7 +390,7 @@ const ContextBar = ({
               <Tabs.Tab
                 data-tour="cohort_summary_charts"
                 value="summary"
-                icon={<SummaryChartIcon />}
+                icon={<SummaryChartIcon aria-hidden="true" />}
               >
                 Summary View
               </Tabs.Tab>
@@ -398,7 +398,7 @@ const ContextBar = ({
               <Tabs.Tab
                 data-tour="cohort_summary_table"
                 value="table"
-                icon={<TableIcon />}
+                icon={<TableIcon aria-hidden="true" />}
               >
                 Table View
               </Tabs.Tab>

--- a/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
@@ -216,13 +216,13 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
                   >
                     {allQueryExpressionsCollapsed ? (
                       <>
-                        <LeftArrowIcon size={16} />
-                        <RightArrowIcon size={16} />
+                        <LeftArrowIcon size={16} aria-hidden="true" />
+                        <RightArrowIcon size={16} aria-hidden="true" />
                       </>
                     ) : (
                       <>
-                        <RightArrowIcon size={16} />
-                        <LeftArrowIcon size={16} />
+                        <RightArrowIcon size={16} aria-hidden="true" />
+                        <LeftArrowIcon size={16} aria-hidden="true" />
                       </>
                     )}
                   </button>
@@ -254,11 +254,11 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
                   >
                     {filtersSectionCollapsed ? (
                       <>
-                        <DownArrowIcon size={30} />
+                        <DownArrowIcon size={30} aria-hidden="true" />
                       </>
                     ) : (
                       <>
-                        <UpArrowIcon size={30} />
+                        <UpArrowIcon size={30} aria-hidden="true" />
                       </>
                     )}
                   </button>

--- a/packages/portal-proto/src/features/cohortBuilder/QueryRepresentation.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryRepresentation.tsx
@@ -48,7 +48,7 @@ const RemoveButton = ({ value }: { value: string }) => (
     variant="transparent"
     aria-label={`remove ${value}`}
   >
-    <ClearIcon size={10} />
+    <ClearIcon size={10} aria-hidden="true" />
   </ActionIcon>
 );
 const QueryRepresentationText = tw.div`
@@ -171,7 +171,11 @@ const IncludeExcludeQueryElement: React.FC<
         aria-label={expanded ? `collapse ${fieldName}` : `expand ${fieldName}`}
         aria-expanded={expanded}
       >
-        {expanded ? <LeftArrow /> : <RightArrow />}
+        {expanded ? (
+          <LeftArrow aria-hidden="true" />
+        ) : (
+          <RightArrow aria-hidden="true" />
+        )}
       </ActionIcon>
       <Divider
         orientation="vertical"
@@ -385,7 +389,7 @@ export const QueryElement = ({
         onClick={handleRemoveFilter}
         aria-label={`remove ${fieldNameToTitle(field)}`}
       >
-        <ClearIcon size="1.5em" className="px-1" />
+        <ClearIcon size="1.5em" className="px-1" aria-hidden="true" />
       </button>
     </QueryItemContainer>
   );

--- a/packages/portal-proto/src/features/cohortBuilder/StickyControl.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/StickyControl.tsx
@@ -22,14 +22,21 @@ const StickyControl = ({
       data-testid="button-cohort-bar-pin-unpin"
       className="bg-primary-darker hover:bg-primary-darkest h-12 w-12 grid place-items-center text-white rounded-md"
       onClick={() => handleIsSticky(!isSticky)}
-      aria-label="Toggle to pin or unpin cohort bar to top of Analysis Center"
+      aria-label={`Toggle to ${
+        isSticky ? "unpin" : "pin"
+      } cohort bar to top of Analysis Center`}
     >
       <>
         {/* Using CSS to hide/unhide is making the tooltip behave correctly */}
-        <StickyOnIcon size="24px" className={isSticky ? "visible" : "hidden"} />
+        <StickyOnIcon
+          size="24px"
+          className={isSticky ? "visible" : "hidden"}
+          aria-hidden="true"
+        />
         <StickyOffIcon
           size="24px"
           className={!isSticky ? "visible" : "hidden"}
+          aria-hidden="true"
         />
       </>
     </button>

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -287,7 +287,11 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
             {showSearch ? (
               <Tooltip label="Search values">
                 <FacetIconButton onClick={toggleSearch} aria-label="Search">
-                  <SearchIcon size="1.45em" className={header.iconStyle} />
+                  <SearchIcon
+                    size="1.45em"
+                    className={header.iconStyle}
+                    aria-hidden="true"
+                  />
                 </FacetIconButton>
               </Tooltip>
             ) : null}
@@ -298,7 +302,11 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
                   aria-pressed={!isFacetView}
                   aria-label="chart view"
                 >
-                  <FlipIcon size="1.45em" className={header.iconStyle} />
+                  <FlipIcon
+                    size="1.45em"
+                    className={header.iconStyle}
+                    aria-hidden="true"
+                  />
                 </FacetIconButton>
               </Tooltip>
             ) : null}
@@ -307,7 +315,11 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
                 onClick={() => clearFilters(field)}
                 aria-label="clear selection"
               >
-                <UndoIcon size="1.25em" className={header.iconStyle} />
+                <UndoIcon
+                  size="1.25em"
+                  className={header.iconStyle}
+                  aria-hidden="true"
+                />
               </FacetIconButton>
             </Tooltip>
             {dismissCallback ? (
@@ -319,7 +331,11 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
                   }}
                   aria-label="Remove the facet"
                 >
-                  <CloseIcon size="1.25em" className={header.iconStyle} />
+                  <CloseIcon
+                    size="1.25em"
+                    className={header.iconStyle}
+                    aria-hidden="true"
+                  />
                 </FacetIconButton>
               </Tooltip>
             ) : null}

--- a/packages/portal-proto/src/features/facets/FacetExpander.tsx
+++ b/packages/portal-proto/src/features/facets/FacetExpander.tsx
@@ -39,7 +39,12 @@ const FacetExpander: React.FC<FacetExpanderProps> = ({
           data-testid="plus-icon"
         >
           <div className="flex flex-row flex-nowrap items-center ">
-            <MoreIcon className="text-accent" key="show-more" size="1.5em" />
+            <MoreIcon
+              className="text-accent"
+              key="show-more"
+              size="1.5em"
+              aria-hidden="true"
+            />
             <ExpanderLabel>{remainingValues} more</ExpanderLabel>
           </div>
         </button>
@@ -54,6 +59,7 @@ const FacetExpander: React.FC<FacetExpanderProps> = ({
               key="show-less"
               size="1.5em"
               onClick={() => onShowChanged(!isGroupExpanded)}
+              aria-hidden="true"
             />
             <ExpanderLabel>show less</ExpanderLabel>
           </div>

--- a/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FacetSortPanel.tsx
@@ -85,7 +85,7 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
           setSort(sortObj);
           setSortingStatus(sortTypeToAriaDescription(sortObj, "Name", field));
         }}
-        rightIcon={<NameSortIcon size={nameIconSize} />}
+        rightIcon={<NameSortIcon size={nameIconSize} aria-hidden="true" />}
         aria-label="Sort name alphabetically"
       >
         Name
@@ -110,7 +110,7 @@ const FacetSortPanel: React.FC<FacetSortPanelProps> = ({
             sortTypeToAriaDescription(sortObj, valueLabel, field),
           );
         }}
-        rightIcon={<ValueSortIcon size={valueIconSize} />}
+        rightIcon={<ValueSortIcon size={valueIconSize} aria-hidden="true" />}
         aria-label={`Sort ${valueLabel} numerically`}
       >
         {valueLabel}

--- a/packages/portal-proto/src/features/files/BAMSlicingButton/index.tsx
+++ b/packages/portal-proto/src/features/files/BAMSlicingButton/index.tsx
@@ -23,7 +23,7 @@ export const BAMSlicingButton = ({
   return (
     <Button
       className="font-medium text-sm text-primary bg-base-max hover:bg-primary-darkest hover:text-primary-contrast-darker"
-      leftIcon={<FaCut />}
+      leftIcon={<FaCut aria-hidden="true" />}
       loading={isActive}
       variant="outline"
       onClick={() => {

--- a/packages/portal-proto/src/features/files/FileVersions.tsx
+++ b/packages/portal-proto/src/features/files/FileVersions.tsx
@@ -118,23 +118,17 @@ const FileVersions = ({
                   dropdownElements={[
                     {
                       title: "TSV",
-                      icon: (
-                        <DownloadIcon size={16} aria-label="download icon" />
-                      ),
+                      icon: <DownloadIcon size={16} aria-hidden="true" />,
                       onClick: handleDownloadTSV,
                     },
                     {
                       title: "JSON",
-                      icon: (
-                        <DownloadIcon size={16} aria-label="download icon" />
-                      ),
+                      icon: <DownloadIcon size={16} aria-hidden="true" />,
                       onClick: downloadVersionJSON,
                     },
                   ]}
                   TargetButtonChildren="Download"
-                  LeftIcon={
-                    <DownloadIcon size="1rem" aria-label="download icon" />
-                  }
+                  LeftIcon={<DownloadIcon size="1rem" aria-hidden="true" />}
                 />
               </div>
             }

--- a/packages/portal-proto/src/features/layout/Header.tsx
+++ b/packages/portal-proto/src/features/layout/Header.tsx
@@ -194,7 +194,9 @@ export const Header: React.FC<HeaderProps> = ({
             <Menu width={200} data-testid="userdropdown" zIndex={9} offset={-5}>
               <Menu.Target>
                 <Button
-                  rightIcon={<ArrowDropDownIcon size="2em" />}
+                  rightIcon={
+                    <ArrowDropDownIcon size="2em" aria-hidden="true" />
+                  }
                   variant="subtle"
                   className="text-primary-darkest font-header text-sm font-medium font-heading"
                   classNames={{ rightIcon: "ml-0" }}

--- a/packages/portal-proto/src/features/layout/Header.tsx
+++ b/packages/portal-proto/src/features/layout/Header.tsx
@@ -135,7 +135,7 @@ export const Header: React.FC<HeaderProps> = ({
             variant="subtle"
             data-testid="button-header-send-feeback"
             className="rounded-md hover:bg-primary-lightest font-medium text-primary-darkest font-heading p-1"
-            leftIcon={<FeebackIcon size="24px" />}
+            leftIcon={<FeebackIcon size="24px" aria-hidden="true" />}
             onClick={() => setOpenFeedbackModal(true)}
           >
             Send Feedback
@@ -309,7 +309,11 @@ export const Header: React.FC<HeaderProps> = ({
                 data-testid="extraButton"
                 className="flex items-center gap-1 p-1 pr-2 rounded-md hover:bg-primary-lightest"
               >
-                <AppsIcon size="24px" className="text-primary-darkest" />
+                <AppsIcon
+                  size="24px"
+                  className="text-primary-darkest"
+                  aria-hidden="true"
+                />
                 <p className="font-heading">GDC Apps</p>
               </button>
             </Menu.Target>

--- a/packages/portal-proto/src/features/manageSets/DeleteSetsNotification.tsx
+++ b/packages/portal-proto/src/features/manageSets/DeleteSetsNotification.tsx
@@ -24,7 +24,7 @@ const DeleteSetsNotification: React.FC<DeleteSetsNotificationProps> = ({
       <Button
         variant={"white"}
         onClick={() => sets.map((set) => dispatch(addSet(set)))}
-        leftIcon={<UndoIcon />}
+        leftIcon={<UndoIcon aria-hidden="true" />}
       >
         <span className="underline">Undo</span>
       </Button>

--- a/packages/portal-proto/src/features/manageSets/ManageSets.tsx
+++ b/packages/portal-proto/src/features/manageSets/ManageSets.tsx
@@ -113,7 +113,11 @@ const ManageSets: React.FC = () => {
         <Grid justify="center" className="flex-grow">
           <Grid.Col span={4} className="my-20 flex flex-col items-center">
             <div className="h-40 w-40 rounded-[50%] bg-emptyIconLighterColor flex justify-center items-center">
-              <FileAddIcon size={80} className="text-primary-darkest" />
+              <FileAddIcon
+                size={80}
+                className="text-primary-darkest"
+                aria-hidden="true"
+              />
             </div>
             <p
               data-testid="text-no-saved-sets-available"

--- a/packages/portal-proto/src/features/manageSets/ManageSetsTable.tsx
+++ b/packages/portal-proto/src/features/manageSets/ManageSetsTable.tsx
@@ -91,7 +91,7 @@ const ManageSetActions: React.FC<ManageSetActionsProps> = ({
         }}
         variant="transparent"
       >
-        <TrashIcon />
+        <TrashIcon aria-hidden="true" />
       </ActionIcon>
       {count > 0 && (
         <ActionIcon
@@ -121,7 +121,7 @@ const ManageSetActions: React.FC<ManageSetActionsProps> = ({
             });
           }}
         >
-          <DownloadIcon />
+          <DownloadIcon aria-hidden="true" />
         </ActionIcon>
       )}
     </div>

--- a/packages/portal-proto/src/features/manageSets/SetNameInput.tsx
+++ b/packages/portal-proto/src/features/manageSets/SetNameInput.tsx
@@ -64,7 +64,7 @@ const SetNameInput: React.FC<SetNameInputProps> = ({
               data-testid="button-close-set-name-input"
               aria-label="Close input"
             >
-              <CloseIcon className="text-nci-red-darkest" />
+              <CloseIcon className="text-nci-red-darkest" aria-hidden="true" />
             </ActionIcon>
             <ActionIcon
               onClick={() => {
@@ -78,7 +78,11 @@ const SetNameInput: React.FC<SetNameInputProps> = ({
               data-testid="button-accept-set-name-input"
               aria-label="Rename set"
             >
-              <CheckIcon className="text-nci-green-darkest" size={10} />
+              <CheckIcon
+                className="text-nci-green-darkest"
+                size={10}
+                aria-hidden="true"
+              />
             </ActionIcon>
           </>
         ) : (
@@ -90,7 +94,7 @@ const SetNameInput: React.FC<SetNameInputProps> = ({
               aria-label="Edit set name"
               data-testid="button-edit-set-name"
             >
-              <EditIcon className="text-accent" />
+              <EditIcon className="text-accent" aria-hidden="true" />
             </ActionIcon>
           </>
         )}

--- a/packages/portal-proto/src/features/projects/ProjectView.tsx
+++ b/packages/portal-proto/src/features/projects/ProjectView.tsx
@@ -267,12 +267,12 @@ export const ProjectView: React.FC<ProjectViewProps> = (
               dropdownElements={[
                 {
                   title: "TSV",
-                  icon: <DownloadIcon size={16} aria-label="download icon" />,
+                  icon: <DownloadIcon size={16} aria-hidden="true" />,
                   onClick: handleBiospeciemenTSVDownload,
                 },
                 {
                   title: "JSON",
-                  icon: <DownloadIcon size={16} aria-label="download icon" />,
+                  icon: <DownloadIcon size={16} aria-hidden="true" />,
                   onClick: handleBiospeciemenJSONDownload,
                 },
               ]}
@@ -285,7 +285,7 @@ export const ProjectView: React.FC<ProjectViewProps> = (
                 biospecimenDownloadActive ? (
                   <Loader size={20} />
                 ) : (
-                  <DownloadIcon size="1rem" aria-label="download icon" />
+                  <DownloadIcon size="1rem" aria-hidden="true" />
                 )
               }
             />
@@ -293,12 +293,12 @@ export const ProjectView: React.FC<ProjectViewProps> = (
               dropdownElements={[
                 {
                   title: "TSV",
-                  icon: <DownloadIcon size={16} aria-label="download icon" />,
+                  icon: <DownloadIcon size={16} aria-hidden="true" />,
                   onClick: handleClinicalTSVDownload,
                 },
                 {
                   title: "JSON",
-                  icon: <DownloadIcon size={16} aria-label="download icon" />,
+                  icon: <DownloadIcon size={16} aria-hidden="true" />,
                   onClick: handleClinicalJSONDownload,
                 },
               ]}
@@ -311,7 +311,7 @@ export const ProjectView: React.FC<ProjectViewProps> = (
                 clinicalDownloadActive ? (
                   <Loader size={20} />
                 ) : (
-                  <DownloadIcon size="1rem" aria-label="download icon" />
+                  <DownloadIcon size="1rem" aria-hidden="true" />
                 )
               }
             />

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -137,7 +137,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
 
   const divRef = useRef();
   return (
-    <div>
+    <div className="relative">
       {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
       <div
         ref={divRef}

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -137,7 +137,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
 
   const divRef = useRef();
   return (
-    <div>
+    <div className="relative">
       {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
       <div
         ref={divRef}

--- a/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
@@ -450,7 +450,7 @@ const FilesTables: React.FC = () => {
           : "File"}
       </div>
       <div>
-        <MdPerson className="ml-2 mr-1 mb-1 inline-block" />
+        <MdPerson className="ml-2 mr-1 mb-1 inline-block" aria-hidden="true" />
         <strong className="mr-1">{totalCaseCount}</strong>
         {fileSizeSliceData?.data?.total_case_count > 1 ||
         fileSizeSliceData?.data?.total_case_count === 0
@@ -458,7 +458,7 @@ const FilesTables: React.FC = () => {
           : "Case"}
       </div>
       <div>
-        <MdSave className="ml-2 mr-1 mb-1 inline-block" />
+        <MdSave className="ml-2 mr-1 mb-1 inline-block" aria-hidden="true" />
         {totalFileSize}
       </div>
     </div>

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -182,7 +182,7 @@ export const RepositoryApp = (): JSX.Element => {
 
                 <FunctionButton
                   data-testid="button-add-all-files-table"
-                  leftIcon={<CartIcon />}
+                  leftIcon={<CartIcon aria-hidden="true" />}
                   loading={allFilesLoading}
                   onClick={() => {
                     // check number of files selected before making call
@@ -204,7 +204,7 @@ export const RepositoryApp = (): JSX.Element => {
                 </FunctionButton>
                 <FunctionButtonRemove
                   data-testid="button-remove-all-files-table"
-                  leftIcon={<VscTrash />}
+                  leftIcon={<VscTrash aria-hidden="true" />}
                   loading={allFilesLoading}
                   onClick={() => {
                     getAllSelectedFiles(

--- a/packages/portal-proto/src/features/set-operations/DownloadButton.tsx
+++ b/packages/portal-proto/src/features/set-operations/DownloadButton.tsx
@@ -83,9 +83,9 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({
               : "bg-base-max hover:bg-primary hover:text-base-max"
           }`}
           disabled={disabled}
-          aria-label="download button"
+          aria-label="download TSV"
         >
-          {loading ? <Loader size={14} /> : <DownloadIcon />}
+          {loading ? <Loader size={14} /> : <DownloadIcon aria-hidden="true" />}
         </ActionIcon>
       </div>
     </Tooltip>

--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisBreadcrumbs.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisBreadcrumbs.tsx
@@ -28,7 +28,7 @@ const AnalysisBreadcrumbs: React.FC<AnalysisBreadcrumbsProps> = ({
         className="bg-base-max text-primary-content-darkest px-2 hover:bg-primary-darkest hover:text-primary-content-lightest rounded-md w-auto h-9"
         aria-label="Close app"
       >
-        <MdClose size={20} />
+        <MdClose size={20} aria-hidden="true" />
       </button>
       <span
         className={`p-2 mx-2 uppercase text-white ${
@@ -59,7 +59,12 @@ const AnalysisBreadcrumbs: React.FC<AnalysisBreadcrumbsProps> = ({
           )}
           {!selectionScreenOpen && (
             <>
-              <MdCircle size={8} color="white" />
+              <MdCircle
+                size={8}
+                color="white"
+                role="separator"
+                aria-hidden="true"
+              />
               <span className="p-2 mx-2 uppercase font-bold text-white">
                 Results
               </span>

--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisBreadcrumbs.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisBreadcrumbs.tsx
@@ -41,7 +41,7 @@ const AnalysisBreadcrumbs: React.FC<AnalysisBreadcrumbsProps> = ({
         <>
           {appInfo?.selectionScreen !== undefined && (
             <>
-              <MdCircle size={8} color="white" />
+              <MdCircle size={8} color="white" role="separator" />
               <span
                 className={`p-2 mx-2 uppercase cursor-pointer text-white ${
                   selectionScreenOpen ? "font-bold" : ""
@@ -59,12 +59,7 @@ const AnalysisBreadcrumbs: React.FC<AnalysisBreadcrumbsProps> = ({
           )}
           {!selectionScreenOpen && (
             <>
-              <MdCircle
-                size={8}
-                color="white"
-                role="separator"
-                aria-hidden="true"
-              />
+              <MdCircle size={8} color="white" role="separator" />
               <span className="p-2 mx-2 uppercase font-bold text-white">
                 Results
               </span>

--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
@@ -59,7 +59,6 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
             <a
               data-testid={`button-${entry.name}`}
               className={`
-                block
                 flex
                 justify-center
                 items-center
@@ -95,7 +94,6 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
               <a
                 data-testid={`button-${entry.name} Demo`}
                 className={`
-                  block
                   flex
                   justify-center
                   items-center
@@ -123,7 +121,7 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
           ) : null}
         </div>
       </div>
-      <Divider variant="dotted" />
+      <Divider variant="dotted" aria-hidden="true" />
       <div className="flex flex-col items-center text-xs">
         <Button
           data-testid="select-description-tool"
@@ -132,9 +130,9 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
           size="xs"
           rightIcon={
             descriptionVisible ? (
-              <MdArrowDropUp size={16} />
+              <MdArrowDropUp size={16} aria-hidden="true" />
             ) : (
-              <MdArrowDropDown size={16} />
+              <MdArrowDropDown size={16} aria-hidden="true" />
             )
           }
           classNames={{

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -32,7 +32,7 @@ export const COHORTS = [
 export const REGISTERED_APPS = [
   {
     name: "Clinical Data Analysis",
-    icon: <ClinicalDataIcon />,
+    icon: <ClinicalDataIcon aria-hidden="true" />,
     tags: ["clinicalAnalysis"],
     hasDemo: true,
     countsField: "repositoryCaseCount",
@@ -45,7 +45,14 @@ export const REGISTERED_APPS = [
   },
   {
     name: "Cohort Builder",
-    icon: <CohortBuilderIcon width={64} height={64} viewBox="0 0 60 60" />,
+    icon: (
+      <CohortBuilderIcon
+        width={64}
+        height={64}
+        viewBox="0 0 60 60"
+        aria-hidden="true"
+      />
+    ),
     tags: ["generalUtility"],
     hasDemo: false,
     id: "CohortBuilder",
@@ -69,7 +76,7 @@ export const REGISTERED_APPS = [
   },
   {
     name: "Repository",
-    icon: <RepositoryIcon />,
+    icon: <RepositoryIcon aria-hidden="true" />,
     tags: ["files"],
     hasDemo: false,
     countsField: "repositoryCaseCount",
@@ -79,7 +86,14 @@ export const REGISTERED_APPS = [
   },
   {
     name: "Projects",
-    icon: <ProjectsIcon width={64} height={64} viewBox="0 -20 128 128" />,
+    icon: (
+      <ProjectsIcon
+        width={64}
+        height={64}
+        viewBox="0 -20 128 128"
+        aria-hidden="true"
+      />
+    ),
     tags: [],
     hasDemo: false,
     id: "Projects",
@@ -89,7 +103,7 @@ export const REGISTERED_APPS = [
   },
   {
     name: "Cohort Comparison",
-    icon: <CohortComparisonIcon />,
+    icon: <CohortComparisonIcon aria-hidden="true" />,
     tags: ["clinicalAnalysis"],
     hasDemo: true,
     id: "CohortComparisonApp",
@@ -117,7 +131,7 @@ export const REGISTERED_APPS = [
   */
   {
     name: "Set Operations",
-    icon: <SetOperationsIcon />,
+    icon: <SetOperationsIcon aria-hidden="true" />,
     tags: ["generalUtility"],
     hasDemo: true,
     hideCounts: true,
@@ -129,7 +143,7 @@ export const REGISTERED_APPS = [
   },
   {
     name: "Sequence Reads",
-    icon: <SequenceReadsIcon />,
+    icon: <SequenceReadsIcon aria-hidden="true" />,
     tags: ["sequenceAnalysis"],
     hasDemo: false,
     countsField: "sequenceReadCaseCount",
@@ -142,7 +156,7 @@ export const REGISTERED_APPS = [
   },
   {
     name: "BAM Slicing Download",
-    icon: <BAMSlicingDownloadIcon />,
+    icon: <BAMSlicingDownloadIcon aria-hidden="true" />,
     tags: ["sequenceAnalysis"],
     hasDemo: false,
     countsField: "sequenceReadCaseCount",
@@ -153,7 +167,14 @@ export const REGISTERED_APPS = [
   },
   {
     name: "ProteinPaint",
-    icon: <ProteinPaintIcon height={48} width={80} viewBox="-12 0 80 48" />,
+    icon: (
+      <ProteinPaintIcon
+        height={48}
+        width={80}
+        viewBox="-12 0 80 48"
+        aria-hidden="true"
+      />
+    ),
     tags: ["variantAnalysis", "ssm"],
     hasDemo: true,
     description:
@@ -167,7 +188,14 @@ export const REGISTERED_APPS = [
   },
   {
     name: "OncoMatrix",
-    icon: <OncoMatrixIcon className="m-auto" height={48} width={80} />,
+    icon: (
+      <OncoMatrixIcon
+        className="m-auto"
+        height={48}
+        width={80}
+        aria-hidden="true"
+      />
+    ),
     tags: ["variantAnalysis", "cnv", "ssm"],
     hasDemo: true,
     description:
@@ -181,7 +209,14 @@ export const REGISTERED_APPS = [
   },
   {
     name: "Gene Expression Clustering",
-    icon: <GeneExpressionIcon className="m-auto" height={48} width={80} />,
+    icon: (
+      <GeneExpressionIcon
+        className="m-auto"
+        height={48}
+        width={80}
+        aria-hidden="true"
+      />
+    ),
     tags: ["variantAnalysis", "cnv", "ssm"],
     hasDemo: true,
     description:

--- a/packages/portal-proto/src/utils/download.tsx
+++ b/packages/portal-proto/src/utils/download.tsx
@@ -37,7 +37,7 @@ const DownloadNotification = ({ onClick }: { onClick: () => void }) => {
       <p>Download preparation in progress. Please wait...</p>
       <Button
         variant="white"
-        leftIcon={<CloseIcon />}
+        leftIcon={<CloseIcon aria-hidden="true" />}
         style={{ color: "#155276", cursor: "pointer" }}
         onClick={onClick}
       >


### PR DESCRIPTION
## Description
Hides any decorative images from screenreader. From https://www.w3.org/WAI/tutorials/images/decorative/ 

>  Images may be decorative when they are:
> 
> Visual styling such as borders, spacers, and corners;
> Supplementary to link text to improve its appearance or increase the clickable area;
> Illustrative of adjacent text but not contributing information (“eye-candy”);
> Identified and described by surrounding text.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
