### PR TITLE
PEAR-1847 removes sample type from cohort builder

### DIFF
--- a/packages/core/src/features/cohort/data/cohort_builder.json
+++ b/packages/core/src/features/cohort/data/cohort_builder.json
@@ -117,7 +117,6 @@
     "biospecimen": {
       "label": "Biospecimen",
       "facets": [
-        "cases.samples.sample_type",
         "cases.samples.tissue_type",
         "cases.samples.biospecimen_anatomic_site",
         "cases.samples.composition",

--- a/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
@@ -265,7 +265,6 @@ describe("cohortConfig reducer", () => {
       "cases.exposures.cigarettes_per_day",
       "cases.exposures.pack_years_smoked",
       "cases.exposures.tobacco_smoking_onset_year",
-      "cases.samples.sample_type",
       "cases.samples.tissue_type",
       "cases.samples.biospecimen_anatomic_site",
       "cases.samples.composition",


### PR DESCRIPTION
## Description
- removes the Sample Type card from Cohort Builder

## Checklist

- [Edited] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
Before change on left; after on right

<img width="2444" alt="Screenshot 2024-03-15 at 12 15 39 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/16ba78fd-bbc9-413b-9435-91fe4d5b1bfa">
