### PR TITLE
PEAR-1160 fixes notes font in annotation summary

### DIFF
--- a/packages/portal-proto/src/features/annotations/AnnotationSummary.tsx
+++ b/packages/portal-proto/src/features/annotations/AnnotationSummary.tsx
@@ -152,7 +152,7 @@ const AnnotationSummary: React.FC<AnnotationSummaryProps> = ({
           </div>
         </div>
         <HeaderTitle>Notes</HeaderTitle>
-        <p className="border-1 border-base-lighter bg-primary-content-lightest p-2">
+        <p className="border-1 border-base-lighter bg-primary-content-lightest p-2 font-content">
           {annotation?.notes}
         </p>
       </div>


### PR DESCRIPTION
## Description
Changes the font of the Notes value from Montserrat to Noto-Sans to make everyone happy.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1203" alt="Screenshot 2024-02-26 at 5 22 43 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/cb0e1b29-2e2b-4c4e-98f4-e3ffc178e2b1">
