### PR TITLE
PEAR-1651 - Saving cohort 2nd time produces wrong message

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -344,7 +344,9 @@ const CohortManager: React.FC = () => {
               .unwrap()
               .then((response) => {
                 coreDispatch(
-                  setCohortMessage([`savedCohort|${cohortName}|${cohortId}`]),
+                  setCohortMessage([
+                    `savedCurrentCohort|${cohortName}|${cohortId}`,
+                  ]),
                 );
                 const cohort = {
                   id: response.id,


### PR DESCRIPTION
## Description
![2024-01-29 15 30 13](https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/bb71976c-9708-41d8-b32d-7d726d9c7bc5)

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
