### PR TITLE
update the proteinpaint-client version to 2.40.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.0.tgz",
-      "integrity": "sha512-XIQPEnRyEQZI//BoThfLguWBP611L/bZqOiFoukoQ/nR4yD8oDjqUK7NgCQVRk1L0snsddkbK5pWAD2s4+1HOA=="
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.1.tgz",
+      "integrity": "sha512-NaghHpOOr41ivqwTfNptGBf3gSomtXYBhzUKop8E2XR/D8vgLGgqNp3WrvLWuRXdyqcIHFJQMGQTdIq/Snz+AA=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.0",
+        "@sjcrh/proteinpaint-client": "^2.40.1",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.0.tgz",
-      "integrity": "sha512-XIQPEnRyEQZI//BoThfLguWBP611L/bZqOiFoukoQ/nR4yD8oDjqUK7NgCQVRk1L0snsddkbK5pWAD2s4+1HOA=="
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.1.tgz",
+      "integrity": "sha512-NaghHpOOr41ivqwTfNptGBf3gSomtXYBhzUKop8E2XR/D8vgLGgqNp3WrvLWuRXdyqcIHFJQMGQTdIq/Snz+AA=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.0",
+        "@sjcrh/proteinpaint-client": "^2.40.1",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.40.0",
+    "@sjcrh/proteinpaint-client": "^2.40.1",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Fixes
- Return a defined adjusted state for the GDC matrix and gene expression tools, so that the undo/redo component can react
- Increase the contrast of the table header text in the BAM files and variants list
- Fix the geneFilter handling in the gdc tool launchers

Known Issues:
- Gene Expression: cohort creation is not shown; list samples table is misplaced at the bottom of the screen
- OncoMatrix: list samples table is misplaced at the bottom of the screen

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
