### PR TITLE
update the proteinpaint-client version to 2.48.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.47.0.tgz",
-      "integrity": "sha512-X6mUNsF3dx6yiB+ruY+YW5VNVimoypxoMJjloRu5l74X6mLopZ1BALPNQSPUTntd5Y4HjJKKfoDDeF+ORiXx7A=="
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.48.0.tgz",
+      "integrity": "sha512-903d/tiwf13ng1MWFR6346TWFocPUjZHEgl+/2w0EBEDqiuWndFWGM2qlUjZKUcBogXH7tU83H01opT/+wzq9w=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27192,7 +27192,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.47.0",
+        "@sjcrh/proteinpaint-client": "^2.48.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32411,9 +32411,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.47.0.tgz",
-      "integrity": "sha512-X6mUNsF3dx6yiB+ruY+YW5VNVimoypxoMJjloRu5l74X6mLopZ1BALPNQSPUTntd5Y4HjJKKfoDDeF+ORiXx7A=="
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.48.0.tgz",
+      "integrity": "sha512-903d/tiwf13ng1MWFR6346TWFocPUjZHEgl+/2w0EBEDqiuWndFWGM2qlUjZKUcBogXH7tU83H01opT/+wzq9w=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -42265,7 +42265,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.47.0",
+        "@sjcrh/proteinpaint-client": "^2.48.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.47.0",
+    "@sjcrh/proteinpaint-client": "^2.48.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Features:
- Enable selecting individual mutation classes upon clicking GDC oncomatrix mutation/cnv button

Fixes:
- Fix the timeout issues when using ky http client in GDC qa-int
- Change the definition of truncating/protein-changing mutation, change oncomatrix mutation classes sorting order
- Do not persist highlighted dendrogram branch selection when the hier. cluster data changes due to changes to cohort, clustering method, etc.
- Disable the geneset submit button when there there is less than a minNumGenes option (3 for hier cluster, 1 for matrix)

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
