### PR TITLE
PEAR-1816: Fix for unexpected error when viewing Follow-Ups/Molecular Tests in some case summary pages

### DIFF
--- a/packages/portal-proto/src/features/cases/ClinicalSummary/DiagnosesOrFollowUps.tsx
+++ b/packages/portal-proto/src/features/cases/ClinicalSummary/DiagnosesOrFollowUps.tsx
@@ -306,9 +306,14 @@ export const DiagnosesOrFollowUps = ({
                       : "bg-base-lightest text-base-contrast-lightest"
                   }`}
                   data-testid="tab"
-                  {...(!data?.submitter_id && { "aria-label": "No Follow Up" })}
+                  {...(!data?.submitter_id && {
+                    "aria-label": "No follow-up ID available",
+                  })}
                 >
-                  <Tooltip label={data?.submitter_id} withinPortal={true}>
+                  <Tooltip
+                    label={data?.submitter_id ?? "No follow-up ID available"}
+                    withinPortal={true}
+                  >
                     <div>
                       {data?.submitter_id
                         ? `${data?.submitter_id?.substring(0, 13)}...`

--- a/packages/portal-proto/src/features/cases/ClinicalSummary/DiagnosesOrFollowUps.tsx
+++ b/packages/portal-proto/src/features/cases/ClinicalSummary/DiagnosesOrFollowUps.tsx
@@ -306,9 +306,14 @@ export const DiagnosesOrFollowUps = ({
                       : "bg-base-lightest text-base-contrast-lightest"
                   }`}
                   data-testid="tab"
+                  {...(!data?.submitter_id && { "aria-label": "No Follow Up" })}
                 >
-                  <Tooltip label={data.submitter_id} withinPortal={true}>
-                    <div>{`${data.submitter_id.substring(0, 13)}...`}</div>
+                  <Tooltip label={data?.submitter_id} withinPortal={true}>
+                    <div>
+                      {data?.submitter_id
+                        ? `${data?.submitter_id?.substring(0, 13)}...`
+                        : "--"}
+                    </div>
                   </Tooltip>
                 </Tabs.Tab>
               ))}


### PR DESCRIPTION
## Description
Some of the follow up ids are undefined. 

NOTE: waiting for check on aria-label by Cemile.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot 2024-02-21 at 4 21 45 PM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/bdb10c22-9007-4fbc-baee-fc64542db6c9)

