### PR TITLE
PEAR-1753 - Null alt text (alt="") for open modal icons

### DIFF
--- a/packages/portal-proto/src/components/PopupIconButton/PopupIconButton.tsx
+++ b/packages/portal-proto/src/components/PopupIconButton/PopupIconButton.tsx
@@ -35,7 +35,7 @@ export const PopupIconButton = forwardRef<
             width={10}
             height={18}
             layout="fixed"
-            aria-hidden="true"
+            alt=""
           />
         }
         ref={ref}


### PR DESCRIPTION
## Description

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
