### PR TITLE
update the proteinpaint-client version to 2.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.38.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.38.1.tgz",
-      "integrity": "sha512-FcsEKtPwUhsDRig8ecZT84vVbep0ZtJh7+VCXI1666wPzsdYyAFjlKtGIhJVE1o0dT7wn5xtLSCfGIQWWoA1Xg=="
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.0.tgz",
+      "integrity": "sha512-Dc+Y+L4Tomm7u8XQIaz0tAOF1xFt2VIfF5nhs9WvmfizMV1eNHmRX5rUqiDQpV5lVwIe/M/eWewgRSj0G1v/2w=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.38.1",
+        "@sjcrh/proteinpaint-client": "^2.39.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.38.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.38.1.tgz",
-      "integrity": "sha512-FcsEKtPwUhsDRig8ecZT84vVbep0ZtJh7+VCXI1666wPzsdYyAFjlKtGIhJVE1o0dT7wn5xtLSCfGIQWWoA1Xg=="
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.0.tgz",
+      "integrity": "sha512-Dc+Y+L4Tomm7u8XQIaz0tAOF1xFt2VIfF5nhs9WvmfizMV1eNHmRX5rUqiDQpV5lVwIe/M/eWewgRSj0G1v/2w=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.38.1",
+        "@sjcrh/proteinpaint-client": "^2.39.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.38.1",
+    "@sjcrh/proteinpaint-client": "^2.39.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -137,7 +137,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
 
   const divRef = useRef();
   return (
-    <div>
+    <div className="relative">
       {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
       <div
         ref={divRef}

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -137,7 +137,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
 
   const divRef = useRef();
   return (
-    <div>
+    <div className="relative">
       {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
       <div
         ref={divRef}


### PR DESCRIPTION
## Description

Features:
- GDC cohort-MAF tool: allow to customize output file columns (unexposed prototype)
- Clicking matrix cell to show similar info table as hovering over the matrix cell.
- Simpler radio buttons to toggle between view modes such as lollipop and occurrence

Fixes:
- Gene exp clustering will display an alert msg to inform user that a map is not doable when there is just one gene
- Display total number of mutations on disco plot
- Fix oncomatrix error: adding dictionary term from row group menu
- Numeric term edit UI allows a term to be default with custom bin config and will not switch to regular binning

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
