### PR TITLE
Update to proteinpaint-client 2.39.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.39.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.3.tgz",
-      "integrity": "sha512-UGCtb39SdBejtGRBtzUx3EwpsOeAomk28cNNJ7ONCYp7c+9UtSgnvTyQqBdisi2x3yYUZdeWgea1qlRY5i0uqQ=="
+      "version": "2.39.5",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.5.tgz",
+      "integrity": "sha512-HPr16Pnsy70oQ9BmOA0qF+ElU4/WRdk8sk36RXyiTwCADD+yJ8Nas2BA+F44f/wgpUqRFVUwR+vOtwRXfjUUOQ=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.38.1",
+        "@sjcrh/proteinpaint-client": "^2.39.5",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.39.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.3.tgz",
-      "integrity": "sha512-UGCtb39SdBejtGRBtzUx3EwpsOeAomk28cNNJ7ONCYp7c+9UtSgnvTyQqBdisi2x3yYUZdeWgea1qlRY5i0uqQ=="
+      "version": "2.39.5",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.5.tgz",
+      "integrity": "sha512-HPr16Pnsy70oQ9BmOA0qF+ElU4/WRdk8sk36RXyiTwCADD+yJ8Nas2BA+F44f/wgpUqRFVUwR+vOtwRXfjUUOQ=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.39.3",
+        "@sjcrh/proteinpaint-client": "^2.39.5",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.39.3",
+    "@sjcrh/proteinpaint-client": "^2.39.5",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -85,10 +85,13 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
   };
 
   const appCallbacks: RxComponentCallbacks = {
-    "preDispatch.gdcPlotApp": () => {
-      setIsLoading(true);
-    },
+    "preDispatch.gdcPlotApp": () => setIsLoading(true),
     "error.gdcPlotApp": () => setIsLoading(false),
+    // There may be an initial geneset edit UI that is not part of the matrix app,
+    // and that also does not emit a postRender event, in which case, this app.callbacks.postRender is
+    // a backup to close the loading overlay when there are no state changes to the matrix
+    // app and so would not have been updated via the rx component.update() chain to rerender
+    "postRender.gdcGeneExpression": () => setIsLoading(false),
   };
 
   useEffect(

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -41,7 +41,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
   const userDetails = useUserDetails();
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
-  const initialFilter0Ref = useRef<FilterSet>();
+  const initialFilter0Ref = useRef<any>();
   const debouncedInitialUpdatesTimeout =
     useRef<ReturnType<typeof setTimeout>>();
   const prevData = useRef<any>();
@@ -103,7 +103,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
       // debounce until one of these is true
       // otherwise, the userDetails.isFetching changing from false > true > false
       // could trigger unnecessary, wastefule PP-app state update
-      if (userDetails.isSuccess === false && userDetails.isError === false)
+      if (userDetails?.isSuccess === false && userDetails?.isError === false)
         return;
       // TODO: ignore the cohort filter changes in demo mode, or combine with demo filter ???
       // data.filter0 = defaultFilter

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -41,6 +41,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
   const userDetails = useUserDetails();
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
+  const initialFilter0Ref = useRef<FilterSet>();
   const debouncedInitialUpdatesTimeout =
     useRef<ReturnType<typeof setTimeout>>();
   const prevData = useRef<any>();
@@ -79,32 +80,39 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
     }
   }, [response.isSuccess, coreDispatch, response.data]);
 
+  const showLoadingOverlay = () => setIsLoading(true);
+  const hideLoadingOverlay = () => setIsLoading(false);
   const geneExpCallbacks: RxComponentCallbacks = {
-    "postRender.gdcGeneExpression": () => setIsLoading(false),
-    "error.gdcGeneExpression": () => setIsLoading(false),
+    "postRender.gdcGeneExpression": hideLoadingOverlay,
+    "error.gdcGeneExpression": hideLoadingOverlay,
   };
-
   const appCallbacks: RxComponentCallbacks = {
-    "preDispatch.gdcPlotApp": () => setIsLoading(true),
-    "error.gdcPlotApp": () => setIsLoading(false),
+    "preDispatch.gdcPlotApp": showLoadingOverlay,
+    "error.gdcPlotApp": hideLoadingOverlay,
     // There may be an initial geneset edit UI that is not part of the matrix app,
     // and that also does not emit a postRender event, in which case, this app.callbacks.postRender is
     // a backup to close the loading overlay when there are no state changes to the matrix
     // app and so would not have been updated via the rx component.update() chain to rerender
-    "postRender.gdcGeneExpression": () => setIsLoading(false),
+    "postRender.gdcGeneExpression": hideLoadingOverlay,
   };
 
   useEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
       const data = { filter0, userDetails };
+      // debounce until one of these is true
+      // otherwise, the userDetails.isFetching changing from false > true > false
+      // could trigger unnecessary, wastefule PP-app state update
+      if (userDetails.isSuccess === false && userDetails.isError === false)
+        return;
+      // TODO: ignore the cohort filter changes in demo mode, or combine with demo filter ???
+      // data.filter0 = defaultFilter
       if (isEqual(prevData.current, data)) return;
-      prevData.current = data;
-      setIsLoading(true);
 
       if (ppRef.current) {
-        ppRef.current.update({ filter0: prevData.current.filter0 });
-      } else if (ppPromise.current && !isDemoMode) {
+        if (!isEqual(data, prevData.current))
+          ppRef.current.update({ filter0: data.filter0 });
+      } else if (ppPromise.current) {
         // in case another state update comes in when there is already
         // an instance that is being created, debounce to the last update
         // Except: during startup in demo mode, the filter0 is not expecect to change,
@@ -112,15 +120,25 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
         if (debouncedInitialUpdatesTimeout.current)
           clearTimeout(debouncedInitialUpdatesTimeout.current);
 
-        debouncedInitialUpdatesTimeout.current = setTimeout(() => {
-          ppPromise.current.then(() => {
-            // if the filter0 has not changed, the PP matrix app (the engine for gene expression app)
-            // will not update unnecessarily
-            if (ppRef.current) ppRef.current.update({ filter0: data.filter0 });
-            else console.error("missing ppRef.current");
-          });
-        }, 1000);
+        if (!isEqual(data, initialFilter0Ref.current)) {
+          // only line up subsequent requests if the filter0 has changed immediately after loading this tool
+          debouncedInitialUpdatesTimeout.current = setTimeout(() => {
+            ppPromise.current.then(() => {
+              // if the filter0 has not changed, the PP matrix app (the engine for gene expression app)
+              // will not update unnecessarily
+              if (ppRef.current)
+                ppRef.current.update({ filter0: data.filter0 });
+              else console.error("missing ppRef.current");
+            });
+          }, 1000);
+        }
       } else {
+        // TODO:
+        // showing and hiding the overlay should be triggered by components that may take a while to load/render,
+        // this wrapper code can show the overlay here since it has supplied postRender callbacks above,
+        // but ideally it is the PP-app that triggers both the showing and hiding of the overlay for reliable behavior
+        showLoadingOverlay();
+        initialFilter0Ref.current = data.filter0;
         const toolContainer = rootElem.parentNode.parentNode
           .parentNode as HTMLElement;
         toolContainer.style.backgroundColor = "#fff";
@@ -128,14 +146,14 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
         const pp_holder = rootElem.querySelector(".sja_root_holder");
         if (pp_holder) pp_holder.remove();
 
-        const data = getGeneExpressionTrack(
+        const geArgs = getGeneExpressionTrack(
           props,
-          prevData.current.filter0,
+          data.filter0,
           callback,
           geneExpCallbacks,
           appCallbacks,
         );
-        if (!data) return;
+        if (!geArgs) return;
 
         const arg = Object.assign(
           {
@@ -144,7 +162,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
             nobox: true,
             hide_dsHandles: true,
           },
-          data,
+          geArgs,
         ) as GeneExpressionArg;
 
         ppPromise.current = runproteinpaint(arg).then((pp) => {
@@ -152,6 +170,8 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
           ppRef.current = pp;
         });
       }
+
+      prevData.current = data;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [filter0, userDetails],

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.unit.test.tsx
@@ -72,6 +72,26 @@ test("GeneExpression arguments", () => {
       <GeneExpressionWrapper />
     </MantineProvider>,
   );
+  // there should be only one runpp instance when switching to this tool,
+  // so the arg key-values should not change on rerender
+  expect(runpparg.filter0).toEqual(filter);
+  unmount();
+});
+
+test("GeneExpression demo filter0", () => {
+  isDemoMode = true;
+  const { unmount } = render(
+    <MantineProvider
+      theme={{
+        colors: {
+          primary: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+          base: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+        },
+      }}
+    >
+      <GeneExpressionWrapper />
+    </MantineProvider>,
+  );
   expect(runpparg.filter0).not.toEqual(filter);
   unmount();
 });

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -85,10 +85,13 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   };
 
   const appCallbacks: RxComponentCallbacks = {
-    "preDispatch.gdcPlotApp": () => {
-      setIsLoading(true);
-    },
+    "preDispatch.gdcPlotApp": () => setIsLoading(true),
     "error.gdcPlotApp": () => setIsLoading(false),
+    // There may be an initial geneset edit UI that is not part of the matrix app,
+    // and that also does not emit a postRender event, in which case, this app.callbacks.postRender is
+    // a backup to close the loading overlay when there are no state changes to the matrix
+    // app and so would not have been updated via the rx component.update() chain to rerender
+    "postRender.gdcOncoMatrix": () => setIsLoading(false),
   };
 
   useEffect(

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -41,7 +41,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   const userDetails = useUserDetails();
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
-  const initialFilter0Ref = useRef<FilterSet>();
+  const initialFilter0Ref = useRef<any>();
   const debouncedInitialUpdatesTimeout =
     useRef<ReturnType<typeof setTimeout>>();
   const prevData = useRef<any>();
@@ -99,7 +99,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
       // debounce until one of these is true
       // otherwise, the userDetails.isFetching changing from false > true > false
       // could trigger unnecessary, wastefule PP-app state update
-      if (userDetails.isSuccess === false && userDetails.isError === false)
+      if (userDetails?.isSuccess === false && userDetails?.isError === false)
         return;
       // TODO: ignore the cohort filter changes in demo mode, or combine with demo filter ???
       // data.filter0 = defaultFilter

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -41,6 +41,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   const userDetails = useUserDetails();
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
+  const initialFilter0Ref = useRef<FilterSet>();
   const debouncedInitialUpdatesTimeout =
     useRef<ReturnType<typeof setTimeout>>();
   const prevData = useRef<any>();
@@ -79,32 +80,35 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
     }
   }, [response.isSuccess, coreDispatch, response.data]);
 
+  const showLoadingOverlay = () => setIsLoading(true);
+  const hideLoadingOverlay = () => setIsLoading(false);
   const matrixCallbacks: RxComponentCallbacks = {
-    "postRender.gdcOncoMatrix": () => setIsLoading(false),
-    "error.gdcOncoMatrix": () => setIsLoading(false),
+    "postRender.gdcOncoMatrix": showLoadingOverlay,
+    "error.gdcOncoMatrix": showLoadingOverlay,
   };
-
   const appCallbacks: RxComponentCallbacks = {
-    "preDispatch.gdcPlotApp": () => setIsLoading(true),
-    "error.gdcPlotApp": () => setIsLoading(false),
-    // There may be an initial geneset edit UI that is not part of the matrix app,
-    // and that also does not emit a postRender event, in which case, this app.callbacks.postRender is
-    // a backup to close the loading overlay when there are no state changes to the matrix
-    // app and so would not have been updated via the rx component.update() chain to rerender
-    "postRender.gdcOncoMatrix": () => setIsLoading(false),
+    "preDispatch.gdcPlotApp": showLoadingOverlay,
+    "error.gdcPlotApp": hideLoadingOverlay,
+    "postRender.gdcGeneExpression": hideLoadingOverlay,
   };
 
   useEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
       const data = { filter0, userDetails };
+      // debounce until one of these is true
+      // otherwise, the userDetails.isFetching changing from false > true > false
+      // could trigger unnecessary, wastefule PP-app state update
+      if (userDetails.isSuccess === false && userDetails.isError === false)
+        return;
+      // TODO: ignore the cohort filter changes in demo mode, or combine with demo filter ???
+      // data.filter0 = defaultFilter
       if (isEqual(prevData.current, data)) return;
-      prevData.current = data;
-      setIsLoading(true);
 
       if (ppRef.current) {
-        ppRef.current.update({ filter0: data.filter0 });
-      } else if (ppPromise.current && !isDemoMode) {
+        if (!isEqual(data, prevData.current))
+          ppRef.current.update({ filter0: data.filter0 });
+      } else if (ppPromise.current) {
         // in case another state update comes in when there is already
         // an instance that is being created, debounce to the last update
         // Except: during startup in demo mode, the filter0 is not expecect to change,
@@ -112,15 +116,25 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
         if (debouncedInitialUpdatesTimeout.current)
           clearTimeout(debouncedInitialUpdatesTimeout.current);
 
-        debouncedInitialUpdatesTimeout.current = setTimeout(() => {
-          ppPromise.current.then(() => {
-            // if the filter0 has not changed, the PP matrix app (the engine for gene expression app)
-            // will not update unnecessarily
-            if (ppRef.current) ppRef.current.update({ filter0: data.filter0 });
-            else console.error("missing ppRef.current");
-          });
-        }, 1000);
+        if (!isEqual(data, initialFilter0Ref.current)) {
+          debouncedInitialUpdatesTimeout.current = setTimeout(() => {
+            ppPromise.current.then(() => {
+              // if the filter0 has not changed, the PP matrix app (the engine for gene expression app)
+              // will not update unnecessarily
+              if (ppRef.current) {
+                if (!isEqual(data, initialFilter0Ref.current))
+                  ppRef.current.update({ filter0: data.filter0 });
+              } else console.error("missing ppRef.current");
+            });
+          }, 1000);
+        }
       } else {
+        // TODO:
+        // showing and hiding the overlay should be triggered by components that may take a while to load/render,
+        // this wrapper code can show the overlay here since it has supplied postRender callbacks above,
+        // but ideally it is the PP-app that triggers both the showing and hiding of the overlay for reliable behavior
+        showLoadingOverlay();
+        initialFilter0Ref.current = data;
         const toolContainer = rootElem.parentNode.parentNode
           .parentNode as HTMLElement;
         toolContainer.style.backgroundColor = "#fff";
@@ -130,7 +144,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
 
         const matrixArgs = getMatrixTrack(
           props,
-          prevData.current.filter0,
+          data.filter0,
           callback,
           matrixCallbacks,
           appCallbacks,
@@ -153,6 +167,8 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
           return pp;
         });
       }
+
+      prevData.current = data;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [filter0, userDetails],

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.unit.test.tsx
@@ -74,6 +74,26 @@ test("OncoMatrix arguments", () => {
       <OncoMatrixWrapper />
     </MantineProvider>,
   );
+  // there should be only one runpp instance when switching to this tool,
+  // so the arg key-values should not change on rerender
+  expect(runpparg.filter0).toEqual(filter);
+  unmount();
+});
+
+test("OncoMatrix demo filter0", () => {
+  isDemoMode = true;
+  const { unmount } = render(
+    <MantineProvider
+      theme={{
+        colors: {
+          primary: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+          base: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+        },
+      }}
+    >
+      <OncoMatrixWrapper />
+    </MantineProvider>,
+  );
   expect(runpparg.filter0).not.toEqual(filter);
   unmount();
 });


### PR DESCRIPTION
## Description

Fixes:
- Use graphql query to replace /analysis/top_mutated_genes_by_project in GDC OncoMatrix
- GDC bam slicing UI bug fix to forget previous coordinate input box search result
- Always trigger the closing of an embedder's loading overlay, even when there are no chart state changes
- Block track menu will not allow to hide a GDC bam tk, and no longer shows delete button for custom tracks


## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
