### PR TITLE
PEAR-1762: Clean up image viewer/detail slice

### DIFF
--- a/packages/core/src/features/imageDetails/imageDetailsSlice.ts
+++ b/packages/core/src/features/imageDetails/imageDetailsSlice.ts
@@ -42,11 +42,7 @@ const slice = createSlice({
       .addCase(fetchImageDetails.fulfilled, (state, action) => {
         if (state.requestId != action.meta.requestId) return state;
 
-        const response = action.payload;
-
-        state.details = {
-          ...response,
-        };
+        state.details = action.payload;
         state.status = "fulfilled";
 
         return state;

--- a/packages/core/src/features/imageDetails/imageViewer.ts
+++ b/packages/core/src/features/imageDetails/imageViewer.ts
@@ -71,7 +71,7 @@ const slice = createSlice({
   name: "imageViewer",
   initialState,
   reducers: {
-    setShouldResetEdgesState(state) {
+    resetEdgesState(state) {
       state.edges = {};
     },
   },
@@ -111,7 +111,7 @@ const slice = createSlice({
 
 export const imageViewerReducer = slice.reducer;
 
-export const { setShouldResetEdgesState } = slice.actions;
+export const { resetEdgesState } = slice.actions;
 
 export const selectImageViewerInfo = (
   state: CoreState,

--- a/packages/portal-proto/src/components/ImageViewer/MultipleImageViewer.tsx
+++ b/packages/portal-proto/src/components/ImageViewer/MultipleImageViewer.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mantine/core";
 import {
   selectCurrentCohortFilters,
-  setShouldResetEdgesState,
+  resetEdgesState,
   useCoreDispatch,
   useCoreSelector,
   useImageViewer,
@@ -79,7 +79,7 @@ export const MultipleImageViewer = ({
 
   useEffect(() => {
     return () => {
-      dispatch(setShouldResetEdgesState());
+      dispatch(resetEdgesState());
     };
   }, [dispatch]);
 
@@ -105,7 +105,7 @@ export const MultipleImageViewer = ({
 
   const removeFilters = (filter: string) => {
     setSearchValues(searchValues.filter((value) => value !== filter));
-    dispatch(setShouldResetEdgesState());
+    dispatch(resetEdgesState());
     resetStates();
   };
 
@@ -119,7 +119,7 @@ export const MultipleImageViewer = ({
   };
 
   const performSearch = () => {
-    dispatch(setShouldResetEdgesState());
+    dispatch(resetEdgesState());
     setShowMorePressed(false);
     setSearchValues([searchText.toUpperCase().trim(), ...searchValues]);
     setSearchText("");


### PR DESCRIPTION
## Description
1. The state will not constantly grow as the state is being reset when the component unmounts.

2. It was found that the chance or scenario of race condition is highly unlikely. That might be a different case once Image Viewer will be an app.

**Note:**
Please verify that the multiple image viewer works as before.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
