### PR TITLE
Sjpp client 2.40.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.39.6",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.6.tgz",
-      "integrity": "sha512-ilnQQPRCb6GP107uKNaZrrVe4vA1+kEQqJizw2JBOTE9v6My8+r6x2A6l5zCRJ659TY5M844cIO+0DU29htnJQ=="
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.0.tgz",
+      "integrity": "sha512-XIQPEnRyEQZI//BoThfLguWBP611L/bZqOiFoukoQ/nR4yD8oDjqUK7NgCQVRk1L0snsddkbK5pWAD2s4+1HOA=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.39.6",
+        "@sjcrh/proteinpaint-client": "^2.40.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.39.6",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.39.6.tgz",
-      "integrity": "sha512-ilnQQPRCb6GP107uKNaZrrVe4vA1+kEQqJizw2JBOTE9v6My8+r6x2A6l5zCRJ659TY5M844cIO+0DU29htnJQ=="
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.0.tgz",
+      "integrity": "sha512-XIQPEnRyEQZI//BoThfLguWBP611L/bZqOiFoukoQ/nR4yD8oDjqUK7NgCQVRk1L0snsddkbK5pWAD2s4+1HOA=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.39.6",
+        "@sjcrh/proteinpaint-client": "^2.40.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.39.6",
+    "@sjcrh/proteinpaint-client": "^2.40.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -84,7 +84,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   const hideLoadingOverlay = () => setIsLoading(false);
   const matrixCallbacks: RxComponentCallbacks = {
     "postRender.gdcOncoMatrix": showLoadingOverlay,
-    "error.gdcOncoMatrix": showLoadingOverlay,
+    "error.gdcOncoMatrix": hideLoadingOverlay,
   };
   const appCallbacks: RxComponentCallbacks = {
     "preDispatch.gdcPlotApp": showLoadingOverlay,


### PR DESCRIPTION
## Description

Fixes:
- GDC bam slicing UI can still pull BAM files when experimental_strategy=Methylation Array filtering is used
- Support navigation-by-keyboard of bam UI elements
- Fix the display of no data error message and hiding of previously rendered heatmap in the hier cluster app
- For hierCluster, set left dendrogram position based on max gene label length, ignore variable labels.
- ignore the computed twlst of the hierCluster term group when tracking recoverable state
- Do not modify the hierCluster term group lst with server data, to avoid unnecessary state tracking and to prevent unwanted geneset edits
- Use the geneset edit UI when there is no initial computed geneset for hierCluster

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
