### PR TITLE
update the proteinpaint-client version to 2.40.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.40.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.1.tgz",
-      "integrity": "sha512-NaghHpOOr41ivqwTfNptGBf3gSomtXYBhzUKop8E2XR/D8vgLGgqNp3WrvLWuRXdyqcIHFJQMGQTdIq/Snz+AA=="
+      "version": "2.40.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.2.tgz",
+      "integrity": "sha512-cqPg2Am7gH50nx3Qqa8Fzl3u33NU+73y5SFhxYCp2amw9+ntoCQshM2NpeNcNNAZmJsHRPTcMs0nqPGKBkODfg=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.1",
+        "@sjcrh/proteinpaint-client": "^2.40.2",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.40.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.1.tgz",
-      "integrity": "sha512-NaghHpOOr41ivqwTfNptGBf3gSomtXYBhzUKop8E2XR/D8vgLGgqNp3WrvLWuRXdyqcIHFJQMGQTdIq/Snz+AA=="
+      "version": "2.40.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.2.tgz",
+      "integrity": "sha512-cqPg2Am7gH50nx3Qqa8Fzl3u33NU+73y5SFhxYCp2amw9+ntoCQshM2NpeNcNNAZmJsHRPTcMs0nqPGKBkODfg=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.1",
+        "@sjcrh/proteinpaint-client": "^2.40.2",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.40.2",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.2.tgz",
-      "integrity": "sha512-cqPg2Am7gH50nx3Qqa8Fzl3u33NU+73y5SFhxYCp2amw9+ntoCQshM2NpeNcNNAZmJsHRPTcMs0nqPGKBkODfg=="
+      "version": "2.40.3",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.3.tgz",
+      "integrity": "sha512-YdEanhxsv794yHuerq33XADKSzMK+C0ziRyQIgBa0dqlgQ2y4Hmm2GpFIcM1go6uxvNj/54oFAsbawyTmsTfIw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.2",
+        "@sjcrh/proteinpaint-client": "^2.40.3",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.40.2",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.2.tgz",
-      "integrity": "sha512-cqPg2Am7gH50nx3Qqa8Fzl3u33NU+73y5SFhxYCp2amw9+ntoCQshM2NpeNcNNAZmJsHRPTcMs0nqPGKBkODfg=="
+      "version": "2.40.3",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.3.tgz",
+      "integrity": "sha512-YdEanhxsv794yHuerq33XADKSzMK+C0ziRyQIgBa0dqlgQ2y4Hmm2GpFIcM1go6uxvNj/54oFAsbawyTmsTfIw=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.2",
+        "@sjcrh/proteinpaint-client": "^2.40.3",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.40.1",
+    "@sjcrh/proteinpaint-client": "^2.40.3",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -93,7 +93,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
     // and that also does not emit a postRender event, in which case, this app.callbacks.postRender is
     // a backup to close the loading overlay when there are no state changes to the matrix
     // app and so would not have been updated via the rx component.update() chain to rerender
-    "postRender.gdcGeneExpression": hideLoadingOverlay,
+    "postRender.gdcPlotApp": hideLoadingOverlay,
   };
 
   useEffect(

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -83,13 +83,13 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   const showLoadingOverlay = () => setIsLoading(true);
   const hideLoadingOverlay = () => setIsLoading(false);
   const matrixCallbacks: RxComponentCallbacks = {
-    "postRender.gdcOncoMatrix": showLoadingOverlay,
+    "postRender.gdcOncoMatrix": hideLoadingOverlay,
     "error.gdcOncoMatrix": hideLoadingOverlay,
   };
   const appCallbacks: RxComponentCallbacks = {
     "preDispatch.gdcPlotApp": showLoadingOverlay,
     "error.gdcPlotApp": hideLoadingOverlay,
-    "postRender.gdcGeneExpression": hideLoadingOverlay,
+    "postRender.gdcPlotApp": hideLoadingOverlay,
   };
 
   useEffect(
@@ -133,7 +133,6 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
         // showing and hiding the overlay should be triggered by components that may take a while to load/render,
         // this wrapper code can show the overlay here since it has supplied postRender callbacks above,
         // but ideally it is the PP-app that triggers both the showing and hiding of the overlay for reliable behavior
-        showLoadingOverlay();
         initialFilter0Ref.current = data;
         const toolContainer = rootElem.parentNode.parentNode
           .parentNode as HTMLElement;


### PR DESCRIPTION
## Description

Fixes:
- Fix OncoMatrix and Gene Expression brushing and list samples issue
- Refresh the case count when there is no matching oncomatrix data
- Skip OncoMatrix data processing steps after detecting stale action, to avoid confusing rerenders   
- Pass opts.hierCluster in the launcher to handle create cohort
- Hide the rendered OncoMatrix and Gene Expression svg/canvas on error or matching data
- Darken table2col row titles to meet Section 508 contrast requirements
- Do not show the option to replace a gene expression/hierCluster term

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
