### PR TITLE
QA-2133 Fix auto-maximize issue

### DIFF
--- a/holmes-py/step_impl/base/utility.py
+++ b/holmes-py/step_impl/base/utility.py
@@ -24,6 +24,7 @@ class Utility:
     def get_screen_size():
         # Try/except around pyautogui as a workaround to this not working within Docker runs
         if not getenv('IS_DOCKER'):
+            import AppKit
             import pyautogui
             width, height = pyautogui.size()
             return {"width": width, "height": height}


### PR DESCRIPTION
## Description
On some Mac operating systems, the auto-maximize does not work as expected resulting in tests bombing out pre-maturely. This simple fix will allow us fix that issue where the tests do not bomb out pre-maturely.

## Running the tests
1. Install the holmes-py as per the Readme.
2. Run this command:
```bash
gauge run specs
```

Expected:
On headed mode, the browser should maximize automatically and the tests should continue to run as expected without bombing out (even the first tests wouldn't run before on my system without this change)
