### PR TITLE
update the proteinpaint-client version to 2.42.1-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6458,9 +6458,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.40.6",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.6.tgz",
-      "integrity": "sha512-B0soNSY3dKsIDgvSUq7SYxwVyayzlZrSizpNuVUcpcd6YtCMb3Y8+UJ9quqpmSdf6Gzz/GEdmNJ50GSxAJqJcw=="
+      "version": "2.42.1-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.42.1-0.tgz",
+      "integrity": "sha512-SJhVPiHYlfwUtQtpMAWq8O8q90VJ/GdLBfV2XFu+2l2yPXNHZXa8Mv5GezLxQrb9OQei6mP/Li7rdBSSpgx56g=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27164,7 +27164,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.6",
+        "@sjcrh/proteinpaint-client": "^2.42.1-0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32383,9 +32383,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.40.6",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.40.6.tgz",
-      "integrity": "sha512-B0soNSY3dKsIDgvSUq7SYxwVyayzlZrSizpNuVUcpcd6YtCMb3Y8+UJ9quqpmSdf6Gzz/GEdmNJ50GSxAJqJcw=="
+      "version": "2.42.1-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.42.1-0.tgz",
+      "integrity": "sha512-SJhVPiHYlfwUtQtpMAWq8O8q90VJ/GdLBfV2XFu+2l2yPXNHZXa8Mv5GezLxQrb9OQei6mP/Li7rdBSSpgx56g=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -42221,7 +42221,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.40.6",
+        "@sjcrh/proteinpaint-client": "^2.42.1-0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.40.6",
+    "@sjcrh/proteinpaint-client": "^2.42.1-0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

@craigrbarnes I assume that `develop` should be the base branch, please let me know if a different branch should be used as base for this PR.

Features:
- upgrade node from v16 to v20
- adding geneset edit ui from Gene Expression chart button

Fixes:
- Replace require syntax with import to prevent bundling errors in client package bundlers
- Show user error message for an invalid genome provided in a URL. Error message contains the list of available genomes from that server.
- when downloading GDC bam slice (no caching), do not limit request region max size;
- Reload page while streaming/downloading gdc bam slice to client will not crash server
- GDC bam slice ui requires hitting Enter to search and no longer auto search to avoid showing duplicate ssm table
- support ?massnative=genome,dslabel url parameter shorthand
- Bug fix to show correct category total size by passing a missing filter0
- profilegenevalue track reports subtrack file error in a legible way
- Bug fix for disco plot launched from sunburst shows aachange in sandbox header rather than undefined
- BAM track bug fix to handle reads with no sequence and not to break.
- BAM track bug fix to not to break by hide/show toggling at track menu
- In GDC BAM slicing, before creating new cache file, find out old enough ones to delete to free up storage
- Bug fix to convert "case." to "cases." in case_filters[] for GDC mds3 sunburst clicking to load sample table
- Bug fix for GDC mds3 category total sample count to respond/shrink with cohort change
- Prevent double-clicking on a sunburst ring so that same sample table will not appear duplicated
- Fix the detection of sorting-related updates in the matrix app, as distinct from the hierchical cluster
- Pass the cohort filter to the lollipop track from the matrix and disco plot label click

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
