### PR TITLE
Limit the loading overlay coverage outside of the tool div 

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -193,7 +193,11 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
           filters={newCohortFilters}
         />
       )}
-      <LoadingOverlay data-testid="loading-spinner" visible={isLoading} />
+      <LoadingOverlay
+        data-testid="loading-spinner"
+        visible={isLoading}
+        zIndex={0}
+      />
     </div>
   );
 };

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -190,7 +190,11 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
           filters={newCohortFilters}
         />
       )}
-      <LoadingOverlay data-testid="loading-spinner" visible={isLoading} />
+      <LoadingOverlay
+        data-testid="loading-spinner"
+        visible={isLoading}
+        zIndex={0}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description

This sets the zIndex=0 for the loading overlay of the OncoMatrix and Gene Expression tools, so that when scrolling, the overlay does not cover page elements that are outside of the tool div.

To test: Open the OncoMatrix and Gene Expression tools, and try to scroll while the data is being requested and processed. The loading overlay should only cover the tool div when scrolling.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
