### PR TITLE
update the proteinpaint-client version to 2.49.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.48.0.tgz",
-      "integrity": "sha512-903d/tiwf13ng1MWFR6346TWFocPUjZHEgl+/2w0EBEDqiuWndFWGM2qlUjZKUcBogXH7tU83H01opT/+wzq9w=="
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.49.0.tgz",
+      "integrity": "sha512-9xw/4+pBaTU926ZkH4wZEZbnytm1FgzPYZgB1vNVdN/CLLFf0Y2HsLOoQMPmT8b/zFAPh5YMLkhA7p6FFhwftg=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27192,7 +27192,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.48.0",
+        "@sjcrh/proteinpaint-client": "^2.49.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32411,9 +32411,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.48.0.tgz",
-      "integrity": "sha512-903d/tiwf13ng1MWFR6346TWFocPUjZHEgl+/2w0EBEDqiuWndFWGM2qlUjZKUcBogXH7tU83H01opT/+wzq9w=="
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.49.0.tgz",
+      "integrity": "sha512-9xw/4+pBaTU926ZkH4wZEZbnytm1FgzPYZgB1vNVdN/CLLFf0Y2HsLOoQMPmT8b/zFAPh5YMLkhA7p6FFhwftg=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -42265,7 +42265,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.48.0",
+        "@sjcrh/proteinpaint-client": "^2.49.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.48.0",
+    "@sjcrh/proteinpaint-client": "^2.49.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Features:
- Display hints about persisted matrix gene set and option to unhide CNV and mutations when there is no matrix data to render
- Reenable the option to create a single sample cohort from a lollipop sample table/menu
- Refactor to move all gdc plot launchers into a separate folder
- Group similar mutation class colors together when sorting matrix samples and if CNVs are displayed
- Add Single style for GDC oncoMatrix

Fixes:
- GDC bam slicing download app now calls gdc api directly from client without going through pp backend

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
