### PR TITLE
PEAR-1572 - Cancer gene census toggle not always reflecting user's change

### DIFF
--- a/packages/portal-proto/src/features/facets/ToggleFacet.tsx
+++ b/packages/portal-proto/src/features/facets/ToggleFacet.tsx
@@ -14,7 +14,7 @@ import { LoadingOverlay, Switch, Tooltip } from "@mantine/core";
 import { MdClose as CloseIcon } from "react-icons/md";
 
 const extractToggleValue = (values?: ReadonlyArray<string>): boolean =>
-  values && values.length > 0 && values.includes("true");
+  values !== undefined && values.length > 0 && values.includes("true");
 
 /**
  * Facet card for a boolean field


### PR DESCRIPTION
## Description
The function that parsed the toggle value was returned undefined when values was undefined instead of false so it wasn't updating correctly (undefined = I'm not passing in a value for this prop).

## Checklist

- [tried to add a unit test but testing library didn't accurately reflect the failure] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
