### PR TITLE
PEAR-1818 - Portal v2 is too aggressively refreshing tokens

### DIFF
--- a/packages/core/src/features/users/usersSlice.ts
+++ b/packages/core/src/features/users/usersSlice.ts
@@ -55,7 +55,7 @@ const userAuthApi = coreCreateApi({
     } catch (e) {
       /*
         Because an "error" response is valid for the auth requests we don't want to
-        put the request in an error state or it will attempt the request over and over again 
+        put the request in an error state or it will attempt the request over and over again
       */
     }
 

--- a/packages/core/src/features/users/usersSlice.ts
+++ b/packages/core/src/features/users/usersSlice.ts
@@ -72,7 +72,6 @@ const userAuthApi = coreCreateApi({
 });
 
 export const {
-  useFetchTokenQuery,
   useFetchUserDetailsQuery,
   useLazyFetchTokenQuery,
   useLazyFetchUserDetailsQuery,

--- a/packages/core/src/features/users/usersSlice.ts
+++ b/packages/core/src/features/users/usersSlice.ts
@@ -1,13 +1,7 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { coreCreateApi } from "src/coreCreateApi";
 import { GDC_AUTH } from "../../constants";
-import {
-  CoreDataSelectorResponse,
-  createUseCoreDataHook,
-  DataStatus,
-} from "../../dataAccess";
-import { CoreState } from "../../reducers";
 
-export interface UserResponse {
+export interface UserInfo {
   projects: {
     phs_ids: Record<string, Array<string>>;
     gdc_ids: Record<string, Array<string>>;
@@ -15,12 +9,19 @@ export interface UserResponse {
   username: string;
 }
 
+export interface UserAuthResponse<D> {
+  readonly data: D;
+  readonly status: number;
+}
+
 export async function fetchAuth({
   endpoint,
+  isJSON = false,
 }: {
   endpoint: string;
-}): Promise<Response> {
-  return await fetch(`${GDC_AUTH}/${endpoint}`, {
+  isJSON: boolean;
+}) {
+  const response = await fetch(`${GDC_AUTH}/${endpoint}`, {
     credentials: "same-origin",
     method: "GET",
     headers: {
@@ -28,111 +29,54 @@ export async function fetchAuth({
       "Content-Type": "application/json",
     },
   });
-}
-
-export const fetchUserDetails = createAsyncThunk<UserResponse>(
-  "userInfo/fetchUserDetails",
-  async () => {
-    const response = await fetchAuth({ endpoint: "user" });
-
-    if (response.ok) {
-      return response.json();
-    }
-
-    throw Error(await response.text());
-  },
-);
-
-export const fetchToken = async (): Promise<{
-  text: string | null;
-  status: number;
-}> => {
-  const response = await fetchAuth({ endpoint: "token/refresh" });
 
   if (response.ok) {
     return {
-      text: await response.text(),
+      data: isJSON ? await response.json() : await response.text(),
       status: response.status,
     };
   }
 
-  if (response.status === 401) {
-    return {
-      status: response.status,
-      text: null,
-    };
-  }
-
-  throw Error(await response.text());
-};
-
-export interface userSliceInitialStateInterface {
-  projects: {
-    phs_ids: Record<string, Array<string>>;
-    gdc_ids: Record<string, Array<string>>;
+  return {
+    status: response.status,
+    data: null,
   };
-  username: string | null;
-  status: DataStatus;
 }
-const userSliceInitialState: userSliceInitialStateInterface = {
-  projects: {
-    phs_ids: {},
-    gdc_ids: {},
+
+const userAuthApi = coreCreateApi({
+  reducerPath: "userAuthApi",
+  refetchOnFocus: true,
+  refetchOnMountOrArgChange: 1800,
+  baseQuery: async ({ endpoint, isJSON }) => {
+    let results;
+
+    try {
+      results = await fetchAuth({ endpoint, isJSON });
+    } catch (e) {
+      /*
+        Because an "error" response is valid for the auth requests we don't want to
+        put the request in an error state or it will attempt the request over and over again 
+      */
+    }
+
+    return { data: results };
   },
-  username: null,
-  status: "uninitialized",
-};
-
-export type UserInfo = Omit<userSliceInitialStateInterface, "status">;
-
-const slice = createSlice({
-  name: "userInfo",
-  initialState: userSliceInitialState,
-  reducers: {},
-  extraReducers: (builder) => {
-    builder
-      .addCase(fetchUserDetails.fulfilled, (state, action) => {
-        const response = action.payload;
-
-        state.projects = { ...response.projects };
-        state.username = response.username;
-        state.status = "fulfilled";
-        return state;
-      })
-      .addCase(fetchUserDetails.pending, (state) => {
-        state.projects = {
-          phs_ids: {},
-          gdc_ids: {},
-        };
-        state.username = null;
-        state.status = "pending";
-        return state;
-      })
-      .addCase(fetchUserDetails.rejected, (state) => {
-        state.projects = {
-          phs_ids: {},
-          gdc_ids: {},
-        };
-        state.username = null;
-        state.status = "rejected";
-        return state;
-      });
-  },
+  endpoints: (builder) => ({
+    fetchToken: builder.query<UserAuthResponse<string>, void>({
+      query: () => ({ endpoint: "token/refresh" }),
+    }),
+    fetchUserDetails: builder.query<UserAuthResponse<UserInfo>, void>({
+      query: () => ({ endpoint: "user", isJSON: true }),
+    }),
+  }),
 });
 
-export const userDetailsReducer = slice.reducer;
-
-export const selectUserDetailsInfo = (
-  state: CoreState,
-): CoreDataSelectorResponse<UserInfo> => ({
-  data: {
-    projects: state.userInfo.projects,
-    username: state.userInfo.username,
-  },
-  status: state.userInfo.status,
-});
-
-export const useUserDetails = createUseCoreDataHook(
-  fetchUserDetails,
-  selectUserDetailsInfo,
-);
+export const {
+  useFetchTokenQuery,
+  useFetchUserDetailsQuery,
+  useLazyFetchTokenQuery,
+  useLazyFetchUserDetailsQuery,
+} = userAuthApi;
+export const userAuthApiMiddleware = userAuthApi.middleware;
+export const userAuthApiReducerPath = userAuthApi.reducerPath;
+export const userAuthApiReducer = userAuthApi.reducer;

--- a/packages/core/src/reducers.ts
+++ b/packages/core/src/reducers.ts
@@ -47,7 +47,6 @@ import { biospecimenReducer } from "./features/biospecimen/biospecimenSlice";
 import { clinicalDataAnalysisReducer } from "./features/clinicalDataAnalysis";
 import { caseSummarySliceReducer } from "./features/cases/caseSummarySlice";
 import { facetsByNameTypeAndFilterReducer } from "./features/facets/facetsByNameTypeAndFilter";
-import { userDetailsReducer } from "./features/users/usersSlice";
 import { modalReducer } from "./features/modals/modalsSlice";
 import { quickSearchReducer } from "./features/quickSearch/quickSearch";
 import { versionInfoReducer } from "./features/versionInfo/versionInfoSlice";
@@ -62,6 +61,10 @@ import {
 } from "./features/gdcapi/gdcapi";
 import { setsReducer } from "./features/sets";
 import { sessionStorage } from "./storage-persist";
+import {
+  userAuthApiReducer,
+  userAuthApiReducerPath,
+} from "./features/users/usersSlice";
 
 // We want unsaved cohorts to be persisted through a refresh but not through a user ending their session
 const cohortPersistConfig = {
@@ -94,7 +97,6 @@ export const reducers = combineReducers({
   caseSummary: caseSummarySliceReducer,
   ssms: ssmsReducer,
   genesSummary: genesSummaryReducer,
-  userInfo: userDetailsReducer,
   modals: modalReducer,
   quickSearch: quickSearchReducer,
   [filesApiSliceReducerPath]: filesApiReducer,
@@ -105,6 +107,7 @@ export const reducers = combineReducers({
   [survivalApiSliceReducerPath]: survivalApiReducer,
   [graphqlAPISliceReducerPath]: graphqlAPIReducer,
   [endpointSliceReducerPath]: endpointReducer,
+  [userAuthApiReducerPath]: userAuthApiReducer,
   versionInfo: versionInfoReducer,
   sets: setsReducer,
 });

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -22,6 +22,7 @@ import { endpointSliceMiddleware } from "./features/gdcapi/gdcapi";
 import { projectApiSliceMiddleware } from "./features/projects/projectsSlice";
 import { filesApiSliceMiddleware } from "./features/files/filesSlice";
 import storage from "./storage-persist";
+import { userAuthApiMiddleware } from "./features/users/usersSlice";
 
 const persistConfig = {
   key: "root",
@@ -67,6 +68,7 @@ export const coreStore = configureStore({
         graphqlAPISliceMiddleware,
         endpointSliceMiddleware,
         projectApiSliceMiddleware,
+        userAuthApiMiddleware,
       )
       .prepend(coreStoreListenerMiddleware.middleware), // needs to be prepended
 });

--- a/packages/portal-proto/src/components/LoginButton.tsx
+++ b/packages/portal-proto/src/components/LoginButton.tsx
@@ -1,9 +1,9 @@
 import openAuthWindow from "@/features/layout/auth/openAuthWindow";
 import {
   fetchNotifications,
-  fetchUserDetails,
   hideModal,
   useCoreDispatch,
+  useLazyFetchUserDetailsQuery,
 } from "@gff/core";
 import { Button } from "@mantine/core";
 import { MdOutlineLogin as LoginIcon } from "react-icons/md";
@@ -16,6 +16,7 @@ export const LoginButton = ({
   fromHeader?: boolean;
 }): JSX.Element => {
   const dispatch = useCoreDispatch();
+  const [fetchUserDetails] = useLazyFetchUserDetailsQuery();
   return (
     <Button
       className={`${
@@ -26,7 +27,7 @@ export const LoginButton = ({
       onClick={async () => {
         fromSession && dispatch(hideModal());
         await openAuthWindow();
-        await dispatch(fetchUserDetails());
+        await fetchUserDetails();
         await dispatch(fetchNotifications());
       }}
       leftIcon={

--- a/packages/portal-proto/src/components/Modals/CartDownloadModal.unit.test.tsx
+++ b/packages/portal-proto/src/components/Modals/CartDownloadModal.unit.test.tsx
@@ -5,6 +5,9 @@ import * as core from "@gff/core";
 import CartDownloadModal from "./CartDownloadModal";
 
 jest.spyOn(core, "useCoreDispatch").mockImplementation(jest.fn());
+jest
+  .spyOn(core, "useLazyFetchUserDetailsQuery")
+  .mockImplementation(jest.fn().mockReturnValue([jest.fn()]));
 
 describe("<CartDownloadModal />", () => {
   it("shows number of auth and unauth files", () => {

--- a/packages/portal-proto/src/components/Modals/UserProfileModal.tsx
+++ b/packages/portal-proto/src/components/Modals/UserProfileModal.tsx
@@ -1,19 +1,25 @@
-import { useCoreSelector, selectUserDetailsInfo } from "@gff/core";
+import { useFetchUserDetailsQuery } from "@gff/core";
 import { Text } from "@mantine/core";
 import { FaCheck } from "react-icons/fa";
 import { ScrollableTableWithFixedHeader } from "../ScrollableTableWithFixedHeader/ScrollableTableWithFixedHeader";
 import { BaseModal } from "./BaseModal";
+import { SessionExpireModal } from "./SessionExpireModal";
 
 export const UserProfileModal = ({
   openModal,
 }: {
   openModal: boolean;
 }): JSX.Element => {
-  const userInfo = useCoreSelector((state) => selectUserDetailsInfo(state));
+  const { data: userInfo } = useFetchUserDetailsQuery();
+
+  if (userInfo?.status === 401) {
+    return <SessionExpireModal openModal />;
+  }
+
   const {
     projects: { gdc_ids },
     username,
-  } = userInfo?.data || {};
+  } = userInfo?.data || { username: undefined, projects: {} };
 
   // get the unique permission properties
   const allPermissionValues = Array.from(

--- a/packages/portal-proto/src/components/Modals/UserProfileModal.unit.test.tsx
+++ b/packages/portal-proto/src/components/Modals/UserProfileModal.unit.test.tsx
@@ -9,14 +9,17 @@ describe("<UserProfileModal />", () => {
   });
 
   it("should show no access message when there are not projets assigned to the user. ", () => {
-    jest.spyOn(core, "useCoreSelector").mockReturnValue({
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValue({
       data: {
-        username: "test",
-        projects: {
-          gdc_ids: {},
+        data: {
+          username: "test",
+          projects: {
+            gdc_ids: {},
+          },
         },
+        status: 200,
       },
-    });
+    } as any);
 
     const { getByTestId, queryByTestId } = render(
       <UserProfileModal openModal />,
@@ -26,19 +29,38 @@ describe("<UserProfileModal />", () => {
   });
 
   it("should show no access message when there are not projets assigned to the user. ", () => {
-    jest.spyOn(core, "useCoreSelector").mockReturnValue({
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValue({
       data: {
-        username: "test",
-        projects: {
-          gdc_ids: { testgc: ["_member_"], "CGCI-HTMCP-CC": ["_member_"] },
+        data: {
+          username: "test",
+          projects: {
+            gdc_ids: { testgc: ["_member_"], "CGCI-HTMCP-CC": ["_member_"] },
+          },
         },
+        status: 200,
       },
-    });
+    } as any);
 
     const { getByTestId, queryByTestId } = render(
       <UserProfileModal openModal />,
     );
     expect(getByTestId("scrolltable")).toBeInTheDocument();
     expect(queryByTestId("warningText")).toBeNull();
+  });
+
+  test("should show Session Expire modal when user details returns 401", async () => {
+    jest
+      .spyOn(core, "useLazyFetchUserDetailsQuery")
+      .mockImplementation(jest.fn().mockReturnValue([jest.fn()]));
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValue({
+      data: {
+        data: null,
+        status: 401,
+      },
+    } as any);
+
+    const { getByText } = render(<UserProfileModal openModal />);
+
+    expect(getByText("Your session has expired. Please login."));
   });
 });

--- a/packages/portal-proto/src/components/TableActionButtons/TableActionButton.unit.test.tsx
+++ b/packages/portal-proto/src/components/TableActionButtons/TableActionButton.unit.test.tsx
@@ -9,6 +9,9 @@ describe("<TableActionButtons />", () => {
   beforeEach(() => {
     jest.spyOn(core, "useCoreSelector").mockReturnValue([] as CartFile[]);
     jest.spyOn(core, "useCoreDispatch").mockReturnValue(jest.fn());
+    jest
+      .spyOn(core, "useLazyFetchUserDetailsQuery")
+      .mockImplementation(jest.fn().mockReturnValue([jest.fn()]));
   });
 
   it("should remove already present file from the cart", async () => {

--- a/packages/portal-proto/src/features/cart/Cart.tsx
+++ b/packages/portal-proto/src/features/cart/Cart.tsx
@@ -6,7 +6,7 @@ import {
   useCartSummary,
   useCoreSelector,
   selectCart,
-  useUserDetails,
+  useFetchUserDetailsQuery,
 } from "@gff/core";
 import FilesTable from "./FilesTable";
 import ProjectTable from "./ProjectTable";
@@ -34,8 +34,8 @@ const Cart: React.FC = () => {
   const cart = useCoreSelector((state) => selectCart(state));
   const { data: summaryData } = useCartSummary(cart.map((f) => f.file_id));
   const { data: userDetails, isFetching: userDetailsFetching } =
-    useUserDetails();
-  const filesByCanAccess = groupByAccess(cart, userDetails);
+    useFetchUserDetailsQuery();
+  const filesByCanAccess = groupByAccess(cart, userDetails?.data);
   const dbGapList = Array.from(
     new Set(
       (filesByCanAccess?.true || [])

--- a/packages/portal-proto/src/features/cart/Cart.unit.test.tsx
+++ b/packages/portal-proto/src/features/cart/Cart.unit.test.tsx
@@ -4,7 +4,7 @@ import Cart from "./Cart";
 
 describe("<Cart />", () => {
   beforeEach(() => {
-    jest.spyOn(core, "useUserDetails").mockReturnValue({} as any);
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValue({} as any);
   });
 
   it("Displays empty state", () => {

--- a/packages/portal-proto/src/features/cart/CartHeader.tsx
+++ b/packages/portal-proto/src/features/cart/CartHeader.tsx
@@ -8,7 +8,7 @@ import {
   useCoreSelector,
   selectCurrentModal,
   Modals,
-  useUserDetails,
+  useFetchUserDetailsQuery,
 } from "@gff/core";
 import fileSize from "filesize";
 import { Button, Loader, Menu } from "@mantine/core";
@@ -103,7 +103,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
   dbGapList,
 }: CartHeaderProps) => {
   const dispatch = useCoreDispatch();
-  const { data: userDetails } = useUserDetails();
+  const { data: userDetails } = useFetchUserDetailsQuery();
   const [downloadActive, setDownloadActive] = useState(false);
   const [clinicalTSVDownloadActive, setClinicalTSVDownloadActive] =
     useState(false);
@@ -124,7 +124,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
       {modal === Modals.CartDownloadModal && (
         <CartDownloadModal
           openModal
-          user={userDetails}
+          user={userDetails?.data}
           filesByCanAccess={filesByCanAccess}
           dbGapList={dbGapList}
           setActive={setDownloadActive}

--- a/packages/portal-proto/src/features/files/BAMSlicingButton/BAMSlicingButton.unit.test.tsx
+++ b/packages/portal-proto/src/features/files/BAMSlicingButton/BAMSlicingButton.unit.test.tsx
@@ -13,12 +13,14 @@ describe("<BAMSlicingButton />", () => {
   it("show NoAccessModal when not logged in", async () => {
     const mockDispatch = jest.fn();
     jest.spyOn(core, "useCoreDispatch").mockImplementation(() => mockDispatch);
-    jest.spyOn(core, "useCoreSelector").mockReturnValueOnce({
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValueOnce({
       data: {
-        username: null,
-        projects: { gdc_ids: {} },
+        data: {
+          username: null,
+          projects: { gdc_ids: {} },
+        },
       },
-    });
+    } as any);
     const { getByTestId } = render(
       <BAMSlicingButton isActive={false} file={{} as core.GdcFile} />,
     );
@@ -33,12 +35,14 @@ describe("<BAMSlicingButton />", () => {
   it("show NoAccessModal when not logged in", async () => {
     const mockDispatch = jest.fn();
     jest.spyOn(core, "useCoreDispatch").mockImplementation(() => mockDispatch);
-    jest.spyOn(core, "useCoreSelector").mockReturnValueOnce({
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValueOnce({
       data: {
-        username: "testid",
-        projects: { gdc_ids: {} },
+        data: {
+          username: "testid",
+          projects: { gdc_ids: {} },
+        },
       },
-    });
+    } as any);
     jest.spyOn(util, "userCanDownloadFile").mockReturnValueOnce(true);
     const { getByTestId } = render(
       <BAMSlicingButton isActive={false} file={{} as core.GdcFile} />,
@@ -54,12 +58,14 @@ describe("<BAMSlicingButton />", () => {
   it("show NoAccessToProjectModal when not logged in", async () => {
     const mockDispatch = jest.fn();
     jest.spyOn(core, "useCoreDispatch").mockImplementation(() => mockDispatch);
-    jest.spyOn(core, "useCoreSelector").mockReturnValueOnce({
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValueOnce({
       data: {
-        username: "testid",
-        projects: { gdc_ids: {} },
+        data: {
+          username: "testid",
+          projects: { gdc_ids: {} },
+        },
       },
-    });
+    } as any);
     jest.spyOn(util, "userCanDownloadFile").mockReturnValueOnce(false);
     const { getByTestId } = render(
       <BAMSlicingButton isActive={false} file={{} as core.GdcFile} />,

--- a/packages/portal-proto/src/features/files/BAMSlicingButton/index.tsx
+++ b/packages/portal-proto/src/features/files/BAMSlicingButton/index.tsx
@@ -1,12 +1,12 @@
 import {
   useCoreDispatch,
-  useCoreSelector,
-  selectUserDetailsInfo,
+  useFetchUserDetailsQuery,
   showModal,
   Modals,
   GdcFile,
 } from "@gff/core";
 import { Button } from "@mantine/core";
+import { useCallback } from "react";
 import { FaCut } from "react-icons/fa";
 import { userCanDownloadFile } from "src/utils/userProjectUtils";
 
@@ -18,26 +18,29 @@ export const BAMSlicingButton = ({
   file: GdcFile;
 }): JSX.Element => {
   const dispatch = useCoreDispatch();
-  const userInfo = useCoreSelector((state) => selectUserDetailsInfo(state));
+  const { data: userInfo } = useFetchUserDetailsQuery();
   const { username } = userInfo?.data || {};
+
+  const onClick = useCallback(() => {
+    if (username && userCanDownloadFile({ user: userInfo?.data, file })) {
+      dispatch(showModal({ modal: Modals.BAMSlicingModal }));
+    } else if (
+      username &&
+      !userCanDownloadFile({ user: userInfo?.data, file })
+    ) {
+      dispatch(showModal({ modal: Modals.NoAccessToProjectModal }));
+    } else {
+      dispatch(showModal({ modal: Modals.NoAccessModal }));
+    }
+  }, [dispatch, file, userInfo?.data, username]);
+
   return (
     <Button
       className="font-medium text-sm text-primary bg-base-max hover:bg-primary-darkest hover:text-primary-contrast-darker"
       leftIcon={<FaCut aria-hidden="true" />}
       loading={isActive}
       variant="outline"
-      onClick={() => {
-        if (username && userCanDownloadFile({ user: userInfo.data, file })) {
-          dispatch(showModal({ modal: Modals.BAMSlicingModal }));
-        } else if (
-          username &&
-          !userCanDownloadFile({ user: userInfo.data, file })
-        ) {
-          dispatch(showModal({ modal: Modals.NoAccessToProjectModal }));
-        } else {
-          dispatch(showModal({ modal: Modals.NoAccessModal }));
-        }
-      }}
+      onClick={onClick}
       data-testid="bamButton"
     >
       {isActive ? "Slicing" : "BAM Slicing"}

--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
+import { useDeepCompareCallback } from "use-deep-compare";
 import {
   GdcFile,
   HistoryDefaults,
@@ -95,7 +96,7 @@ export const FileView: React.FC<FileViewProps> = ({
   const [fileToDownload, setFileToDownload] = useState(file);
   const isFileInCart = fileInCart(currentCart, file.file_id);
 
-  const formatDataForFileProperties = useCallback(
+  const formatDataForFileProperties = useDeepCompareCallback(
     () =>
       formatDataForHorizontalTable(file, [
         {
@@ -133,7 +134,7 @@ export const FileView: React.FC<FileViewProps> = ({
     [file],
   );
 
-  const formatDataForDataInformation = useCallback(
+  const formatDataForDataInformation = useDeepCompareCallback(
     () =>
       formatDataForHorizontalTable(file, [
         {
@@ -156,7 +157,7 @@ export const FileView: React.FC<FileViewProps> = ({
     [file],
   );
 
-  const formatDataForAnalysis = useCallback(
+  const formatDataForAnalysis = useDeepCompareCallback(
     () =>
       formatDataForHorizontalTable(file, [
         {

--- a/packages/portal-proto/src/features/layout/Header.tsx
+++ b/packages/portal-proto/src/features/layout/Header.tsx
@@ -95,7 +95,7 @@ export const Header: React.FC<HeaderProps> = ({
 
   const { entityMetadata, setEntityMetadata } = useContext(SummaryModalContext);
 
-  const [fetchToken] = useLazyFetchTokenQuery();
+  const [fetchToken] = useLazyFetchTokenQuery({ refetchOnFocus: false });
 
   return (
     <div className="px-4 py-3 border-b border-gdc-grey-lightest flex flex-col">

--- a/packages/portal-proto/src/features/layout/Header.unit.test.tsx
+++ b/packages/portal-proto/src/features/layout/Header.unit.test.tsx
@@ -1,4 +1,3 @@
-import { fireEvent } from "@testing-library/react";
 import { headerElements } from "../user-flow/workflow/navigation-utils";
 import { Header } from "./Header";
 import * as router from "next/router";
@@ -49,16 +48,15 @@ describe("<Header />", () => {
 
   test("should show login button when the username is null initially", () => {
     jest.spyOn(core, "useCoreDispatch").mockImplementation(jest.fn());
-    jest
-      .spyOn(core, "useCoreSelector")
-      .mockReturnValueOnce({
+    jest.spyOn(core, "useCoreSelector").mockImplementation(jest.fn());
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValueOnce({
+      data: {
         data: {
           username: null,
           projects: { gdc_ids: {} },
         },
-      })
-      .mockReturnValueOnce(["1", "2"])
-      .mockReturnValueOnce(null);
+      },
+    } as any);
 
     const { getByTestId, queryByTestId } = render(
       <Header {...{ headerElements, indexPath: "/" }} />,
@@ -69,89 +67,20 @@ describe("<Header />", () => {
 
   test("should not show login button when the username is present", () => {
     jest.spyOn(core, "useCoreDispatch").mockImplementation(jest.fn());
-    jest
-      .spyOn(core, "useCoreSelector")
-      .mockReturnValueOnce({
+    jest.spyOn(core, "useCoreSelector").mockImplementation(jest.fn());
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValueOnce({
+      data: {
         data: {
           username: "testName",
           projects: { gdc_ids: {} },
         },
-      })
-      .mockReturnValueOnce(["1", "2"])
-      .mockReturnValueOnce(null);
+      },
+    } as any);
 
     const { getByTestId, queryByTestId } = render(
       <Header {...{ headerElements, indexPath: "/" }} />,
     );
     expect(queryByTestId("loginButton")).toBeNull();
     expect(getByTestId("userdropdown")).toBeInTheDocument();
-  });
-
-  test("should show Session Expire Modal when fetch token returns 401", async () => {
-    const mockDispatch = jest.fn();
-    jest.spyOn(core, "useCoreDispatch").mockImplementation(() => mockDispatch);
-
-    jest
-      .spyOn(core, "useCoreSelector")
-      .mockReturnValueOnce({
-        data: {
-          username: "testName",
-          projects: { gdc_ids: {} },
-        },
-      })
-      .mockReturnValueOnce(["1", "2"])
-      .mockReturnValueOnce(null);
-
-    jest
-      .spyOn(core, "fetchToken")
-      .mockReturnValue(Promise.resolve({ text: "", status: 401 }));
-    const { getByTestId } = render(
-      <Header {...{ headerElements, indexPath: "/" }} />,
-    );
-
-    await fireEvent.click(getByTestId("userdropdown"));
-    await fireEvent.click(getByTestId("userprofilemenu"));
-    expect(mockDispatch).toBeCalledWith({
-      payload: { modal: "SessionExpireModal" },
-      type: "modals/showModal",
-    });
-    expect(mockDispatch).not.toBeCalledWith({
-      payload: { modal: "UserProfileModal" },
-      type: "modals/showModal",
-    });
-  });
-});
-
-test("should show User Profile Modal when fetch token returns 401", async () => {
-  const mockDispatch = jest.fn();
-  jest.spyOn(core, "useCoreDispatch").mockImplementation(() => mockDispatch);
-
-  jest
-    .spyOn(core, "useCoreSelector")
-    .mockReturnValueOnce({
-      data: {
-        username: "testName",
-        projects: { gdc_ids: {} },
-      },
-    })
-    .mockReturnValueOnce(["1", "2"])
-    .mockReturnValueOnce(null);
-
-  jest
-    .spyOn(core, "fetchToken")
-    .mockReturnValue(Promise.resolve({ text: "", status: 200 }));
-  const { getByTestId } = render(
-    <Header {...{ headerElements, indexPath: "/" }} />,
-  );
-
-  await fireEvent.click(getByTestId("userdropdown"));
-  await fireEvent.click(getByTestId("userprofilemenu"));
-  expect(mockDispatch).not.toBeCalledWith({
-    payload: { modal: "SessionExpireModal" },
-    type: "modals/showModal",
-  });
-  expect(mockDispatch).toBeCalledWith({
-    payload: { modal: "UserProfileModal" },
-    type: "modals/showModal",
   });
 });

--- a/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
+++ b/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
@@ -6,7 +6,6 @@ import {
   useCoreDispatch,
   fetchNotifications,
   selectBanners,
-  fetchUserDetails,
   selectCurrentCohortName,
   selectCohortMessage,
   clearCohortMessage,
@@ -47,7 +46,6 @@ export const UserFlowVariedPages = ({
   const dispatch = useCoreDispatch();
 
   useEffect(() => {
-    dispatch(fetchUserDetails());
     dispatch(fetchNotifications());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -7,7 +7,7 @@ import {
   buildCohortGqlOperator,
   FilterSet,
   PROTEINPAINT_API,
-  useUserDetails,
+  useFetchUserDetailsQuery,
   useCoreDispatch,
   useCreateCaseSetFromValuesMutation,
 } from "@gff/core";
@@ -38,7 +38,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
   const filter0 = isDemoMode
     ? defaultFilter
     : buildCohortGqlOperator(currentCohort);
-  const userDetails = useUserDetails();
+  const userDetails = useFetchUserDetailsQuery();
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
   const initialFilter0Ref = useRef<any>();

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.unit.test.tsx
@@ -15,7 +15,7 @@ jest.mock("@gff/core", () => ({
   selectCurrentCohortFilterSet: jest.fn().mockReturnValue({}),
   buildCohortGqlOperator: jest.fn(() => filter),
   useAddCohortMutation: jest.fn(() => [() => null, { isSuccess: true }]),
-  useUserDetails: jest.fn(() => userDetails),
+  useFetchUserDetailsQuery: jest.fn(() => userDetails),
   useCoreDispatch: jest.fn(() => nullFunction()),
   PROTEINPAINT_API: "host:port/basepath",
   useCreateCaseSetFromValuesMutation: () => [

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -7,7 +7,7 @@ import {
   buildCohortGqlOperator,
   FilterSet,
   PROTEINPAINT_API,
-  useUserDetails,
+  useFetchUserDetailsQuery,
   useCoreDispatch,
   useCreateCaseSetFromValuesMutation,
 } from "@gff/core";
@@ -38,7 +38,8 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   const filter0 = isDemoMode
     ? defaultFilter
     : buildCohortGqlOperator(currentCohort);
-  const userDetails = useUserDetails();
+  const userDetails = useFetchUserDetailsQuery();
+
   const ppRef = useRef<PpApi>();
   const ppPromise = useRef<Promise<PpApi>>();
   const initialFilter0Ref = useRef<any>();

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.unit.test.tsx
@@ -15,7 +15,7 @@ jest.mock("@gff/core", () => ({
   selectCurrentCohortFilterSet: jest.fn().mockReturnValue({}),
   buildCohortGqlOperator: jest.fn(() => filter),
   useAddCohortMutation: jest.fn(() => [() => null, { isSuccess: true }]),
-  useUserDetails: jest.fn(() => userDetails),
+  useFetchUserDetailsQuery: jest.fn(() => userDetails),
   useCoreDispatch: jest.fn(() => nullFunction()),
   PROTEINPAINT_API: "host:port/basepath",
   useCreateCaseSetFromValuesMutation: () => [

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -6,7 +6,7 @@ import {
   selectCurrentCohortFilters,
   FilterSet,
   PROTEINPAINT_API,
-  useUserDetails,
+  useFetchUserDetailsQuery,
   useCoreDispatch,
   buildCohortGqlOperator,
   useCreateCaseSetFromValuesMutation,
@@ -35,7 +35,8 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
   const isDemoMode = useIsDemoApp();
   const currentCohort = useCoreSelector(selectCurrentCohortFilters);
   const filter0 = isDemoMode ? null : buildCohortGqlOperator(currentCohort);
-  const { data: userDetails } = useUserDetails();
+  const userDetails = useFetchUserDetailsQuery();
+
   // to track reusable instance for mds3 skewer track
   const ppRef = useRef<PpApi>();
   const prevArg = useRef<any>({});

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
@@ -15,7 +15,7 @@ jest.mock("@gff/core", () => ({
   selectCurrentCohortFilterSet: jest.fn(() => filter),
   buildCohortGqlOperator: jest.fn(() => filter),
   useAddCohortMutation: jest.fn(() => [() => null, { isSuccess: true }]),
-  useUserDetails: jest.fn(() => userDetails),
+  useFetchUserDetailsQuery: jest.fn(() => userDetails),
   useCoreDispatch: jest.fn(() => nullFunction()),
   setActiveCohort: jest.fn(() => null),
   PROTEINPAINT_API: "host:port/basepath",

--- a/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
@@ -6,7 +6,7 @@ import {
   buildCohortGqlOperator,
   FilterSet,
   PROTEINPAINT_API,
-  useUserDetails,
+  useFetchUserDetailsQuery,
 } from "@gff/core";
 import { isEqual, cloneDeep } from "lodash";
 
@@ -22,7 +22,8 @@ export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
     useCoreSelector(selectCurrentCohortFilters),
   );
 
-  const { data: userDetails } = useUserDetails();
+  const { data: userDetails } = useFetchUserDetailsQuery();
+
   const [alertDisplay, setAlertDisplay] = useState("none");
   const [rootDisplay, setRootDisplay] = useState("none");
 
@@ -33,12 +34,14 @@ export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
   useEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
-      const isAuthorized = userDetails.username && true;
+      const isAuthorized = userDetails?.data.username && true;
       setAlertDisplay(isAuthorized ? "none" : "block");
       setRootDisplay(isAuthorized ? "block" : "none");
       if (!isAuthorized) return;
 
-      const data = userDetails?.username ? getBamTrack(props, filter0) : null;
+      const data = userDetails?.data?.username
+        ? getBamTrack(props, filter0)
+        : null;
 
       if (!data) return;
       if (isEqual(prevArg.current, data)) return;

--- a/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.unit.test.tsx
@@ -7,7 +7,7 @@ jest.mock("@gff/core", () => ({
   useCoreSelector: jest.fn().mockReturnValue({}),
   selectCurrentCohortFilterSet: jest.fn().mockReturnValue({}),
   buildCohortGqlOperator: jest.fn(() => filter),
-  useUserDetails: jest.fn(() => userDetails),
+  useFetchUserDetailsQuery: jest.fn(() => userDetails),
   PROTEINPAINT_API: "host:port/basepath",
 }));
 
@@ -20,7 +20,7 @@ jest.mock("@sjcrh/proteinpaint-client", () => ({
 }));
 
 test("Sequence Read arguments - logged in", () => {
-  userDetails = { data: { username: "test" } };
+  userDetails = { data: { data: { username: "test" } } };
   filter = { test: 1 };
   const { unmount, container } = render(<SequenceReadWrapper />);
   expect(typeof runpparg).toBe("object");
@@ -45,7 +45,7 @@ test("Sequence Read arguments - logged in", () => {
 
 // make this the last test so that userDetails
 test("Sequence Read arguments - not logged in", () => {
-  userDetails = { data: { username: null } };
+  userDetails = { data: { data: { username: null } } };
   filter = { test: 1 };
   const { unmount, container } = render(<SequenceReadWrapper />);
   expect(container.querySelector(".sjpp-wrapper-alert-div")).toHaveStyle(


### PR DESCRIPTION
## Description
Switches auth calls to rtk create API so we can take advantage of the [automatic refetching 
](https://redux-toolkit.js.org/rtk-query/api/createApi#refetchonmountorargchange) and eliminate the need to refresh the token when displaying the user profile while still handling the session expiring. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
User will now see their session as logged out if they log out in another tab. 
https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/551ae2a5-2da5-4280-ba26-480424cab77f