### PR TITLE
(PEAR-1810): disable buttons while loading for Analysis cards and Cases View

### DIFF
--- a/packages/portal-proto/src/features/GenomicTables/GenesTable/GTableContainer.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/GenesTable/GTableContainer.tsx
@@ -462,6 +462,7 @@ export const GTableContainer: React.FC<GTableContainerProps> = ({
             <FunctionButton
               onClick={handleTSVDownload}
               data-testid="button-tsv-mutation-frequency"
+              disabled={isFetching}
             >
               {downloadMutatedGenesTSVActive ? <Loader size="sm" /> : "TSV"}
             </FunctionButton>

--- a/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
@@ -506,6 +506,7 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
                       caseFilter ? handleTSVCaseDownload : handleTSVGeneDownload
                     }
                     aria-label="Download TSV"
+                    disabled={isFetching}
                   >
                     {downloadMutationsFrequencyTSVActive ? (
                       <Loader size="sm" />
@@ -518,6 +519,7 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
                     onClick={handleTSVDownload}
                     data-testid="button-tsv-mutation-frequency"
                     aria-label="Download TSV"
+                    disabled={isFetching}
                   >
                     {downloadMutationsFrequencyTSVActive ? (
                       <Loader size="sm" />

--- a/packages/portal-proto/src/features/cancerDistributionTable/CancerDistributionTable.tsx
+++ b/packages/portal-proto/src/features/cancerDistributionTable/CancerDistributionTable.tsx
@@ -515,6 +515,7 @@ const CancerDistributionTable: React.FC<CancerDistributionTableProps> = ({
           <div className="flex gap-2 mb-2">
             <FunctionButton
               onClick={() => handleJSONDownload(formattedData, isGene)}
+              disabled={isFetching}
             >
               JSON
             </FunctionButton>
@@ -526,6 +527,7 @@ const CancerDistributionTable: React.FC<CancerDistributionTableProps> = ({
                   isGene,
                 )
               }
+              disabled={isFetching}
             >
               TSV
             </FunctionButton>

--- a/packages/portal-proto/src/features/cart/FilesTable.tsx
+++ b/packages/portal-proto/src/features/cart/FilesTable.tsx
@@ -376,6 +376,7 @@ const FilesTable: React.FC<FilesTableProps> = () => {
             <FunctionButton
               onClick={handleDownloadJSON}
               aria-label="Download JSON"
+              disabled={isFetching}
             >
               JSON
             </FunctionButton>
@@ -384,6 +385,7 @@ const FilesTable: React.FC<FilesTableProps> = () => {
             <FunctionButton
               onClick={handleDownloadTSV}
               aria-label="Download TSV"
+              disabled={isFetching}
             >
               TSV
             </FunctionButton>

--- a/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
@@ -10,7 +10,8 @@ import {
   GqlOperation,
   useCurrentCohortCounts,
 } from "@gff/core";
-import { Button, Divider, Loader, LoadingOverlay } from "@mantine/core";
+import { Divider, Loader } from "@mantine/core";
+import FunctionButton from "@/components/FunctionButton";
 import { SummaryModalContext } from "src/utils/contexts";
 import {
   ageDisplay,
@@ -378,9 +379,8 @@ export const ContextualCasesView: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col relative" data-testid="cases-table">
+    <div className="flex flex-col" data-testid="cases-table">
       <Divider color="#C5C5C5" className="mb-3" />
-      <LoadingOverlay visible={isFetching} />
 
       <VerticalTable
         data={casesData}
@@ -392,6 +392,7 @@ export const ContextualCasesView: React.FC = () => {
             <CasesCohortButtonFromValues pickedCases={pickedCases} />
 
             <DropdownWithIcon
+              targetButtonDisabled={isFetching}
               dropdownElements={[
                 {
                   title: "JSON",
@@ -421,6 +422,7 @@ export const ContextualCasesView: React.FC = () => {
             />
 
             <DropdownWithIcon
+              targetButtonDisabled={isFetching}
               dropdownElements={[
                 {
                   title: "JSON",
@@ -449,23 +451,13 @@ export const ContextualCasesView: React.FC = () => {
               }
             />
 
-            <Button
-              onClick={handleJSONDownload}
-              variant="outline"
-              color="primary"
-              className="bg-base-max"
-            >
+            <FunctionButton onClick={handleJSONDownload} disabled={isFetching}>
               {cohortTableJSONDownloadActive ? <Loader /> : "JSON"}
-            </Button>
+            </FunctionButton>
 
-            <Button
-              variant="outline"
-              color="primary"
-              className="bg-base-max"
-              onClick={handleTSVDownload}
-            >
+            <FunctionButton onClick={handleTSVDownload} disabled={isFetching}>
               {cohortTableTSVDownloadActive ? <Loader /> : "TSV"}
-            </Button>
+            </FunctionButton>
           </div>
         }
         tableTitle={`Total of ${pagination?.total?.toLocaleString() ?? "..."} ${

--- a/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
@@ -10,7 +10,7 @@ import {
   GqlOperation,
   useCurrentCohortCounts,
 } from "@gff/core";
-import { Button, Divider, Loader } from "@mantine/core";
+import { Button, Divider, Loader, LoadingOverlay } from "@mantine/core";
 import { SummaryModalContext } from "src/utils/contexts";
 import {
   ageDisplay,
@@ -378,8 +378,9 @@ export const ContextualCasesView: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col" data-testid="cases-table">
+    <div className="flex flex-col relative" data-testid="cases-table">
       <Divider color="#C5C5C5" className="mb-3" />
+      <LoadingOverlay visible={isFetching} />
 
       <VerticalTable
         data={casesData}

--- a/packages/portal-proto/src/features/mutationSummary/ConsequenceTable.tsx
+++ b/packages/portal-proto/src/features/mutationSummary/ConsequenceTable.tsx
@@ -364,10 +364,12 @@ export const ConsequenceTable = ({
       }}
       additionalControls={
         <div className="flex gap-2 mb-2">
-          <FunctionButton onClick={handleJSONDownload}>
+          <FunctionButton onClick={handleJSONDownload} disabled={isFetching}>
             {consequenceTableJSONDownloadActive ? <Loader /> : "JSON"}
           </FunctionButton>
-          <FunctionButton onClick={handleTSVDownload}>TSV</FunctionButton>
+          <FunctionButton onClick={handleTSVDownload} disabled={isFetching}>
+            TSV
+          </FunctionButton>
         </div>
       }
       status={statusBooleansToDataStatus(isFetching, isSuccess, isError)}

--- a/packages/portal-proto/src/features/projectsCenter/ProjectsTable.tsx
+++ b/packages/portal-proto/src/features/projectsCenter/ProjectsTable.tsx
@@ -377,12 +377,14 @@ const ProjectsTable: React.FC = () => {
           <FunctionButton
             data-testid="button-json-projects-table"
             onClick={handleDownloadJSON}
+            disabled={isFetching}
           >
             JSON
           </FunctionButton>
           <FunctionButton
             data-testid="button-tsv-projects-table"
             onClick={handleDownloadTSV}
+            disabled={isFetching}
           >
             TSV
           </FunctionButton>

--- a/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
@@ -475,12 +475,14 @@ const FilesTables: React.FC = () => {
               <FunctionButton
                 onClick={handleDownloadJSON}
                 data-testid="button-json-files-table"
+                disabled={isFetching}
               >
                 JSON
               </FunctionButton>
               <FunctionButton
                 onClick={handleDownloadTSV}
                 data-testid="button-tsv-files-table"
+                disabled={isFetching}
               >
                 TSV
               </FunctionButton>

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -50,7 +50,7 @@ const useCohortCentricFiles = () => {
   );
 
   const allFilters = joinFilters(cohortFilters, repositoryFilters);
-  const { data: fileData } = useGetFilesQuery({
+  const { data: fileData, isFetching: fileDataFetching } = useGetFilesQuery({
     case_filters: buildCohortGqlOperator(cohortFilters),
     filters: buildCohortGqlOperator(repositoryFilters),
     expand: [
@@ -67,6 +67,7 @@ const useCohortCentricFiles = () => {
     caseFilters: cohortFilters,
     localFilters: repositoryFilters,
     pagination: fileData?.pagination,
+    fileDataFetching,
     repositoryFilters,
     imagesCount,
   };
@@ -82,6 +83,7 @@ export const RepositoryApp = (): JSX.Element => {
     pagination,
     repositoryFilters,
     imagesCount,
+    fileDataFetching,
   } = useCohortCentricFiles();
   const [
     getFileSizeSliceData, // This is the mutation trigger
@@ -192,6 +194,7 @@ export const RepositoryApp = (): JSX.Element => {
                   data-testid="button-add-all-files-table"
                   leftIcon={<CartIcon aria-hidden="true" />}
                   loading={allFilesLoading}
+                  disabled={fileDataFetching}
                   onClick={() => {
                     // check number of files selected before making call
                     if (

--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
@@ -31,7 +31,7 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
     caseCounts = 0;
   }
 
-  const inactive = caseCounts === 0;
+  const inactive = caseCounts === 0 || cohortCounts?.status === "pending";
   const { ref: descRef, height: descHeight } = useElementSize();
 
   return (


### PR DESCRIPTION
## Description

- disable buttons while loading for Analysis cards
- disable buttons while loading for Cases View
- disable TSV and JSON download buttons when table data is loading 

## Checklist

- [na] Added proper unit tests
- [na] Left proper TODO messages for any remaining tasks
- [na] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
