### PR TITLE
update the proteinpaint-client version to 2.40.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,9 +6566,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.40.5",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.5.tgz",
-      "integrity": "sha512-tiNdWKsfpXKhxsTvwo/3Msxx390YT01a+16iz0WpBYNXr56WrZqFLDYgzNqCYiHpMS5XSEiSP5cCzubvOKULmw=="
+      "version": "2.40.6",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.6.tgz",
+      "integrity": "sha512-B0soNSY3dKsIDgvSUq7SYxwVyayzlZrSizpNuVUcpcd6YtCMb3Y8+UJ9quqpmSdf6Gzz/GEdmNJ50GSxAJqJcw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26960,7 +26960,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.5",
+        "@sjcrh/proteinpaint-client": "^2.40.6",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32245,9 +32245,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.40.5",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.5.tgz",
-      "integrity": "sha512-tiNdWKsfpXKhxsTvwo/3Msxx390YT01a+16iz0WpBYNXr56WrZqFLDYgzNqCYiHpMS5XSEiSP5cCzubvOKULmw=="
+      "version": "2.40.6",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.6.tgz",
+      "integrity": "sha512-B0soNSY3dKsIDgvSUq7SYxwVyayzlZrSizpNuVUcpcd6YtCMb3Y8+UJ9quqpmSdf6Gzz/GEdmNJ50GSxAJqJcw=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -41919,7 +41919,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.5",
+        "@sjcrh/proteinpaint-client": "^2.40.6",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.40.5",
+    "@sjcrh/proteinpaint-client": "^2.40.6",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

@craigrbarnes I had to implement a loading overlay for the geneset that initially loads for OncoMatrix and Gene Expression fully renders, as part of making sure that the initial geneset matches the cohort that's selected before the tool fully renders. I can restyle this as needed, please let me know. I am able to use the standard portal loading overlay with the correct timing to disappear, but the await chain may cause the initial geneset to ignore the cohort changes that a user may do on page load. I thought for now, it's safer to make sure the rendered data is correct and take care of matching the loading overlay more precisely later.

![Screenshot 2024-02-05 at 7 11 38 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/411031/c9b7d81f-2807-4dbf-b07a-9c4d594904df)


Fixes:
- Refactor and improve backend GDC BAM slicing logic
- BAM track in variant-typing mode, read group header clicking is disabled due to known issue with GFF
- GDC BAM slicing will reject if range>=50kb to be safe
- Reliably detect stale async results using a rx component api method
- Cancel stale fetch requests to unblock current geneset, matrix, and hierCluster requests that are being throttled by the browser's concurrent request limit
- Do not re-render the matrix controls as part of displaying a no data message when svg dimensions and layout have not been computed yet
- Do not assign a non-auth related error as a token verification message, which caused the matrix to not rerender even with subsequent valid data. (NOTE: The token here is not used for GDC login, only in an SJ portal)
- Do not display a mouseover over a hidden matrix or hier cluster svg
- An unrendered matrix or hierCluster should not react to window resize


## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
