### PR TITLE
PEAR-1817 updates quick search's annotations links

### DIFF
--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -114,11 +114,6 @@ export const QuickSearch = (): JSX.Element => {
     }
     const selectedObj = matchedSearchList.find((obj) => obj.value == id).obj;
     const entityPath = extractEntityPath(selectedObj);
-    // Note: for annotations we need to open v1 portal in a new tab
-    if (entityPath.includes("annotations")) {
-      window.open(entityPath, "_ blank");
-      return;
-    }
     router.push(entityPath);
     setSearchText("");
   };

--- a/packages/portal-proto/src/components/QuickSearch/utils.ts
+++ b/packages/portal-proto/src/components/QuickSearch/utils.ts
@@ -3,9 +3,6 @@ import { isObject } from "lodash";
 export const extractEntityPath = (item: Record<string, any>): string => {
   if (item.id) {
     const entity = `${atob(item.id).split(":")[0].toLocaleLowerCase()}s`;
-    if (entity === "annotations") {
-      return `https://portal.gdc.cancer.gov/v1/annotations/${item.annotation_id}`;
-    }
     return `/${entity}/${atob(item.id).split(":")[1]}`;
   } else {
     return `/files/${item.uuid}`;


### PR DESCRIPTION
## Description
- quick search's annotations links should display the new annotation summary page and in the same tab

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
