### PR TITLE
PEAR-1759/1715/1689 X button, aria-label fixes, removes demo button

### DIFF
--- a/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
+++ b/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
@@ -32,7 +32,12 @@ class ClearStoreErrorBoundary extends Component<
         this.props.router.push("/");
       } else {
         return (
-          <Modal opened onClose={undefined} title="Unexpected Error">
+          <Modal
+            opened
+            withCloseButton={false}
+            onClose={undefined}
+            title="Unexpected Error"
+          >
             <p className="py-2 px-4">
               An unexpected error has occurred. Your saved cohorts are being
               recovered, but your cart and sets may be lost.

--- a/packages/portal-proto/src/features/cohortComparison/AdditionalCohortSelection.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/AdditionalCohortSelection.tsx
@@ -22,7 +22,6 @@ interface AdditionalCohortSelectionProps {
 }
 
 const AdditionalCohortSelection: React.FC<AdditionalCohortSelectionProps> = ({
-  app,
   setActiveApp,
   setOpen,
   setComparisonCohort,
@@ -38,11 +37,6 @@ const AdditionalCohortSelection: React.FC<AdditionalCohortSelectionProps> = ({
   );
 
   const [selectedCohort, setSelectedCohort] = useState<Cohort>(null);
-
-  const closeCohortSelection = () => {
-    setOpen(false);
-    setSelectedCohort(null);
-  };
 
   const cohortListTableColumnHelper = createColumnHelper<typeof cohorts[0]>();
 
@@ -155,16 +149,6 @@ const AdditionalCohortSelection: React.FC<AdditionalCohortSelectionProps> = ({
         </div>
       </div>
       <div className="flex flex-row justify-end w-full sticky bottom-0 bg-base-lightest py-2 px-4">
-        <FunctionButton
-          data-testid="button-demo-cohort-comparison"
-          className="mr-auto"
-          onClick={() => {
-            setActiveApp(app, true);
-            closeCohortSelection();
-          }}
-        >
-          Demo
-        </FunctionButton>
         <FunctionButton
           data-testid="button-cancel-cohort-comparison"
           className="mr-4"

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -858,7 +858,7 @@ const NumericRangeFacet: React.FC<NumericFacetProps> = ({
                 <FacetIconButton
                   onClick={toggleFlip}
                   aria-pressed={!isFacetView}
-                  aria-label="chart view"
+                  aria-label={isFacetView ? "Chart view" : "Selection view"}
                 >
                   <FlipIcon size="1.45em" className={controlsIconStyle} />
                 </FacetIconButton>

--- a/packages/portal-proto/src/features/set-operations/SelectionPanel.tsx
+++ b/packages/portal-proto/src/features/set-operations/SelectionPanel.tsx
@@ -161,7 +161,6 @@ interface SelectionPanelProps {
 }
 
 const SelectionPanel: React.FC<SelectionPanelProps> = ({
-  app,
   setActiveApp,
   setOpen,
   selectedEntities,
@@ -435,17 +434,6 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
         </div>
       </div>
       <div className="flex flex-row justify-end w-full sticky bottom-0 bg-base-lightest py-2 px-4">
-        <FunctionButton
-          className="mr-auto"
-          onClick={() => {
-            setSelectedEntityType(undefined);
-            setSelectedEntities([]);
-            setActiveApp(app, true);
-            setOpen(false);
-          }}
-        >
-          Demo
-        </FunctionButton>
         <FunctionButton
           className="mr-4"
           onClick={() => {


### PR DESCRIPTION
## Description
- PEAR-1759: removes X button from unexpected error modal because the X button doesn't do anything
- PEAR-1715: adjusts/fixes aria-label for the flip button on range cards
- PEAR-1689: removes the Demo buttons from the selection view of Cohort Comparison and Set Operations because they were deemed confusing

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

**Removed X button:**

<img width="672" alt="Screenshot 2024-02-14 at 8 43 45 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/37eef5ea-dda3-43a0-9f46-5f8423ea0628">

**Changed aria-label:**

<img width="1691" alt="Screenshot 2024-02-14 at 9 10 30 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/fa930d7f-dfb1-4689-a4de-8095147495e5">

<img width="1684" alt="Screenshot 2024-02-14 at 9 10 42 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/7ce2b48e-194d-4ca2-b46b-027f395838d0">

**Removed Demo buttons:**

<img width="1721" alt="Screenshot 2024-02-14 at 9 56 36 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/2f63d4fc-5e34-4bcc-8c04-5b96a0cc0f1b">

<img width="1725" alt="Screenshot 2024-02-14 at 9 56 46 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/b92b0e98-b7dd-4ad8-b488-886d1812a833">

__
To test the X button, you can use the steps for the bug in PEAR-1816 to cause the modal to show up. 