### PR TITLE
PEAR-1536 - cDAVE - Adding multiple filters and selecting survival plot, box/qq plots cause performance slow down   

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@reactour/tour": "^2.9.0",
         "classnames": "^2.3.1",
         "dom-to-svg": "^0.12.2",
+        "echarts": "^5.4.3",
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
         "immutability-helper": "^3.1.1",
@@ -11573,6 +11574,20 @@
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/echarts": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.4.4"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -27058,6 +27073,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zrender": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
     "packages/core": {
       "name": "@gff/core",
       "version": "2.12.0",
@@ -35934,6 +35962,22 @@
     "eastasianwidth": {
       "version": "0.2.0",
       "dev": true
+    },
+    "echarts": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "requires": {
+        "tslib": "2.3.0",
+        "zrender": "5.4.4"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     },
     "ee-first": {
       "version": "1.1.1"
@@ -46232,6 +46276,21 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zrender": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "requires": {
+        "tslib": "2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@reactour/tour": "^2.9.0",
     "classnames": "^2.3.1",
     "dom-to-svg": "^0.12.2",
+    "echarts": "^5.4.3",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
     "immutability-helper": "^3.1.1",

--- a/packages/core/src/features/clinicalDataAnalysis/clinicalFieldsSlice.ts
+++ b/packages/core/src/features/clinicalDataAnalysis/clinicalFieldsSlice.ts
@@ -1,12 +1,4 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import {
-  createUseCoreDataHook,
-  DataStatus,
-  CoreDataSelectorResponse,
-} from "../../dataAccess";
-import { CoreDispatch } from "../../store";
-import { CoreState } from "../../reducers";
-import { GraphQLApiResponse, graphqlAPI } from "../gdcapi/gdcgraphql";
+import { graphqlAPISlice } from "../gdcapi/gdcgraphql";
 
 const graphQLQuery = `
   query CDaveFields {
@@ -30,74 +22,22 @@ const graphQLQuery = `
   }
 `;
 
-export const fetchClinicalFieldsResult = createAsyncThunk<
-  GraphQLApiResponse,
-  void,
-  { dispatch: CoreDispatch; state: CoreState }
->("clinicalFields", async () => {
-  return await graphqlAPI(graphQLQuery, {});
-});
-
 interface CDaveField {
   readonly description?: string;
   readonly name: string;
 }
 
-export interface ClinicalFieldsResult {
-  data: CDaveField[];
-  status: DataStatus;
-  readonly requestId?: string;
-}
-
-const initialState: ClinicalFieldsResult = {
-  data: [],
-  status: "uninitialized",
-};
-
-const slice = createSlice({
-  name: "clinicalFields",
-  initialState,
-  reducers: {},
-  extraReducers: (builder) => {
-    builder
-      .addCase(fetchClinicalFieldsResult.fulfilled, (state, action) => {
-        if (state.requestId != action.meta.requestId) return state;
-        const response = action.payload;
-
-        if (response.errors) {
-          state.status = "rejected";
-          return state;
-        } else {
-          state.status = "fulfilled";
-          state.data = response.data.introspectiveType.fields[1].type.fields;
-        }
-        return state;
-      })
-      .addCase(fetchClinicalFieldsResult.pending, (state, action) => {
-        state.status = "pending";
-        state.requestId = action.meta.requestId;
-        return state;
-      })
-      .addCase(fetchClinicalFieldsResult.rejected, (state, action) => {
-        if (state.requestId != action.meta.requestId) return state;
-        state.status = "rejected";
-        return state;
-      });
-  },
+const clinicalFieldsAPISlice = graphqlAPISlice.injectEndpoints({
+  endpoints: (builder) => ({
+    clinicalFields: builder.query<CDaveField[], void>({
+      query: () => ({
+        graphQLQuery,
+        graphQLFilters: {},
+      }),
+      transformResponse: (response) =>
+        response.data.introspectiveType.fields[1].type.fields,
+    }),
+  }),
 });
 
-export const clinicalFieldsReducer = slice.reducer;
-
-export const selectClinicalFieldsData = (
-  state: CoreState,
-): CoreDataSelectorResponse<CDaveField[]> => {
-  return {
-    data: state.clinicalDataAnalysis.fields.data,
-    status: state.clinicalDataAnalysis.fields.status,
-  };
-};
-
-export const useClinicalFields = createUseCoreDataHook(
-  fetchClinicalFieldsResult,
-  selectClinicalFieldsData,
-);
+export const { useClinicalFieldsQuery } = clinicalFieldsAPISlice;

--- a/packages/core/src/features/clinicalDataAnalysis/index.ts
+++ b/packages/core/src/features/clinicalDataAnalysis/index.ts
@@ -3,25 +3,19 @@ import {
   useGetClinicalAnalysisQuery,
   clinicalAnalysisApiReducer,
 } from "./clinicalDataAnalysisSlice";
-import {
-  fetchClinicalFieldsResult,
-  useClinicalFields,
-  clinicalFieldsReducer,
-} from "./clinicalFieldsSlice";
+import { useClinicalFieldsQuery } from "./clinicalFieldsSlice";
 import {
   useGetContinuousDataStatsQuery,
   ClinicalContinuousStatsData,
 } from "./clinicalContinuousStatsSlice";
 
 export {
-  fetchClinicalFieldsResult,
-  useClinicalFields,
+  useClinicalFieldsQuery,
   useGetClinicalAnalysisQuery,
   useGetContinuousDataStatsQuery,
   ClinicalContinuousStatsData,
 };
 
 export const clinicalDataAnalysisReducer = combineReducers({
-  fields: clinicalFieldsReducer,
   resultCase: clinicalAnalysisApiReducer,
 });

--- a/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
@@ -276,7 +276,6 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
         <div className="w-full h-72 basis-2/3 overflow-hidden" ref={qqPlotRef}>
           <QQPlot
             chartValues={formattedQQValues}
-            field={fieldName}
             isLoading={isLoading}
             color={color}
             width={boundingRectQQ.width}
@@ -298,7 +297,6 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
         <OffscreenWrapper>
           <QQPlot
             chartValues={formattedQQValues}
-            field={fieldName}
             isLoading={isLoading}
             color={color}
             chartRef={qqDownloadChartRef}

--- a/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
@@ -273,7 +273,7 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
             height={boundingRectBox.height}
           />
         </div>
-        <div className="w-full h-72 basis-2/3" ref={qqPlotRef}>
+        <div className="w-full h-72 basis-2/3 overflow-hidden" ref={qqPlotRef}>
           <QQPlot
             chartValues={formattedQQValues}
             field={fieldName}

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
@@ -13,6 +13,7 @@ import VictoryBarChart from "../../charts/VictoryBarChart";
 import { COLOR_MAP } from "../constants";
 import { toDisplayName } from "../utils";
 import { DisplayData } from "../types";
+import { useDeepCompareMemo } from "use-deep-compare";
 
 const formatBarChartData = (
   data: DisplayData,
@@ -54,7 +55,10 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
     DownloadProgressContext,
   );
 
-  const barChartData = formatBarChartData(data, yTotal, displayPercent);
+  const barChartData = useDeepCompareMemo(
+    () => formatBarChartData(data, yTotal, displayPercent),
+    [data, yTotal, displayPercent],
+  );
 
   const color =
     tailwindConfig.theme.extend.colors[COLOR_MAP[field.split(".").at(-2)]]

--- a/packages/portal-proto/src/features/cDave/CDaveCard/EChartWrapper.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/EChartWrapper.tsx
@@ -6,6 +6,7 @@ export interface EChartWrapperProps {
   readonly chartRef?: React.MutableRefObject<HTMLElement>;
   readonly height: number;
   readonly width: number;
+  readonly label: string;
 }
 
 const EChartWrapper: React.FC<EChartWrapperProps> = ({
@@ -13,6 +14,7 @@ const EChartWrapper: React.FC<EChartWrapperProps> = ({
   chartRef,
   height,
   width,
+  label,
 }: EChartWrapperProps) => {
   const ref = useRef<HTMLElement>(null);
   const wrapperRef = chartRef ?? ref;
@@ -43,6 +45,8 @@ const EChartWrapper: React.FC<EChartWrapperProps> = ({
     <div
       ref={wrapperRef ? (r) => (wrapperRef.current = r) : undefined}
       style={{ height, width }}
+      role="img"
+      aria-label={label}
     />
   );
 };

--- a/packages/portal-proto/src/features/cDave/CDaveCard/EChartWrapper.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/EChartWrapper.tsx
@@ -4,7 +4,6 @@ import { init, EChartsOption, ECharts } from "echarts";
 export interface EChartWrapperProps {
   readonly option: EChartsOption;
   readonly chartRef?: React.MutableRefObject<HTMLElement>;
-  readonly ariaLabeledBy: string;
   readonly height: number;
   readonly width: number;
 }
@@ -12,7 +11,6 @@ export interface EChartWrapperProps {
 const EChartWrapper: React.FC<EChartWrapperProps> = ({
   option,
   chartRef,
-  ariaLabeledBy,
   height,
   width,
 }: EChartWrapperProps) => {
@@ -45,7 +43,6 @@ const EChartWrapper: React.FC<EChartWrapperProps> = ({
     <div
       ref={wrapperRef ? (r) => (wrapperRef.current = r) : undefined}
       style={{ height, width }}
-      aria-labelledby={ariaLabeledBy}
     />
   );
 };

--- a/packages/portal-proto/src/features/cDave/CDaveCard/EChartWrapper.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/EChartWrapper.tsx
@@ -1,0 +1,53 @@
+import React, { useRef, useEffect } from "react";
+import { init, EChartsOption, ECharts } from "echarts";
+
+export interface EChartWrapperProps {
+  readonly option: EChartsOption;
+  readonly chartRef?: React.MutableRefObject<HTMLElement>;
+  readonly ariaLabeledBy: string;
+  readonly height: number;
+  readonly width: number;
+}
+
+const EChartWrapper: React.FC<EChartWrapperProps> = ({
+  option,
+  chartRef,
+  ariaLabeledBy,
+  height,
+  width,
+}: EChartWrapperProps) => {
+  const ref = useRef<HTMLElement>(null);
+  const wrapperRef = chartRef ?? ref;
+
+  useEffect(() => {
+    let chart: ECharts | undefined;
+
+    if (
+      wrapperRef.current !== null &&
+      wrapperRef?.current?.clientHeight !== 0 &&
+      wrapperRef?.current?.clientWidth !== 0
+    ) {
+      chart = init(wrapperRef.current, null, {
+        renderer: "svg",
+        height,
+        width,
+      });
+      chart.setOption(option);
+      chart.resize();
+    }
+
+    return () => {
+      chart?.dispose();
+    };
+  }, [wrapperRef, height, width, option]);
+
+  return (
+    <div
+      ref={wrapperRef ? (r) => (wrapperRef.current = r) : undefined}
+      style={{ height, width }}
+      aria-labelledby={ariaLabeledBy}
+    />
+  );
+};
+
+export default EChartWrapper;

--- a/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
@@ -81,13 +81,6 @@ const QQPlot: React.FC<QQPlotProps> = ({
   const option: EChartsOption = useDeepCompareMemo(
     () => ({
       animation: false,
-      aria: {
-        enabled: true,
-        label: {
-          enabled: true,
-          description: label,
-        },
-      },
       grid: {
         show: false,
         left: 60,
@@ -189,6 +182,7 @@ const QQPlot: React.FC<QQPlotProps> = ({
       height={height}
       chartRef={chartRef}
       width={width}
+      label={label}
     />
   );
 };

--- a/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
@@ -83,18 +83,19 @@ const QQPlot: React.FC<QQPlotProps> = ({
       animation: false,
       grid: {
         show: false,
-        left: 60,
-        right: 50,
+        left: 80,
         top: 40,
       },
       title: {
         text: label,
-        left: "center",
+        textAlign: "center",
+        left: (width + 50) / 2,
         textStyle: {
           fontWeight: "normal",
           fontSize: 16,
           fontFamily: "Noto Sans",
           color: "black",
+          width,
         },
       },
       xAxis: {
@@ -106,7 +107,7 @@ const QQPlot: React.FC<QQPlotProps> = ({
         nameLocation: "middle",
         nameTextStyle: {
           padding: 8,
-          fontSize: 14,
+          fontSize: 12,
           color: "black",
           fontFamily: "Noto Sans",
         },
@@ -134,8 +135,8 @@ const QQPlot: React.FC<QQPlotProps> = ({
         },
         nameLocation: "middle",
         nameTextStyle: {
-          padding: 26,
-          fontSize: 14,
+          padding: 36,
+          fontSize: 12,
           color: "black",
           fontFamily: "Noto Sans",
         },
@@ -157,15 +158,20 @@ const QQPlot: React.FC<QQPlotProps> = ({
           type: "scatter" as const,
           data: chartData,
           large: true,
+          symbolSize: 6,
           itemStyle: {
-            opacity: 0.7,
             borderColor: color,
+            borderWidth: 2,
+            color: "transparent",
           },
         },
         {
           type: "line" as const,
           data: lineData,
           showSymbol: false,
+          itemStyle: {
+            color: "black",
+          },
         },
       ],
     }),

--- a/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
@@ -46,7 +46,6 @@ export const getQ1Q3Line = (
 
 interface QQPlotProps {
   readonly chartValues: { id: string; x: number; y: number }[];
-  readonly field: string;
   readonly isLoading: boolean;
   readonly color: string;
   readonly height: number;
@@ -57,7 +56,6 @@ interface QQPlotProps {
 
 const QQPlot: React.FC<QQPlotProps> = ({
   chartValues,
-  field,
   isLoading,
   height,
   width,
@@ -83,6 +81,13 @@ const QQPlot: React.FC<QQPlotProps> = ({
   const option: EChartsOption = useDeepCompareMemo(
     () => ({
       animation: false,
+      aria: {
+        enabled: true,
+        label: {
+          enabled: true,
+          description: label,
+        },
+      },
       grid: {
         show: false,
         left: 60,
@@ -184,7 +189,6 @@ const QQPlot: React.FC<QQPlotProps> = ({
       height={height}
       chartRef={chartRef}
       width={width}
-      ariaLabeledBy={`${field}-qq-plot-label`}
     />
   );
 };

--- a/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
@@ -1,14 +1,8 @@
 import React from "react";
 import { useDeepCompareMemo } from "use-deep-compare";
 import { Loader } from "@mantine/core";
-import {
-  VictoryAxis,
-  VictoryChart,
-  VictoryLine,
-  VictoryScatter,
-  VictoryLabel,
-  VictoryContainer,
-} from "victory";
+import EChartWrapper from "./EChartWrapper";
+import { EChartsOption } from "echarts";
 
 const getQuantile = (count: number, quantile: number) =>
   Math.ceil(count * (quantile / 4)) - 1;
@@ -57,12 +51,6 @@ interface QQPlotProps {
   readonly color: string;
   readonly height: number;
   readonly width: number;
-  readonly chartPadding?: {
-    left?: number;
-    right?: number;
-    top?: number;
-    bottom?: number;
-  };
   readonly chartRef?: React.MutableRefObject<HTMLElement>;
   readonly label?: string;
 }
@@ -73,77 +61,131 @@ const QQPlot: React.FC<QQPlotProps> = ({
   isLoading,
   height,
   width,
-  chartPadding = { left: 80, right: 20, bottom: 60, top: 50 },
   color,
   chartRef,
   label = "QQ Plot",
 }: QQPlotProps) => {
-  const emptyChart = chartValues.every((val) => val.x === 0);
-
-  const xMin = Math.floor(Math.min(...chartValues.map((v) => v.x)));
-  const yMin = Math.floor(Math.min(...chartValues.map((v) => v.y)));
-  const xMax = Math.ceil(Math.max(...chartValues.map((v) => v.x)));
-  const yMax = Math.ceil(Math.max(...chartValues.map((v) => v.y)));
-
   const lineValues = useDeepCompareMemo(
     () => (chartValues.length > 0 ? getQ1Q3Line(chartValues) : []),
     [chartValues],
   );
 
+  const chartData = useDeepCompareMemo(
+    () => chartValues.map((v) => [v.x, v.y]),
+    [chartValues],
+  );
+
+  const lineData = useDeepCompareMemo(
+    () => lineValues.map((v) => [v.x, v.y]),
+    [lineValues],
+  );
+
+  const option: EChartsOption = useDeepCompareMemo(
+    () => ({
+      animation: false,
+      grid: {
+        show: false,
+        left: 60,
+        right: 50,
+        top: 40,
+      },
+      title: {
+        text: label,
+        left: "center",
+        textStyle: {
+          fontWeight: "normal",
+          fontSize: 16,
+          fontFamily: "Noto Sans",
+          color: "black",
+        },
+      },
+      xAxis: {
+        name: "Theoretical Normal Quantiles",
+        type: "value",
+        splitLine: {
+          show: false,
+        },
+        nameLocation: "middle",
+        nameTextStyle: {
+          padding: 8,
+          fontSize: 14,
+          color: "black",
+          fontFamily: "Noto Sans",
+        },
+        axisLabel: {
+          fontSize: 12,
+          color: "black",
+          fontFamily: "Noto Sans",
+        },
+        axisTick: {
+          length: 6,
+          lineStyle: {
+            color: "black",
+          },
+        },
+      },
+      yAxis: {
+        name: "Sample Quantiles",
+        type: "value",
+        axisLine: {
+          onZero: false,
+        },
+        position: "left",
+        splitLine: {
+          show: false,
+        },
+        nameLocation: "middle",
+        nameTextStyle: {
+          padding: 26,
+          fontSize: 14,
+          color: "black",
+          fontFamily: "Noto Sans",
+        },
+        axisLabel: {
+          fontSize: 12,
+          color: "black",
+          fontFamily: "Noto Sans",
+        },
+        axisTick: {
+          length: 6,
+          lineStyle: {
+            color: "black",
+          },
+        },
+      },
+      color: [color, "black"],
+      series: [
+        {
+          type: "scatter" as const,
+          data: chartData,
+          large: true,
+          itemStyle: {
+            opacity: 0.7,
+            borderColor: color,
+          },
+        },
+        {
+          type: "line" as const,
+          data: lineData,
+          showSymbol: false,
+        },
+      ],
+    }),
+    [chartData, color, lineData, label],
+  );
+
   return isLoading ? (
     <Loader />
   ) : chartValues.length < 10 ? (
-    <>Not enough data</>
+    <div className="flex justify-center">Not enough data</div>
   ) : (
-    <VictoryChart
+    <EChartWrapper
+      option={option}
       height={height}
+      chartRef={chartRef}
       width={width}
-      padding={chartPadding}
-      minDomain={{ x: xMin, y: yMin < 0 ? yMin : 0 }}
-      maxDomain={{ x: xMax, y: yMax }}
-      containerComponent={
-        <VictoryContainer
-          containerRef={
-            chartRef ? (ref) => (chartRef.current = ref) : undefined
-          }
-          aria-labelledby={`${field}-qq-plot-label`}
-        />
-      }
-    >
-      <VictoryLabel
-        dy={20}
-        dx={(width + chartPadding.left - chartPadding.right) / 2}
-        text={label}
-        style={{ fontSize: 16, fontFamily: "Noto Sans" }}
-        textAnchor="middle"
-        id={`${field}-qq-plot-label`}
-      />
-      <VictoryAxis
-        label="Theoretical Normal Quantiles"
-        axisLabelComponent={<VictoryLabel dy={5} />}
-        tickLabelComponent={<VictoryLabel dy={-5} />}
-        tickFormat={(t) => Number(t.toFixed())}
-        tickCount={8}
-        style={{ ticks: { stroke: "black", size: 8 } }}
-        crossAxis={false}
-        orientation="bottom"
-      />
-      <VictoryAxis
-        dependentAxis
-        axisValue={xMin}
-        label="Sample Quantiles"
-        axisLabelComponent={<VictoryLabel dy={-40} />}
-        tickLabelComponent={emptyChart ? <></> : <VictoryLabel dx={5} />}
-        style={{ ticks: { stroke: "black", size: 8 } }}
-        crossAxis={false}
-      />
-      <VictoryScatter
-        data={chartValues}
-        style={{ data: { stroke: color, strokeWidth: 2, fill: "none" } }}
-        groupComponent={<g />}
-      />
-      <VictoryLine data={lineValues} />
-    </VictoryChart>
+      ariaLabeledBy={`${field}-qq-plot-label`}
+    />
   );
 };
 

--- a/packages/portal-proto/src/features/cDave/Dashboard.tsx
+++ b/packages/portal-proto/src/features/cDave/Dashboard.tsx
@@ -11,6 +11,7 @@ import {
 import { convertDateToString } from "@/utils/date";
 import SurvivalPlot, { SurvivalPlotTypes } from "../charts/SurvivalPlot";
 import CDaveCard from "./CDaveCard/CDaveCard";
+import { useDeepCompareMemo } from "use-deep-compare";
 
 interface DashboardProps {
   readonly cohortFilters: GqlOperation;
@@ -29,13 +30,17 @@ const Dashboard: React.FC<DashboardProps> = ({
 }: DashboardProps) => {
   const initialDashboardRender = useRef(true);
   const lastDashboardRender = usePrevious(initialDashboardRender);
+  const filters = useDeepCompareMemo(
+    () => cohortFilters && [cohortFilters],
+    [cohortFilters],
+  );
   const {
     data: survivalData,
     isError,
     isFetching,
     isUninitialized,
   } = useGetSurvivalPlotQuery({
-    filters: cohortFilters && [cohortFilters],
+    filters,
   });
   useFacetDictionary();
 

--- a/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
+++ b/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
@@ -112,19 +112,21 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
   chartLabel,
   width = 400,
   height = 400,
-  chartPadding = { left: 80, right: 80, bottom: 80, top: 10 },
+  chartPadding,
   hideYTicks = false,
   hideXTicks = false,
   chartRef = undefined,
   truncateLabels = false,
 }: VictoryBarChartProps) => {
+  const padding = chartPadding ?? { left: 80, right: 80, bottom: 80, top: 10 };
+
   return (
     <VictoryChart
       title={title}
       width={width}
       height={height}
       domainPadding={60}
-      padding={chartPadding}
+      padding={padding}
       containerComponent={
         <VictoryContainer
           containerRef={
@@ -137,7 +139,7 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
       {chartLabel && (
         <VictoryLabel
           dy={20}
-          dx={(width + chartPadding.left - chartPadding.right) / 2}
+          dx={(width + padding.left - padding.right) / 2}
           text={chartLabel}
           textAnchor="middle"
           style={{ fontSize: 28, fontFamily: "Noto Sans" }}


### PR DESCRIPTION
## Description
 Improve performance of cDave with large QQ plots by 
1) replacing Victory Charts with Apache eCharts which handles charts with large datasets more performantly 
2) reducing renders on the page with memoization and other techniques

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="620" alt="Screenshot 2024-02-19 at 1 10 27 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/02fb24c2-a8f0-43b3-b80d-a0f161c8f880">
