### PR TITLE
QA-2074 Check for gdc_context_id cookie is accessible using Javascript

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/home_page/access_gdc_cookie.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/home_page/access_gdc_cookie.spec
@@ -1,0 +1,12 @@
+# Home Page - Check Cookies
+Date Created    : 02/14/2024
+Version		    : 1.0
+Owner		    : GDC QA
+Description	    : Check Cookie - Home Page
+Test-case       : QA-2074
+
+tags: gdc-data-portal-v2, regression, home-page, cookie
+
+## Navigate to Home Page
+* On GDC Data Portal V2 app
+* Check that "gdc_context_id" cookie is accessible using Javascript and that it's generated using uuid version "4"

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -1,9 +1,10 @@
 import json
+import re
 import tarfile
 import time
-import re
 
 from datetime import datetime as dt
+from uuid import UUID, uuid4
 
 from getgauge.python import step, before_spec, after_spec, before_suite, data_store
 
@@ -647,3 +648,17 @@ def click_nav_item_check_text_in_new_tab(page_name: str, table):
         is_text_visible = APP.shared.is_text_visible_on_new_tab(new_tab,v[1])
         assert is_text_visible, f"After click on '{v[0]}', the expected text '{v[1]}' in NOT present"
         new_tab.close()
+
+@step("Check that <var_to_check> cookie is accessible using Javascript and that it's generated using uuid version <ver>")
+def check_if_cookie_accessible(var_to_check:str, ver:int):
+    cookie = APP.driver.evaluate('()=>document.cookie')
+    var_to_check += "="
+
+    # check to see if gdc_context_id exists in cookie
+    assert var_to_check in cookie
+
+    start_value = cookie[cookie.index(var_to_check)+len(var_to_check):]
+    gdc_context_id = start_value[:start_value.find(";")]
+
+    # check if the gdc_context_id is version 4
+    assert UUID(gdc_context_id).version == int(ver)


### PR DESCRIPTION
## Description
Check whether the `gdc_context_id` is accessible using Javascript

Additional check was made to ensure that the `gdc_context_id` was generated using uuid4.

