### PR TITLE
PEAR-1792: Fix Clinical and Biospecimen downloads don't include data with FM and TP53 cohort

### DIFF
--- a/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
@@ -318,7 +318,8 @@ export const ContextualCasesView: React.FC = () => {
         filename: `clinical.${
           pickedCases.length > 0 ? "cases_selection" : "cohort"
         }.${new Date().toISOString().slice(0, 10)}.tar.gz`,
-        filters: downloadFilter,
+        case_filters: downloadFilter, // NOTE: as downloadFilter is either a list of case_ids or the cohort's filters
+        // there are no local filters to be passed
         size: caseCounts,
       },
       done: () => setClinicalDownloadActive(false),
@@ -337,7 +338,7 @@ export const ContextualCasesView: React.FC = () => {
         filename: `clinical.${
           pickedCases.length > 0 ? "cases_selection" : "cohort"
         }.${new Date().toISOString().slice(0, 10)}.json`,
-        filters: downloadFilter,
+        case_filters: downloadFilter,
         size: caseCounts,
       },
       done: () => setClinicalDownloadActive(false),
@@ -354,7 +355,7 @@ export const ContextualCasesView: React.FC = () => {
         filename: `biospecimen.${
           pickedCases.length > 0 ? "cases_selection" : "cohort"
         }.${new Date().toISOString().slice(0, 10)}.tar.gz`,
-        filters: downloadFilter,
+        case_filters: downloadFilter,
         size: caseCounts,
       },
       done: () => setBiospecimenDownloadActive(false),
@@ -373,7 +374,7 @@ export const ContextualCasesView: React.FC = () => {
         filename: `biospecimen.${
           pickedCases.length > 0 ? "cases_selection" : "cohort"
         }.${new Date().toISOString().slice(0, 10)}.json`,
-        filters: downloadFilter,
+        case_filters: downloadFilter,
         size: caseCounts,
       },
       done: () => setBiospecimenDownloadActive(false),


### PR DESCRIPTION
## Description
changes `filters` to `case_filters` for the Clinical and Biospecimen downloads in CasesView.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
