### PR TITLE
PEAR-1829: Fix for Genes and SSM Table expand button does not expand when clicked

### DIFF
--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -433,8 +433,9 @@ function VerticalTable<TData>({
                         {row.getCanExpand() &&
                         expandableColumnIds.includes(columnId) &&
                         // check to make sure item is expandable
-                        Array.isArray(cellValue) &&
-                        cellValue.length > 1 ? (
+                        (cellValue !== undefined
+                          ? Array.isArray(cellValue) && cellValue.length > 1
+                          : true) ? (
                           <button
                             onClick={() => {
                               setClickedColumnId(columnId);


### PR DESCRIPTION
## Description

If the column type is "accessor," then the cell value is defined; otherwise, it's undefined. Since for accessors, the cell value represents its data type, it makes sense to have an array. For display, the cell has a complex data type, so we don't know if it is an array or not. 
Also this makes sure that for column type accessor if the array length is < 2 then it's not gonna be a button which is what we wanted to avoid in the first place.

### Note:
Please verify that rows are expandable for tables listed below:
1. Somatic Mutation Table
2. Genes Table (they are both in MF app)
3. Primary Site (Project)
4. Projects
5. Cancer Distribution

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
