### PR TITLE
update the proteinpaint-client to 2.40.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.40.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.3.tgz",
-      "integrity": "sha512-YdEanhxsv794yHuerq33XADKSzMK+C0ziRyQIgBa0dqlgQ2y4Hmm2GpFIcM1go6uxvNj/54oFAsbawyTmsTfIw=="
+      "version": "2.40.5",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.5.tgz",
+      "integrity": "sha512-tiNdWKsfpXKhxsTvwo/3Msxx390YT01a+16iz0WpBYNXr56WrZqFLDYgzNqCYiHpMS5XSEiSP5cCzubvOKULmw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.3",
+        "@sjcrh/proteinpaint-client": "^2.40.5",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.40.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.3.tgz",
-      "integrity": "sha512-YdEanhxsv794yHuerq33XADKSzMK+C0ziRyQIgBa0dqlgQ2y4Hmm2GpFIcM1go6uxvNj/54oFAsbawyTmsTfIw=="
+      "version": "2.40.5",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.5.tgz",
+      "integrity": "sha512-tiNdWKsfpXKhxsTvwo/3Msxx390YT01a+16iz0WpBYNXr56WrZqFLDYgzNqCYiHpMS5XSEiSP5cCzubvOKULmw=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.3",
+        "@sjcrh/proteinpaint-client": "^2.40.5",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.40.3",
+    "@sjcrh/proteinpaint-client": "^2.40.5",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Fixes:
- do not redispatch a plot_splice from the oncomatrix and gene expression launchers
- Hide the undo/redo buttons until a more thorough fix is implemented for the oncomatrix and gene expression

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
