### PR TITLE
PEAR-1845 - Cohort Bar - After replacing a cohort with the same name, saving cohorts do not work 

### DIFF
--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useDeepCompareEffect } from "use-deep-compare";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { Modal, Button } from "@mantine/core";
@@ -69,6 +69,15 @@ const SaveCohortModal = ({
     isLoading: cohortListLoading,
   } = useGetCohortsByContextIdQuery(null, { skip: !cohortReplaced });
 
+  const closeModal = useCallback(() => {
+    onClose();
+    // Reset modal state on close
+    setShowReplaceCohort(false);
+    setCohortReplaced(false);
+    setEnteredName(undefined);
+    setCohortSavedMessage(undefined);
+  }, [onClose]);
+
   useDeepCompareEffect(() => {
     if (opened && cohortListSuccess && cohortReplaced) {
       // Remove replaced cohort
@@ -83,7 +92,7 @@ const SaveCohortModal = ({
       }
 
       coreDispatch(setCohortMessage(cohortSavedMessage));
-      onClose();
+      closeModal();
     }
   }, [
     cohortListSuccess,
@@ -205,7 +214,7 @@ const SaveCohortModal = ({
           setCohortReplaced(true);
         } else {
           coreDispatch(setCohortMessage(tempCohortMsg));
-          onClose();
+          closeModal();
         }
       })
       .catch((e: FetchBaseQueryError) => {

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.unit.test.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.unit.test.tsx
@@ -295,4 +295,73 @@ describe("SaveCohortModal", () => {
 
     expect(setCurrentCohortMock).toBeCalledWith("2");
   });
+
+  test("clears state when modal is closed", async () => {
+    const mockMutation = jest.fn().mockReturnValue({
+      unwrap: jest
+        .fn()
+        .mockRejectedValueOnce({
+          data: {
+            message: "Bad Request: Name must be unique (case-insensitive)",
+          },
+        })
+        .mockResolvedValueOnce({
+          id: 1,
+          name: "my saved cohort",
+        }),
+    });
+    jest
+      .spyOn(core, "useAddCohortMutation")
+      .mockReturnValue([mockMutation, { isLoading: false } as any]);
+    jest
+      .spyOn(core, "useLazyGetCohortByIdQuery")
+      .mockReturnValue([jest.fn()] as any);
+    jest
+      .spyOn(core, "useGetCohortsByContextIdQuery")
+      .mockReturnValue({ data: [], isSuccess: true, isLoading: false } as any);
+
+    const { getByText, queryByText, rerender } = render(
+      <SaveCohortModal
+        opened
+        onClose={jest.fn()}
+        filters={{
+          root: {
+            "projects.program.name": {
+              field: "projects.program.name",
+              operands: ["TCGA"],
+              operator: "includes",
+            },
+          },
+          mode: "and",
+        }}
+        cohortId="1"
+      />,
+    );
+
+    await userEvent.type(getByText("Name"), "my new cohort");
+    await userEvent.click(getByText("Save"));
+    await userEvent.click(getByText("Replace"));
+
+    // Modal is closed
+
+    rerender(
+      <SaveCohortModal
+        opened
+        onClose={jest.fn()}
+        filters={{
+          root: {
+            "projects.program.name": {
+              field: "projects.program.name",
+              operands: ["TCGA"],
+              operator: "includes",
+            },
+          },
+          mode: "and",
+        }}
+        cohortId="1"
+      />,
+    );
+
+    expect(queryByText("Replace Existing Cohort")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Description
Modal is no longer unmounting after PEAR-1658 so the state needs to be cleared on close. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
