### PR TITLE
PEAR-1807 - Cart's File counts by auth level displays the wrong information

### DIFF
--- a/packages/portal-proto/src/features/cart/AuthorizationTable.tsx
+++ b/packages/portal-proto/src/features/cart/AuthorizationTable.tsx
@@ -6,10 +6,12 @@ import VerticalTable from "@/components/Table/VerticalTable";
 
 interface AuthorizationTableProps {
   readonly filesByCanAccess: Record<string, CartFile[]>;
+  readonly loading: boolean;
 }
 
 const AuthorizationTable: React.FC<AuthorizationTableProps> = ({
   filesByCanAccess,
+  loading,
 }: AuthorizationTableProps) => {
   const authorizationTableData = [
     {
@@ -58,6 +60,7 @@ const AuthorizationTable: React.FC<AuthorizationTableProps> = ({
     <VerticalTable
       data={authorizationTableData}
       columns={authorizationTableColumns}
+      status={loading ? "pending" : "fulfilled"}
     />
   );
 };

--- a/packages/portal-proto/src/features/cart/Cart.tsx
+++ b/packages/portal-proto/src/features/cart/Cart.tsx
@@ -38,7 +38,8 @@ const Cart: React.FC = () => {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const cart = useCoreSelector((state) => selectCart(state));
   const { data: summaryData } = useCartSummary(cart.map((f) => f.file_id));
-  const { data: userDetails } = useUserDetails();
+  const { data: userDetails, isFetching: userDetailsFetching } =
+    useUserDetails();
   const filesByCanAccess = groupByAccess(cart, userDetails);
   const dbGapList = Array.from(
     new Set(
@@ -159,7 +160,10 @@ const Cart: React.FC = () => {
         <div className="flex gap-8 mt-4">
           <div className="flex-1">
             <HeaderTitle>File counts by authorization level</HeaderTitle>
-            <AuthorizationTable filesByCanAccess={filesByCanAccess} />
+            <AuthorizationTable
+              filesByCanAccess={filesByCanAccess}
+              loading={userDetailsFetching}
+            />
           </div>
           <div className="flex-1">
             <HeaderTitle>File counts by project</HeaderTitle>


### PR DESCRIPTION
## Description
Fix authorization table update issues by adding data status

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
