### PR TITLE
PEAR-1849 - Add anchor link or similar to files table in case summary page

### DIFF
--- a/packages/core/src/features/users/usersSlice.ts
+++ b/packages/core/src/features/users/usersSlice.ts
@@ -57,6 +57,7 @@ const userAuthApi = coreCreateApi({
         Because an "error" response is valid for the auth requests we don't want to
         put the request in an error state or it will attempt the request over and over again
       */
+      return { data: {} };
     }
 
     return { data: results };

--- a/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SaveCohortModal.tsx
@@ -101,7 +101,7 @@ const SaveCohortModal = ({
     cohorts,
     coreDispatch,
     opened,
-    onClose,
+    closeModal,
     cohortSavedMessage,
   ]);
   const [fetchSavedFilters] = useLazyGetCohortByIdQuery();

--- a/packages/portal-proto/src/components/Modals/SummaryModal/SummaryModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SummaryModal/SummaryModal.tsx
@@ -44,9 +44,7 @@ export const SummaryModal = ({
         }
       : entity_type === "case"
       ? {
-          SummaryPage: (
-            <CaseSummary case_id={entity_id} bio_id="" isModal={true} />
-          ),
+          SummaryPage: <CaseSummary case_id={entity_id} isModal={true} />,
           title: "Case",
         }
       : entity_type === "file"
@@ -85,6 +83,7 @@ export const SummaryModal = ({
         header: "m-0 p-0 border-0",
         title: "sr-only",
         close: `absolute right-5 top-6 text-base-darkest [&_svg]:h-14 [&_svg]:w-14 float-right z-30 ${focusStyles}`,
+        content: "scroll-smooth",
       }}
       padding={0}
       overlayProps={{ opacity: 0.5 }}

--- a/packages/portal-proto/src/components/Summary/CategoryTableSummary.tsx
+++ b/packages/portal-proto/src/components/Summary/CategoryTableSummary.tsx
@@ -1,23 +1,38 @@
-import { HeaderTitle } from "@/components/tailwindComponents";
-
+import { MdInfo as InfoIcon } from "react-icons/md";
 import { ColumnDef } from "@tanstack/react-table";
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { HeaderTitle } from "@/components/tailwindComponents";
 import VerticalTable from "../Table/VerticalTable";
 
 interface CategoryTableSummaryProps<TData> {
   title: string;
   data: TData[];
   columns: ColumnDef<TData, any>[];
+  tooltip?: string;
 }
 
 function CategoryTableSummary<TData>({
   title,
   data,
   columns,
+  tooltip,
 }: CategoryTableSummaryProps<TData>): JSX.Element {
   return (
     <div className="basis-1/2">
-      <div className="text-base-contrast-lighter">
+      <div className="text-base-contrast-lighter flex">
         <HeaderTitle>{title}</HeaderTitle>
+        {tooltip && (
+          <Tooltip
+            label={tooltip}
+            events={{ hover: true, focus: true, touch: false }}
+            withArrow
+            withinPortal={false}
+          >
+            <ActionIcon>
+              <InfoIcon size={16} className="text-accent" />
+            </ActionIcon>
+          </Tooltip>
+        )}
       </div>
       <VerticalTable data={data} columns={columns} />
     </div>

--- a/packages/portal-proto/src/features/cases/CaseSummary.tsx
+++ b/packages/portal-proto/src/features/cases/CaseSummary.tsx
@@ -12,7 +12,7 @@ export const CaseSummary = ({
   isModal = false,
 }: {
   case_id: string;
-  bio_id: string;
+  bio_id?: string;
   isModal?: boolean;
 }): JSX.Element => {
   const [shouldScrollToBio, setShouldScrollToBio] = useState(

--- a/packages/portal-proto/src/features/layout/Header.unit.test.tsx
+++ b/packages/portal-proto/src/features/layout/Header.unit.test.tsx
@@ -49,7 +49,7 @@ describe("<Header />", () => {
   test("should show login button when the username is null initially", () => {
     jest.spyOn(core, "useCoreDispatch").mockImplementation(jest.fn());
     jest.spyOn(core, "useCoreSelector").mockImplementation(jest.fn());
-    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValueOnce({
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValue({
       data: {
         data: {
           username: null,
@@ -68,7 +68,7 @@ describe("<Header />", () => {
   test("should not show login button when the username is present", () => {
     jest.spyOn(core, "useCoreDispatch").mockImplementation(jest.fn());
     jest.spyOn(core, "useCoreSelector").mockImplementation(jest.fn());
-    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValueOnce({
+    jest.spyOn(core, "useFetchUserDetailsQuery").mockReturnValue({
       data: {
         data: {
           username: "testName",

--- a/packages/portal-proto/src/styles/globals.css
+++ b/packages/portal-proto/src/styles/globals.css
@@ -19,6 +19,10 @@ input[type="search"] {
   font-family: Noto Sans, sans-serif;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   position: relative;
 }


### PR DESCRIPTION
## Description
\+ PEAR-1838 - Add information telling users we have a files table in the case summary page
\+ PEAR-1832 - Remove supplements tables from case summary page 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1386" alt="Screenshot 2024-03-20 at 10 32 25 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/d73d2dd5-6805-40c3-b551-b3947338ff3e">