### PR TITLE
PEAR-1791: Fix repository JSON does not include files data with FM and TP53 cohort

### DIFF
--- a/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
@@ -360,7 +360,8 @@ const FilesTables: React.FC = () => {
       endpoint: "files",
       method: "POST",
       params: {
-        filters: buildCohortGqlOperator(allFilters) ?? {},
+        case_filters: buildCohortGqlOperator(cohortFilters) ?? {},
+        filters: buildCohortGqlOperator(repositoryFilters) ?? {},
         size: 10000,
         attachment: true,
         format: "JSON",


### PR DESCRIPTION
## Description
Adds case_filters to JSON download in the repository FileTable. It local repository filters are passed as filters.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
