### PR TITLE
PEAR-1766: case count fix for copyToSavedCohort 

### DIFF
--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -653,12 +653,8 @@ const slice = createSlice({
           modified: false,
           saved: true,
           counts: {
-            ...sourceCohort.counts, // Its possible that the source cohort doesn't have counts yet so we need to reset it so it can be fetched
-            status:
-              sourceCohort.counts.status !== "fulfilled"
-                ? ("uninitialized" as DataStatus)
-                : sourceCohort.counts.status,
-            requestId: undefined,
+            // will need to re-request counts
+            ...NullCountsData,
           },
         };
         cohortsAdapter.addOne(state, destCohort);

--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -10,7 +10,6 @@ import {
   EntityState,
   Dictionary,
 } from "@reduxjs/toolkit";
-import { isEqual } from "lodash";
 
 import { CoreState } from "../../reducers";
 import { buildCohortGqlOperator, FilterSet } from "./filters";
@@ -653,6 +652,14 @@ const slice = createSlice({
           id: action.payload.destId,
           modified: false,
           saved: true,
+          counts: {
+            ...sourceCohort.counts, // Its possible that the source cohort doesn't have counts yet so we need to reset it so it can be fetched
+            status:
+              sourceCohort.counts.status !== "fulfilled"
+                ? ("uninitialized" as DataStatus)
+                : sourceCohort.counts.status,
+            requestId: undefined,
+          },
         };
         cohortsAdapter.addOne(state, destCohort);
       }
@@ -997,6 +1004,14 @@ const slice = createSlice({
         });
       })
       .addCase(fetchCohortCaseCounts.fulfilled, (state, action) => {
+        if (
+          action.meta.requestId !==
+          state.entities[action.meta.arg]?.counts.requestId
+        ) {
+          // ignore if the request id is not the same as the current cohort
+          return;
+        }
+
         const response = action.payload;
         if (response.errors && Object.keys(response.errors).length > 0) {
           cohortsAdapter.updateOne(state, {
@@ -1005,28 +1020,6 @@ const slice = createSlice({
               counts: { ...NullCountsData, status: "rejected" },
             },
           });
-          return;
-        }
-
-        const cohort = cohortsAdapter
-          .getSelectors()
-          .selectById(state, action.meta.arg);
-
-        if (!isEqual(cohort?.filters, response.cohortFilters)) {
-          // count request is not for the current cohort
-          // TODO: possibly add logging to track this
-          if (cohort?.counts.caseCount === -1) {
-            // reject if the cohort counts are null
-            cohortsAdapter.updateOne(state, {
-              id: action.meta.arg,
-              changes: {
-                counts: {
-                  ...NullCountsData,
-                  status: "rejected",
-                },
-              },
-            });
-          }
           return;
         }
 
@@ -1068,11 +1061,18 @@ const slice = createSlice({
               repositoryCaseCount: -1,
               geneExpressionCaseCount: -1,
               status: "pending",
+              requestId: action.meta.requestId,
             },
           },
         });
       })
       .addCase(fetchCohortCaseCounts.rejected, (state, action) => {
+        if (
+          action.meta.requestId !==
+          state.entities[action.meta.arg]?.counts.requestId
+        ) {
+          return;
+        }
         cohortsAdapter.updateOne(state, {
           id: action.meta.arg,
           changes: {

--- a/packages/core/src/features/cohort/cohortCountsQuery.ts
+++ b/packages/core/src/features/cohort/cohortCountsQuery.ts
@@ -34,6 +34,7 @@ export interface CountsData {
 
 export interface CountsDataAndStatus extends CountsData {
   readonly status: DataStatus;
+  readonly requestId?: string;
 }
 
 /**
@@ -51,6 +52,7 @@ export const NullCountsData: CountsDataAndStatus = {
   repositoryCaseCount: -1,
   geneExpressionCaseCount: -1,
   status: "uninitialized",
+  requestId: undefined,
 };
 
 const CountsGraphQLQuery = `

--- a/packages/core/src/listeners.ts
+++ b/packages/core/src/listeners.ts
@@ -12,6 +12,7 @@ import {
   removeCohortFilter,
   addNewUnsavedCohort,
   selectAvailableCohorts,
+  selectCohortById,
   addNewDefaultUnsavedCohort,
   createCaseSetsIfNeeded,
   createCaseSet,
@@ -20,6 +21,7 @@ import {
   addNewSavedCohort,
   selectCurrentCohortId,
   removeCohort,
+  copyToSavedCohort,
   selectCurrentCohort,
 } from "./features/cohort/availableCohortsSlice";
 import { fetchCohortCaseCounts } from "./features/cohort/cohortCountsQuery";
@@ -82,6 +84,23 @@ startCoreListening({
     const currentCohort = selectCurrentCohort(listenerApi.getState());
     if (currentCohort?.counts.status === "uninitialized") {
       listenerApi.dispatch(fetchCohortCaseCounts(currentCohort.id));
+    }
+  },
+});
+
+/**
+ * copying to Saved Cohort can potentially create a cohort without a caseCount so we need to fetch it
+ */
+startCoreListening({
+  matcher: isAnyOf(copyToSavedCohort),
+  effect: async (action, listenerApi) => {
+    const cohort = selectCohortById(
+      listenerApi.getState(),
+      action.payload.destId,
+    );
+    if (cohort && cohort?.counts.status !== "fulfilled") {
+      // only fetch if the cohort doesn't have a fullfilled caseCount
+      listenerApi.dispatch(fetchCohortCaseCounts(cohort.id));
     }
   },
 });

--- a/packages/core/src/listeners.ts
+++ b/packages/core/src/listeners.ts
@@ -12,7 +12,6 @@ import {
   removeCohortFilter,
   addNewUnsavedCohort,
   selectAvailableCohorts,
-  selectCohortById,
   addNewDefaultUnsavedCohort,
   createCaseSetsIfNeeded,
   createCaseSet,
@@ -21,7 +20,6 @@ import {
   addNewSavedCohort,
   selectCurrentCohortId,
   removeCohort,
-  copyToSavedCohort,
   selectCurrentCohort,
 } from "./features/cohort/availableCohortsSlice";
 import { fetchCohortCaseCounts } from "./features/cohort/cohortCountsQuery";
@@ -84,23 +82,6 @@ startCoreListening({
     const currentCohort = selectCurrentCohort(listenerApi.getState());
     if (currentCohort?.counts.status === "uninitialized") {
       listenerApi.dispatch(fetchCohortCaseCounts(currentCohort.id));
-    }
-  },
-});
-
-/**
- * copying to Saved Cohort can potentially create a cohort without a caseCount so we need to fetch it
- */
-startCoreListening({
-  matcher: isAnyOf(copyToSavedCohort),
-  effect: async (action, listenerApi) => {
-    const cohort = selectCohortById(
-      listenerApi.getState(),
-      action.payload.destId,
-    );
-    if (cohort && cohort?.counts.status !== "fulfilled") {
-      // only fetch if the cohort doesn't have a fullfilled caseCount
-      listenerApi.dispatch(fetchCohortCaseCounts(cohort.id));
     }
   },
 });

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
@@ -22,6 +22,7 @@ import {
   discardCohortChanges,
   showModal,
   Modals,
+  fetchCohortCaseCounts,
 } from "@gff/core";
 import { SaveOrCreateEntityBody } from "./SaveOrCreateEntityModal";
 import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
@@ -136,6 +137,11 @@ const SaveCohortModal = ({
             // which does not exist will cause this
             // Therefore, copy the unsaved cohort to the new cohort id received from
             // the BE.
+
+            // possible that the caseCount are undefined or pending so
+            // re-request counts.
+            coreDispatch(fetchCohortCaseCounts(payload.id)); // fetch counts for new cohort
+
             coreDispatch(
               setCohortMessage([`savedCurrentCohort|${newName}|${payload.id}`]),
             );


### PR DESCRIPTION
## Description
Fixes a race condition where a cohort is saved before the case counts request returns.
CaseCount code refactored to match the race condition resolution in the other slider (using requested) 
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
