### PR TITLE
update proteinpaint-client to 2.47.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.42.1-0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.42.1-0.tgz",
-      "integrity": "sha512-SJhVPiHYlfwUtQtpMAWq8O8q90VJ/GdLBfV2XFu+2l2yPXNHZXa8Mv5GezLxQrb9OQei6mP/Li7rdBSSpgx56g=="
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.47.0.tgz",
+      "integrity": "sha512-X6mUNsF3dx6yiB+ruY+YW5VNVimoypxoMJjloRu5l74X6mLopZ1BALPNQSPUTntd5Y4HjJKKfoDDeF+ORiXx7A=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27192,7 +27192,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.42.1-0",
+        "@sjcrh/proteinpaint-client": "^2.47.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32411,9 +32411,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.42.1-0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.42.1-0.tgz",
-      "integrity": "sha512-SJhVPiHYlfwUtQtpMAWq8O8q90VJ/GdLBfV2XFu+2l2yPXNHZXa8Mv5GezLxQrb9OQei6mP/Li7rdBSSpgx56g=="
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.47.0.tgz",
+      "integrity": "sha512-X6mUNsF3dx6yiB+ruY+YW5VNVimoypxoMJjloRu5l74X6mLopZ1BALPNQSPUTntd5Y4HjJKKfoDDeF+ORiXx7A=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -42265,7 +42265,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.42.1-0",
+        "@sjcrh/proteinpaint-client": "^2.47.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.42.1-0",
+    "@sjcrh/proteinpaint-client": "^2.47.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

EDIT: Added Amy and Wendy as reviewers in case Craig is out.

Features:
- Add Mutation and CNV control buttons for GDC. Hide CNV by default for GDC
- Migrate the CJS server workspace into an ESM package
- enable geneVariant legend group filter for hierCluster
- combine all dts (except for dt=4) into mutations/consequences legend group for dt without assay availability

Fixes:
- Fix custom jwt processing by replacing the remaining webpack_require in auth code
- Do not force the sample table to be positioned relative to screen bottom after a sunburst click
- Updated mclass definitions and rank for protein_altering_variant
- mds3 tk temporarily disables sample selection button in single sample table, to avoid creating single-case cohort in GDC
- Deprecated term "sample_type" is dropped from GDC dictionary
- Preliminary fix for mds3 tk using custom bcf file to pull mutated samples
- Dataset configuration should have limited access to server configuration
- When a term has only 2 categories, then only a single category needs to be tested in the association test
- Return early on server validation instead of proceeding with startup
- Fix disco plot width issue
- Restore drag to resize on legacy ds gene exp panel
- GDC BAM slicing will be terminated if slice file size exceeds a limit (user is informed)
- Switching GDC mds3 track from gene to genomic mode it can properly display ssm now
- Mds3 tk sample summary table will scroll if too tall
- Replace require syntax with import to prevent bundling errors in client package bundlers


## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
