### PR TITLE
PEAR-1793 - Endless(?) graphql calls, cannot switch to another cohort successfully

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import { CollapsibleContainer } from "@/components/CollapsibleContainer";
 import { Loader, Tabs } from "@mantine/core";
 import { ContextualCasesView } from "../cases/CasesView/CasesView";
@@ -69,7 +70,7 @@ const ContextBar = ({
     selectCurrentCohortId(state),
   );
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (currentCohortId === undefined && cohorts.length > 0) {
       coreDispatch(setActiveCohort(cohorts[0].id));
     }


### PR DESCRIPTION
## Description
Prevent useEffect from triggering over and over again by using deep compare for cohorts

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
