### PR TITLE
(PEAR-1764): properly use mantine Switch component built in label

### DIFF
--- a/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
+++ b/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
@@ -1,8 +1,5 @@
 import React, { ReactNode } from "react";
-import { useSpring, animated } from "@react-spring/web";
-import { Tooltip } from "@mantine/core";
-import classNames from "classnames";
-import { createKeyboardAccessibleFunction } from "src/utils/";
+import { Tooltip, Switch } from "@mantine/core";
 
 interface SwitchSpringProps {
   isActive: boolean;
@@ -27,22 +24,9 @@ const SwitchSpring: React.FC<SwitchSpringProps> = ({
   margin,
   survivalProps,
 }: SwitchSpringProps) => {
-  const ballSpring = useSpring({
-    width: 20,
-    y: 0,
-    x: isActive ? 12 : -4,
-  });
-
-  const sliderSpring = useSpring({
-    width: 35,
-  });
-
   const { plot } = survivalProps ?? { plot: "" };
 
   const toggleSwitch = () => {
-    if (disabled) {
-      return;
-    }
     // todo: if used for > 2 icons refactor to use switch(icon) statement
     icon
       ? handleSwitch(selected[`symbol`], selected[`name`], plot)
@@ -55,36 +39,27 @@ const SwitchSpring: React.FC<SwitchSpringProps> = ({
       disabled={!tooltip}
       data-testid="tooltipSwitchSpring"
     >
-      <animated.div
-        data-testid="button-middle-switchSpring"
-        style={sliderSpring}
-        className={classNames(
-          "border border-lightgray",
-          disabled ? "cursor-not-allowed" : "cursor-pointer",
-          {
-            "rounded-xl": icon,
-          },
-          isActive ? "bg-activeColor" : "bg-gray-300",
-        )}
-        onClick={toggleSwitch}
-        onKeyDown={createKeyboardAccessibleFunction(toggleSwitch)}
-        aria-disabled={disabled}
-        tabIndex={0}
-        aria-label={tooltip}
-      >
-        <animated.div
-          data-testid="button-bottom-switchSpring"
-          style={ballSpring}
-          className={`ml-1 border-2 rounded-sm ${
-            disabled ? "border-gray-300" : "border-activeColor"
-          }
-             bg-white ${icon && `rounded-xl`} ${
-            isActive && `bg-lightgray`
-          } h-5`}
-        >
-          <div className={margin}>{icon}</div>
-        </animated.div>
-      </animated.div>
+      {/* div added otherwise tooltip does not work in mantine 6 */}
+      <div>
+        <Switch
+          data-testid="button-middle-switchSpring"
+          classNames={{
+            thumb: `border-2 rounded-sm w-5 h-5 ${
+              disabled ? "border-gray-300" : "border-activeColor"
+            } ${margin}`,
+            input: "",
+            track: `overflow-visible border border-base-lightest ${
+              disabled ? "cursor-not-allowed" : "cursor-pointer"
+            } ${isActive ? "bg-activeColor" : "bg-gray-300"}`,
+            root: disabled ? "cursor-not-allowed" : "cursor-pointer",
+          }}
+          aria-label={tooltip}
+          checked={isActive}
+          onChange={toggleSwitch}
+          disabled={disabled}
+          thumbIcon={icon}
+        />
+      </div>
     </Tooltip>
   );
 };

--- a/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
+++ b/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
@@ -44,11 +44,11 @@ const SwitchSpring: React.FC<SwitchSpringProps> = ({
         <Switch
           data-testid="button-switchspring"
           classNames={{
-            thumb: `border-2 rounded-sm w-5 h-5 ${
+            thumb: `border-2 rounded w-5 h-5 ${
               disabled ? "border-gray-300" : "border-activeColor"
-            } ${margin}`,
+            } ${margin} ${isActive ? "left-auto right-0" : "left-0"}`,
             input: "",
-            track: `overflow-visible border border-base-lightest ${
+            track: `rounded box-content overflow-visible border border-base-lightest ${
               disabled ? "cursor-not-allowed" : "cursor-pointer"
             } ${isActive ? "bg-activeColor" : "bg-gray-300"}`,
             root: disabled ? "cursor-not-allowed" : "cursor-pointer",

--- a/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
+++ b/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
@@ -42,7 +42,7 @@ const SwitchSpring: React.FC<SwitchSpringProps> = ({
       {/* div added otherwise tooltip does not work in mantine 6 */}
       <div>
         <Switch
-          data-testid="switchSpring-checkbox"
+          data-testid="button-switchspring"
           classNames={{
             thumb: `border-2 rounded-sm w-5 h-5 ${
               disabled ? "border-gray-300" : "border-activeColor"

--- a/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
+++ b/packages/portal-proto/src/components/SwitchSpring/shared/SwitchSpring.tsx
@@ -42,7 +42,7 @@ const SwitchSpring: React.FC<SwitchSpringProps> = ({
       {/* div added otherwise tooltip does not work in mantine 6 */}
       <div>
         <Switch
-          data-testid="button-middle-switchSpring"
+          data-testid="switchSpring-checkbox"
           classNames={{
             thumb: `border-2 rounded-sm w-5 h-5 ${
               disabled ? "border-gray-300" : "border-activeColor"

--- a/packages/portal-proto/src/components/SwitchSpring/shared/tests/SwitchSpring.unit.test.tsx
+++ b/packages/portal-proto/src/components/SwitchSpring/shared/tests/SwitchSpring.unit.test.tsx
@@ -47,13 +47,6 @@ describe("<SwitchSpring />", () => {
       />,
     );
 
-    expect(getByTestId("button-middle-switchSpring")).toHaveClass(
-      "cursor-not-allowed",
-    );
-
-    expect(getByTestId("button-bottom-switchSpring")).toHaveClass(
-      "border-gray-300",
-    );
     await userEvent.click(getByTestId("button-middle-switchSpring"));
 
     expect(mockHandleSwitch).not.toBeCalled();
@@ -73,13 +66,6 @@ describe("<SwitchSpring />", () => {
       />,
     );
 
-    expect(getByTestId("button-middle-switchSpring")).not.toHaveClass(
-      "cursor-not-allowed",
-    );
-
-    expect(getByTestId("button-bottom-switchSpring")).toHaveClass(
-      "border-activeColor",
-    );
     await userEvent.click(getByTestId("button-middle-switchSpring"));
 
     expect(mockHandleSwitch).toBeCalled();

--- a/packages/portal-proto/src/components/SwitchSpring/shared/tests/SwitchSpring.unit.test.tsx
+++ b/packages/portal-proto/src/components/SwitchSpring/shared/tests/SwitchSpring.unit.test.tsx
@@ -47,7 +47,7 @@ describe("<SwitchSpring />", () => {
       />,
     );
 
-    await userEvent.click(getByTestId("button-middle-switchSpring"));
+    await userEvent.click(getByTestId("switchSpring-checkbox"));
 
     expect(mockHandleSwitch).not.toBeCalled();
   });
@@ -66,7 +66,7 @@ describe("<SwitchSpring />", () => {
       />,
     );
 
-    await userEvent.click(getByTestId("button-middle-switchSpring"));
+    await userEvent.click(getByTestId("switchSpring-checkbox"));
 
     expect(mockHandleSwitch).toBeCalled();
   });

--- a/packages/portal-proto/src/components/SwitchSpring/shared/tests/SwitchSpring.unit.test.tsx
+++ b/packages/portal-proto/src/components/SwitchSpring/shared/tests/SwitchSpring.unit.test.tsx
@@ -47,7 +47,7 @@ describe("<SwitchSpring />", () => {
       />,
     );
 
-    await userEvent.click(getByTestId("switchSpring-checkbox"));
+    await userEvent.click(getByTestId("button-switchspring"));
 
     expect(mockHandleSwitch).not.toBeCalled();
   });
@@ -66,7 +66,7 @@ describe("<SwitchSpring />", () => {
       />,
     );
 
-    await userEvent.click(getByTestId("switchSpring-checkbox"));
+    await userEvent.click(getByTestId("button-switchspring"));
 
     expect(mockHandleSwitch).toBeCalled();
   });

--- a/packages/portal-proto/src/features/cDave/Controls.tsx
+++ b/packages/portal-proto/src/features/cDave/Controls.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import {
-  Box,
   Switch,
   Divider,
   Tooltip,
@@ -145,71 +144,9 @@ const FieldControl: React.FC<FieldControlProps> = ({
     <li key={field.full} className="px-2 pt-2">
       {searchTerm ? (
         <>
-          <div className="flex justify-between items-center pb-1">
-            <label
-              className="font-content font-medium text-md"
-              htmlFor={`switch-${field.full}`}
-            >
-              <Highlight highlight={searchTerm}>{displayName}</Highlight>
-            </label>
-            <Switch
-              styles={(theme) => ({
-                track: {
-                  "&:hover": {
-                    backgroundColor: theme.fn.darken(
-                      tailwindConfig.theme.extend.colors[
-                        COLOR_MAP[field.field_type]
-                      ]?.DEFAULT,
-                      0.05,
-                    ),
-                  },
-                },
-                input: {
-                  "&:checked + .mantine-Switch-track": {
-                    backgroundColor:
-                      tailwindConfig.theme.extend.colors[
-                        COLOR_MAP[field.field_type]
-                      ]?.DEFAULT,
-                    borderColor:
-                      tailwindConfig.theme.extend.colors[
-                        COLOR_MAP[field.field_type]
-                      ]?.DEFAULT,
-                  },
-                },
-              })}
-              classNames={{
-                input: "bg-none rounded-lg",
-              }}
-              checked={checked}
-              onChange={(e) => {
-                setChecked(e.currentTarget.checked);
-                updateFields(field.full);
-              }}
-              id={`switch-${field.full}`}
-            />
-          </div>
-          <Highlight highlight={searchTerm}>
-            {field?.description || ""}
-          </Highlight>
-        </>
-      ) : (
-        <div className="flex justify-between cursor-pointer items-center bg-none py-2">
-          <Tooltip
-            label={field?.description || "No description available"}
-            withArrow
-            width={200}
-            multiline
-          >
-            <Box>
-              <label
-                className="pointer-events-none font-content font-medium"
-                htmlFor={`switch-${field.full}`}
-              >
-                {displayName}
-              </label>
-            </Box>
-          </Tooltip>
           <Switch
+            label={<Highlight highlight={searchTerm}>{displayName}</Highlight>}
+            labelPosition="left"
             styles={(theme) => ({
               track: {
                 "&:hover": {
@@ -235,16 +172,70 @@ const FieldControl: React.FC<FieldControlProps> = ({
               },
             })}
             classNames={{
-              input: "bg-none rounded-lg",
+              root: "py-2",
+              body: "flex justify-between items-center",
+              label:
+                "cursor-pointer text-base text-black font-content font-medium",
+              track: "cursor-pointer",
             }}
             checked={checked}
             onChange={(e) => {
               setChecked(e.currentTarget.checked);
               updateFields(field.full);
             }}
-            id={`switch-${field.full}`}
           />
-        </div>
+          <Highlight highlight={searchTerm}>
+            {field?.description || ""}
+          </Highlight>
+        </>
+      ) : (
+        <Tooltip
+          label={field?.description || "No description available"}
+          withArrow
+          width={200}
+          multiline
+        >
+          <Switch
+            label={displayName}
+            labelPosition="left"
+            styles={(theme) => ({
+              track: {
+                "&:hover": {
+                  backgroundColor: theme.fn.darken(
+                    tailwindConfig.theme.extend.colors[
+                      COLOR_MAP[field.field_type]
+                    ]?.DEFAULT,
+                    0.05,
+                  ),
+                },
+              },
+              input: {
+                "&:checked + .mantine-Switch-track": {
+                  backgroundColor:
+                    tailwindConfig.theme.extend.colors[
+                      COLOR_MAP[field.field_type]
+                    ]?.DEFAULT,
+                  borderColor:
+                    tailwindConfig.theme.extend.colors[
+                      COLOR_MAP[field.field_type]
+                    ]?.DEFAULT,
+                },
+              },
+            })}
+            classNames={{
+              root: "py-2",
+              body: "flex justify-between items-center",
+              label:
+                "cursor-pointer text-base text-black font-content font-medium",
+              track: "cursor-pointer",
+            }}
+            checked={checked}
+            onChange={(e) => {
+              setChecked(e.currentTarget.checked);
+              updateFields(field.full);
+            }}
+          />
+        </Tooltip>
       )}
       <Divider />
     </li>

--- a/packages/portal-proto/src/features/facets/ToggleFacet.tsx
+++ b/packages/portal-proto/src/features/facets/ToggleFacet.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo, useId } from "react";
+import React, { useMemo } from "react";
 import { EnumFacetHooks, FacetCardProps } from "./types";
 import { updateFacetEnum } from "./utils";
 
 import {
   controlsIconStyle,
   FacetIconButton,
-  FacetLabelText,
+  FacetText,
   FacetHeader,
 } from "@/features/facets/components";
 
@@ -57,8 +57,6 @@ const ToggleFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
     else clearFilters(field);
   };
 
-  const labelId = useId();
-
   return (
     <div
       className={`flex flex-col ${
@@ -74,7 +72,7 @@ const ToggleFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
           withArrow
           transitionProps={{ duration: 200, transition: "fade" }}
         >
-          <FacetLabelText htmlFor={labelId}>{facetTitle}</FacetLabelText>
+          <FacetText>{facetTitle}</FacetText>
         </Tooltip>
         <div className="flex flex-row">
           {dismissCallback && (
@@ -99,17 +97,22 @@ const ToggleFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
         <div className="flex flex-nowrap justify-between items-center p-2 ">
           <LoadingOverlay data-testid="loading-spinner" visible={!isSuccess} />
           <Switch
+            label={
+              data === undefined || Object.keys(data).length == 0
+                ? "No data for this field"
+                : data["1"].toLocaleString("en-US")
+            }
             color="accent"
             checked={toggleValue}
             onChange={(event) => setValue(event.currentTarget.checked)}
-            id={labelId}
+            aria-label={facetTitle}
             data-testid="toggle-facet-value"
+            classNames={{
+              root: "w-full",
+              body: "flex justify-between items-center",
+              label: "text-xs font-content",
+            }}
           />
-          <p className="font-content">
-            {data === undefined || Object.keys(data).length == 0
-              ? "No data for this field"
-              : data["1"].toLocaleString("en-US")}
-          </p>
         </div>
       </div>
     </div>

--- a/packages/portal-proto/src/features/facets/components.ts
+++ b/packages/portal-proto/src/features/facets/components.ts
@@ -18,10 +18,6 @@ export const FacetText = tw.div`
 text-primary-contrast-darker font-heading font-semibold text-[1.25em] break-words py-2
 `;
 
-export const FacetLabelText = tw.label`
-text-primary-contrast-darker font-heading font-semibold text-[1.25em] break-words py-2
-`;
-
 export const FacetHeader = tw.div`
 flex items-start justify-between flex-nowrap bg-primary-darker px-2
 `;


### PR DESCRIPTION
## Description

- change instances of mantine Switch component to use built in label in preparation for mantine patch 
- convert SwitchSpring to use mantine Switch component
- adjust tests and test ids to better match new SwitchSpring code

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

