### PR TITLE
PEAR-1850 - Session Expired modal

### DIFF
--- a/packages/portal-proto/src/components/Modals/UserProfileModal.tsx
+++ b/packages/portal-proto/src/components/Modals/UserProfileModal.tsx
@@ -13,7 +13,7 @@ export const UserProfileModal = ({
   const { data: userInfo } = useFetchUserDetailsQuery();
 
   if (userInfo?.status === 401) {
-    return <SessionExpireModal openModal />;
+    return <SessionExpireModal openModal={openModal} />;
   }
 
   const {


### PR DESCRIPTION
## Description
I was able to recreate this error on develop using the auth setup: https://github.com/NCI-GDC/gdc-frontend-framework/blob/develop/README.md#running-auth-in-localhost-login-and-other-auth-related-actions . Bug was caused by PEAR-1818 + the change to the way the modals were rendered from PEAR-1658.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
