### PR TITLE
Sjpp client 2.39.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.1.tgz",
-      "integrity": "sha512-gI0kRGX+xJVCNGxFJ1pLV3L8bUEJbWPcLR42NFYd2+EBoLL2pKrXxdKyV7B7DKERmjA2nFx1cOuklXp5VjYiGw=="
+      "version": "2.39.3",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.3.tgz",
+      "integrity": "sha512-UGCtb39SdBejtGRBtzUx3EwpsOeAomk28cNNJ7ONCYp7c+9UtSgnvTyQqBdisi2x3yYUZdeWgea1qlRY5i0uqQ=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.39.1",
+        "@sjcrh/proteinpaint-client": "^2.39.3",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.1.tgz",
-      "integrity": "sha512-gI0kRGX+xJVCNGxFJ1pLV3L8bUEJbWPcLR42NFYd2+EBoLL2pKrXxdKyV7B7DKERmjA2nFx1cOuklXp5VjYiGw=="
+      "version": "2.39.3",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.3.tgz",
+      "integrity": "sha512-UGCtb39SdBejtGRBtzUx3EwpsOeAomk28cNNJ7ONCYp7c+9UtSgnvTyQqBdisi2x3yYUZdeWgea1qlRY5i0uqQ=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.39.1",
+        "@sjcrh/proteinpaint-client": "^2.39.3",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.0.tgz",
-      "integrity": "sha512-Dc+Y+L4Tomm7u8XQIaz0tAOF1xFt2VIfF5nhs9WvmfizMV1eNHmRX5rUqiDQpV5lVwIe/M/eWewgRSj0G1v/2w=="
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.1.tgz",
+      "integrity": "sha512-gI0kRGX+xJVCNGxFJ1pLV3L8bUEJbWPcLR42NFYd2+EBoLL2pKrXxdKyV7B7DKERmjA2nFx1cOuklXp5VjYiGw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.39.0",
+        "@sjcrh/proteinpaint-client": "^2.39.1",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.0.tgz",
-      "integrity": "sha512-Dc+Y+L4Tomm7u8XQIaz0tAOF1xFt2VIfF5nhs9WvmfizMV1eNHmRX5rUqiDQpV5lVwIe/M/eWewgRSj0G1v/2w=="
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.1.tgz",
+      "integrity": "sha512-gI0kRGX+xJVCNGxFJ1pLV3L8bUEJbWPcLR42NFYd2+EBoLL2pKrXxdKyV7B7DKERmjA2nFx1cOuklXp5VjYiGw=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.39.0",
+        "@sjcrh/proteinpaint-client": "^2.39.1",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.39.0",
+    "@sjcrh/proteinpaint-client": "^2.39.1",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.39.1",
+    "@sjcrh/proteinpaint-client": "^2.39.3",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -41,7 +41,8 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
   const userDetails = useUserDetails();
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
-  const debouncedInitialUpdatesTimeout = useRef<number>();
+  const debouncedInitialUpdatesTimeout =
+    useRef<ReturnType<typeof setTimeout>>();
   const prevData = useRef<any>();
   const coreDispatch = useCoreDispatch();
   const [showSaveCohort, setShowSaveCohort] = useState(false);

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -41,7 +41,8 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   const userDetails = useUserDetails();
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
-  const debouncedInitialUpdatesTimeout = useRef<number>();
+  const debouncedInitialUpdatesTimeout =
+    useRef<ReturnType<typeof setTimeout>>();
   const prevData = useRef<any>();
   const coreDispatch = useCoreDispatch();
   const [showSaveCohort, setShowSaveCohort] = useState(false);

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -99,7 +99,6 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
       setIsLoading(true);
 
       if (ppRef.current) {
-        console.log(101);
         ppRef.current.update({ filter0: data.filter0 });
       } else if (ppPromise.current && !isDemoMode) {
         // in case another state update comes in when there is already

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -40,8 +40,8 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
     : buildCohortGqlOperator(currentCohort);
   const userDetails = useUserDetails();
   const ppRef = useRef<PpApi>();
-  const ppPromise = useRef<Promise>();
-  const newPpInstanceTimeout = useRef<number>();
+  const ppPromise = useRef<Promise<PpApi>>();
+  const debouncedInitialUpdatesTimeout = useRef<number>();
   const prevData = useRef<any>();
   const coreDispatch = useCoreDispatch();
   const [showSaveCohort, setShowSaveCohort] = useState(false);
@@ -99,51 +99,56 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
       setIsLoading(true);
 
       if (ppRef.current) {
+        console.log(101);
         ppRef.current.update({ filter0: data.filter0 });
-      } else if (ppPromise.current) {
+      } else if (ppPromise.current && !isDemoMode) {
         // in case another state update comes in when there is already
-        // an instance that is being created
-        ppPromise.current.then(() => {
-          if (ppRef.current) ppRef.current.update({ filter0: data.filter0 });
-          else console.error("missing ppRef.current");
-        });
+        // an instance that is being created, debounce to the last update
+        // Except: during startup in demo mode, the filter0 is not expecect to change,
+        // so don't trigger a non-user reactive update right after the initial rendering
+        if (debouncedInitialUpdatesTimeout.current)
+          clearTimeout(debouncedInitialUpdatesTimeout.current);
+
+        debouncedInitialUpdatesTimeout.current = setTimeout(() => {
+          ppPromise.current.then(() => {
+            // if the filter0 has not changed, the PP matrix app (the engine for gene expression app)
+            // will not update unnecessarily
+            if (ppRef.current) ppRef.current.update({ filter0: data.filter0 });
+            else console.error("missing ppRef.current");
+          });
+        }, 1000);
       } else {
         const toolContainer = rootElem.parentNode.parentNode
           .parentNode as HTMLElement;
         toolContainer.style.backgroundColor = "#fff";
 
-        if (newPpInstanceTimeout.current)
-          clearTimeout(newPpInstanceTimeout.current);
-        // debounce
-        newPpInstanceTimeout.current = setTimeout(() => {
-          const pp_holder = rootElem.querySelector(".sja_root_holder");
-          if (pp_holder) pp_holder.remove();
+        const pp_holder = rootElem.querySelector(".sja_root_holder");
+        if (pp_holder) pp_holder.remove();
 
-          newPpInstanceTimeout.current = 0;
-          const matrixArgs = getMatrixTrack(
-            props,
-            prevData.current.filter0,
-            callback,
-            matrixCallbacks,
-            appCallbacks,
-          );
-          if (!data) return;
+        const matrixArgs = getMatrixTrack(
+          props,
+          prevData.current.filter0,
+          callback,
+          matrixCallbacks,
+          appCallbacks,
+        );
+        if (!data) return;
 
-          const arg = Object.assign(
-            {
-              holder: rootElem,
-              noheader: true,
-              nobox: true,
-              hide_dsHandles: true,
-            },
-            matrixArgs,
-          ) as MatrixArg;
+        const arg = Object.assign(
+          {
+            holder: rootElem,
+            noheader: true,
+            nobox: true,
+            hide_dsHandles: true,
+          },
+          matrixArgs,
+        ) as MatrixArg;
 
-          ppPromise.current = runproteinpaint(arg).then((pp) => {
-            ppRef.current = pp;
-            return pp;
-          });
-        }, 1000);
+        ppPromise.current = runproteinpaint(arg).then((pp) => {
+          // the ppRef.current is set after the tool fully renders
+          ppRef.current = pp;
+          return pp;
+        });
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Description

This PR replaces https://github.com/NCI-GDC/gdc-frontend-framework/pull/919.

Fixes:

Related to JIRA tickets
- Debounce the initial rapid state changes when calling runpp() to create the OncoMatrix and Gene Expression
- Fix the navigation of matrix and gene expression controls by keyboard
- Option to override the matrix default of not rendering samples that are not annotated for any dictionary term, for more intuitive behavior in gene-centric use-cases
- Matrix should update when the filter0 changes while the geneset edit UI is displayed
- Detect empty hits before trying to render bam variants
- Display an initial geneset edit UI when the GDC default matrix genes is empty

Related to internal PP fixes before the 2.12 build
- Disable the term group menu for hierCluster gene expression term group, and remove the 'edit' and 'sort' options for other hier cluster term groups
- Exclude embedder state in the standalone recover tracked state, for the matrix and hier cluster undo/redo

Fixes to issues found in lower 2.39 releases (was not deployed to qa-orange)
- Ensure that the zoom controls has valid dimensions on update, in case it was initially rendered in an invisible div
- Reenable the handling of genome-level termdbs in the migrated server route

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
