### PR TITLE
PEAR-1731,1743: Fix Case Counts race condition and infinite spinning 

### DIFF
--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -1015,7 +1015,6 @@ const slice = createSlice({
         if (!isEqual(cohort?.filters, response.cohortFilters)) {
           // count request is not for the current cohort
           // TODO: possibly add logging to track this
-          console.error("fetchCohortCaseCounts: cohort filters do not match");
           if (cohort?.counts.caseCount === -1) {
             // reject if the cohort counts are null
             cohortsAdapter.updateOne(state, {

--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -10,6 +10,7 @@ import {
   EntityState,
   Dictionary,
 } from "@reduxjs/toolkit";
+import { isEqual } from "lodash";
 
 import { CoreState } from "../../reducers";
 import { buildCohortGqlOperator, FilterSet } from "./filters";
@@ -997,40 +998,63 @@ const slice = createSlice({
       })
       .addCase(fetchCohortCaseCounts.fulfilled, (state, action) => {
         const response = action.payload;
-
         if (response.errors && Object.keys(response.errors).length > 0) {
           cohortsAdapter.updateOne(state, {
-            id: action.meta.arg ?? getCurrentCohort(state),
+            id: action.meta.arg,
             changes: {
               counts: { ...NullCountsData, status: "rejected" },
             },
           });
-        } else {
-          // copy the counts for explore and repository
-          cohortsAdapter.updateOne(state, {
-            id: action.meta.arg ?? getCurrentCohort(state),
-            changes: {
-              counts: {
-                caseCount: response.data.viewer.explore.cases.hits.total,
-                genesCount: response.data.viewer.explore.genes.hits.total,
-                mutationCount: response.data.viewer.explore.ssms.hits.total,
-                fileCount: response.data.viewer.repository.files.hits.total,
-                ssmCaseCount: response.data.viewer.explore.ssmsCases.hits.total,
-                cnvOrSsmCaseCount:
-                  response.data.viewer.explore.cnvsOrSsmsCases.hits.total,
-                sequenceReadCaseCount:
-                  response.data.viewer.repository.sequenceReads.hits.total,
-                repositoryCaseCount:
-                  response.data.viewer.repository.cases.hits.total,
-                status: "fulfilled",
-              },
-            },
-          });
+          return;
         }
+
+        const cohort = cohortsAdapter
+          .getSelectors()
+          .selectById(state, action.meta.arg);
+
+        if (!isEqual(cohort?.filters, response.cohortFilters)) {
+          // count request is not for the current cohort
+          // TODO: possibly add logging to track this
+          console.error("fetchCohortCaseCounts: cohort filters do not match");
+          if (cohort?.counts.caseCount === -1) {
+            // reject if the cohort counts are null
+            cohortsAdapter.updateOne(state, {
+              id: action.meta.arg,
+              changes: {
+                counts: {
+                  ...NullCountsData,
+                  status: "rejected",
+                },
+              },
+            });
+          }
+          return;
+        }
+
+        // copy the counts for explore and repository
+        cohortsAdapter.updateOne(state, {
+          id: action.meta.arg,
+          changes: {
+            counts: {
+              caseCount: response.data.viewer.explore.cases.hits.total,
+              genesCount: response.data.viewer.explore.genes.hits.total,
+              mutationCount: response.data.viewer.explore.ssms.hits.total,
+              fileCount: response.data.viewer.repository.files.hits.total,
+              ssmCaseCount: response.data.viewer.explore.ssmsCases.hits.total,
+              cnvOrSsmCaseCount:
+                response.data.viewer.explore.cnvsOrSsmsCases.hits.total,
+              sequenceReadCaseCount:
+                response.data.viewer.repository.sequenceReads.hits.total,
+              repositoryCaseCount:
+                response.data.viewer.repository.cases.hits.total,
+              status: "fulfilled",
+            },
+          },
+        });
       })
       .addCase(fetchCohortCaseCounts.pending, (state, action) => {
         cohortsAdapter.updateOne(state, {
-          id: action.meta.arg ?? getCurrentCohort(state),
+          id: action.meta.arg,
           changes: {
             counts: {
               caseCount: -1,
@@ -1048,7 +1072,7 @@ const slice = createSlice({
       })
       .addCase(fetchCohortCaseCounts.rejected, (state, action) => {
         cohortsAdapter.updateOne(state, {
-          id: action.meta.arg ?? getCurrentCohort(state),
+          id: action.meta.arg,
           changes: {
             counts: {
               caseCount: -1,

--- a/packages/core/src/features/cohort/cohortCountsQuery.ts
+++ b/packages/core/src/features/cohort/cohortCountsQuery.ts
@@ -1,14 +1,11 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { DataStatus } from "../../dataAccess";
-import { buildCohortGqlOperator, joinFilters } from "./filters";
+import { buildCohortGqlOperator, joinFilters, FilterSet } from "./filters";
 
 import { CoreDispatch } from "../../store";
 import { CoreState } from "../../reducers";
 import { graphqlAPI, GraphQLApiResponse } from "../gdcapi/gdcgraphql";
-import {
-  selectCohortFilterSetById,
-  selectCurrentCohortFilterSet,
-} from "./availableCohortsSlice";
+import { UnknownJson } from "../gdcapi/gdcapi";
 
 /**
  *  CountsData holds all the case counts for a cohort
@@ -106,16 +103,34 @@ const CountsGraphQLQuery = `
   }
 }`;
 
+/**
+ * Local selector to get cohort filters to prevent circular dependency.
+ * @param state - CoreState to get value from
+ * @param cohortId - id of cohort to get filters from
+ */
+const selectCohortFilterSetById = (
+  state: CoreState,
+  cohortId: string,
+): FilterSet | undefined => {
+  const cohort = state.cohort.availableCohorts.entities[cohortId];
+  return cohort?.filters;
+};
+
+interface CohortCountsResponse extends GraphQLApiResponse {
+  cohortFilters?: FilterSet;
+}
+
 export const fetchCohortCaseCounts = createAsyncThunk<
-  GraphQLApiResponse,
-  string | undefined,
+  CohortCountsResponse,
+  string,
   { dispatch: CoreDispatch; state: CoreState }
 >(
   "cohort/CohortCounts",
-  async (cohortId, thunkAPI): Promise<GraphQLApiResponse> => {
-    const cohortFilters = cohortId
-      ? selectCohortFilterSetById(thunkAPI.getState(), cohortId)
-      : selectCurrentCohortFilterSet(thunkAPI.getState());
+  async (cohortId, thunkAPI): Promise<CohortCountsResponse> => {
+    const cohortFilters = selectCohortFilterSetById(
+      thunkAPI.getState(),
+      cohortId,
+    );
     const caseSSMFilter = buildCohortGqlOperator(
       joinFilters(cohortFilters ?? { mode: "and", root: {} }, {
         mode: "and",
@@ -165,11 +180,19 @@ export const fetchCohortCaseCounts = createAsyncThunk<
 
     const cohortFiltersGQL = buildCohortGqlOperator(cohortFilters);
     const graphQlFilters = {
-      filters: cohortFiltersGQL ?? {},
+      filters: cohortFiltersGQL ?? {}, // the cohort filters
       ssmCaseFilter: caseSSMFilter,
       cnvOrSsmCaseFilter: caseCNVOrSSMFilter,
       sequenceReadsCaseFilter: sequenceReadsFilters,
     };
-    return await graphqlAPI(CountsGraphQLQuery, graphQlFilters);
+    // get the data from the graphql endpoint
+    const data = await graphqlAPI<UnknownJson>(
+      CountsGraphQLQuery,
+      graphQlFilters,
+    );
+    return {
+      ...data,
+      cohortFilters, // add the cohort filters to the response to ensure we did not receive stale data
+    };
   },
 );

--- a/packages/core/src/listeners.ts
+++ b/packages/core/src/listeners.ts
@@ -19,6 +19,8 @@ import {
   discardCohortChanges,
   addNewSavedCohort,
   selectCurrentCohortId,
+  removeCohort,
+  selectCurrentCohort,
 } from "./features/cohort/availableCohortsSlice";
 import { fetchCohortCaseCounts } from "./features/cohort/cohortCountsQuery";
 import { cohortApiSlice } from "./features/api/cohortApiSlice";
@@ -48,29 +50,60 @@ startCoreListening({
     const currentCohortId = selectCurrentCohortId(listenerApi.getState());
     // need to pass the current cohort id to the case count fetcher because it is possible that
     // the current cohort will be different when the fetch is fulfilled
-    listenerApi.dispatch(fetchCohortCaseCounts(currentCohortId));
+    currentCohortId &&
+      listenerApi.dispatch(fetchCohortCaseCounts(currentCohortId));
   },
 });
 
 /**
- * Once the request for the case count is fulfilled, we need to add it to the cohort
- * Optionally if a cohortID is passed in, we can add the case count to that cohort
- * This is used when creating a new cohort from a link, as it is not the current cohort
+ * When a new cohort is added, we need to fetch the case counts for it
+ * both actions are handled here because a new uninitialized cohort is added and
+ * will be the most recent cohort
  */
 startCoreListening({
-  matcher: isAnyOf(
-    addNewUnsavedCohort,
-    addNewSavedCohort,
-    addNewDefaultUnsavedCohort,
-  ),
+  matcher: isAnyOf(addNewUnsavedCohort, addNewDefaultUnsavedCohort),
   effect: async (_, listenerApi) => {
     // the last cohort added is the one we want to get the case count for
     const cohorts = selectAvailableCohorts(listenerApi.getState()).sort(
       (a, b) => (a.modified_datetime <= b.modified_datetime ? 1 : -1),
     );
-
     const latestCohortId = cohorts[0]?.id;
     listenerApi.dispatch(fetchCohortCaseCounts(latestCohortId));
+  },
+});
+
+/**
+ *  Remove cohort can potentially remove the last cohort, which will create a new default cohort
+ *  so in this case we need to fetch the case counts for the new default cohort
+ */
+startCoreListening({
+  matcher: isAnyOf(removeCohort),
+  effect: async (_, listenerApi) => {
+    const currentCohort = selectCurrentCohort(listenerApi.getState());
+    if (currentCohort?.counts.status === "uninitialized") {
+      listenerApi.dispatch(fetchCohortCaseCounts(currentCohort.id));
+    }
+  },
+});
+
+/**
+ * Handle cohort creation/deletion for updating the counts. In this
+ * case the id of the cohort is in the action payload
+ */
+startCoreListening({
+  matcher: isAnyOf(
+    addNewUnsavedCohort,
+    addNewSavedCohort,
+    discardCohortChanges,
+  ),
+  effect: async (action, listenerApi) => {
+    // the last cohort added is the one we want to get the case count for
+
+    const cohortId = action?.payload?.id;
+    if (cohortId === undefined) {
+      console.error("Listener: cohortId is undefined");
+    }
+    listenerApi.dispatch(fetchCohortCaseCounts(cohortId));
   },
 });
 

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
@@ -11,7 +11,6 @@ import {
   updateCohortName,
   useCoreDispatch,
   useAddCohortMutation,
-  fetchCohortCaseCounts,
   FilterSet,
   addNewSavedCohort,
   buildGqlOperationToFilterSet,
@@ -149,7 +148,6 @@ const SaveCohortModal = ({
             );
             coreDispatch(setCurrentCohortId(payload.id));
             coreDispatch(updateCohortName(newName));
-            coreDispatch(fetchCohortCaseCounts(payload.id));
           }
         } else {
           coreDispatch(

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -42,7 +42,6 @@ import {
   DataStatus,
   setActiveCohort,
   useCurrentCohortCounts,
-  fetchCohortCaseCounts,
   selectHasUnsavedCohorts,
   addNewSavedCohort,
   hideModal,
@@ -156,12 +155,8 @@ const CohortManager: React.FC = () => {
   );
 
   const deleteCohort = () => {
-    const lastCohort = cohorts.length === 1; // check to see if deleting the last cohort
     coreDispatch(removeCohort({ shouldShowMessage: true }));
-    if (lastCohort) {
-      // deleted the last cohort., so a new one is created and requires needs counts
-      coreDispatch(fetchCohortCaseCounts(undefined));
-    }
+    // fetch case counts is now handled in listener
   };
 
   const {


### PR DESCRIPTION
## Description
Fixes a race condition with caseCounts. fetchCaseCounts now requires a cohortId as a parameter and passes the filters to the response. Upon fulfillment, if the query filters does not match the current value of the cohort filters, the count values are ignored.

Fixes an issue with removeCohort and caseCounts

Specialized the listeners for new cohorts, removed cohorts, and cohort changes.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
