### PR TITLE
PEAR-1713 - Combination of Save-As and Replace results in changes being lost

### DIFF
--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -666,14 +666,14 @@ const slice = createSlice({
       state,
       action?: PayloadAction<{
         shouldShowMessage?: boolean;
-        currentID?: string;
+        id?: string;
       }>,
     ) => {
       const removedCohort =
-        state.entities[action?.payload?.currentID || getCurrentCohort(state)];
+        state.entities[action?.payload?.id || getCurrentCohort(state)];
       cohortsAdapter.removeOne(
         state,
-        action?.payload?.currentID || getCurrentCohort(state),
+        action?.payload?.id || getCurrentCohort(state),
       );
       // TODO: this will be removed after cohort id issue is fixed in the BE
       // This is just a hack to remove cohort without triggering notification
@@ -697,7 +697,7 @@ const slice = createSlice({
           `deleteCohort|${removedCohort?.name}|${state.currentCohort}`,
           `newCohort|${createdCohort.name}|${createdCohort.id}`,
         ];
-      } else {
+      } else if (action?.payload.id === undefined) {
         state.currentCohort = selector.selectAll(state)[0].id;
       }
     },
@@ -842,10 +842,11 @@ const slice = createSlice({
       action: PayloadAction<{
         filters: FilterSet | undefined;
         showMessage: boolean;
+        id?: string;
       }>,
     ) => {
       cohortsAdapter.updateOne(state, {
-        id: getCurrentCohort(state),
+        id: action.payload.id ?? getCurrentCohort(state),
         changes: {
           filters: action.payload.filters || { mode: "and", root: {} },
           modified: false,

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.unit.test.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.unit.test.tsx
@@ -143,6 +143,7 @@ describe("SaveCohortModal", () => {
         mode: "and",
       },
       showMessage: false,
+      id: "1",
     });
     expect(mockMutation).toBeCalledWith({
       cohort: {

--- a/packages/portal-proto/src/features/cohortBuilder/hooks.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/hooks.ts
@@ -53,7 +53,7 @@ export const useSetupInitialCohorts = (): boolean => {
       coreDispatch(setActiveCohortList(updatedList)); // will create caseSet if needed
       // A saved cohort that's not present in the API response has been deleted in another session
       for (const id of outdatedCohortsIds) {
-        coreDispatch(removeCohort({ currentID: id }));
+        coreDispatch(removeCohort({ id }));
       }
 
       setFetched(true);

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -137,7 +137,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
 
   const divRef = useRef();
   return (
-    <div>
+    <div className="relative">
       {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
       <div
         ref={divRef}

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -137,7 +137,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
 
   const divRef = useRef();
   return (
-    <div>
+    <div className="relative">
       {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
       <div
         ref={divRef}


### PR DESCRIPTION
## Description
Changes from the first cohort were getting discarded before the second cohort was saved with the combination of save as + replace. Most of the changes are just reorganizing the saving logic so its easier to follow. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
