### PR TITLE
PEAR-661: hide range control if there is no data

### DIFF
--- a/packages/portal-proto/src/components/FacetSelection.tsx
+++ b/packages/portal-proto/src/components/FacetSelection.tsx
@@ -108,8 +108,8 @@ const FacetSelectionPanel = ({
       const s = Object.values(facets)
         .filter((y) => {
           return searchString
-            ? y.field.includes(searchString.trim()) ||
-                y.description.includes(searchString.trim())
+            ? y.field?.includes(searchString.trim()) ||
+                y.description?.includes(searchString.trim())
             : true;
         })
         .reduce((res: Record<string, FacetDefinition>, value) => {

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -671,6 +671,7 @@ const DaysOrYears: React.FC<NumericFacetData> = ({
 }: NumericFacetData) => {
   const [units, setUnits] = useState("years");
   // no data if true means the Day/Year SegmentedControl should not be rendered.
+  // TODO: this is not ideal and perhaps should be refactored
   const [noData, setNoData] = useState(false);
   // set up a fixed range -90 to 90 years over 19 buckets
   const rangeMinimum = -32873;

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useDeepCompareEffect } from "react-use";
 import {
   MdClose as CloseIcon,
   MdFlip as FlipIcon,
@@ -550,7 +551,7 @@ const RangeInputWithPrefixedRanges: React.FC<
 
   // informs the parent component if there is data or no data
   // only used by the DaysOrYears component
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (isSuccess && filterValues === undefined && totalBuckets === 0)
       setHasData(false);
     else setHasData(true);
@@ -560,7 +561,7 @@ const RangeInputWithPrefixedRanges: React.FC<
   // otherwise this facet has some filters set and the custom range
   // should be shown
   if (isSuccess && filterValues === undefined && totalBuckets === 0) {
-    return <div className="mx-4 font-content">No data for this field</div>;
+    return <div className="mx-4 font-content pb-2">No data for this field</div>;
   }
 
   return (

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -687,7 +687,7 @@ const DaysOrYears: React.FC<NumericFacetData> = ({
             { label: "Years", value: "years" },
           ]}
           value={units}
-          color={"primary"}
+          color="primary"
           onChange={setUnits}
         />
       )}

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -325,7 +325,7 @@ const FromTo: React.FC<FromToProps> = ({
     units !== "years" ? maximum : getLowerAgeYears(maximum);
 
   return (
-    <div className="flex flex-col m-2 text-base-contrast-max bg-base-max">
+    <div className="flex flex-col grow m-2 text-base-contrast-max bg-base-max">
       <fieldset>
         <legend className="sr-only">Numeric from/to filters</legend>
         <div className="flex flex-row justify-end items-center flex-nowrap border font-content">
@@ -346,7 +346,7 @@ const FromTo: React.FC<FromToProps> = ({
           />
           <NumberInput
             data-testid="textbox-input-from-value"
-            className="basis-2/5 text-sm"
+            className="text-sm grow"
             placeholder={`eg. ${lowerUnitRange}${unitsLabel} `}
             min={lowerUnitRange}
             max={upperUnitRange}
@@ -384,7 +384,7 @@ const FromTo: React.FC<FromToProps> = ({
           />
           <NumberInput
             data-testid="textbox-input-to-value"
-            className="basis-2/5"
+            className="grow text-sm"
             placeholder={`eg. ${upperUnitRange}${unitsLabel} `}
             min={lowerUnitRange}
             max={upperUnitRange}
@@ -565,8 +565,8 @@ const RangeInputWithPrefixedRanges: React.FC<
   return (
     <>
       <LoadingOverlay data-testid="loading-spinner" visible={!isSuccess} />
-      <div className="flex flex-col w-100 space-y-2 mt-1 ">
-        <div className="flex flex-row  justify-items-stretch items-center">
+      <div className="flex flex-col space-y-2 mt-1 ">
+        <div className="flex justify-items-stretch items-center">
           <input
             aria-label="custom range"
             type="radio"

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -465,7 +465,7 @@ interface RangeInputWithPrefixedRangesProps {
   readonly showZero?: boolean;
   readonly clearValues?: boolean;
   readonly isFacetView?: boolean;
-  readonly setNoData?: (boolean) => void;
+  readonly setHasData?: (boolean) => void;
 }
 
 const RangeInputWithPrefixedRanges: React.FC<
@@ -481,7 +481,7 @@ const RangeInputWithPrefixedRanges: React.FC<
   showZero = false,
   clearValues = undefined,
   isFacetView = true,
-  setNoData = () => null,
+  setHasData = () => null,
 }: RangeInputWithPrefixedRangesProps) => {
   const [isGroupExpanded, setIsGroupExpanded] = useState(false); // handles the expanded group
 
@@ -552,9 +552,9 @@ const RangeInputWithPrefixedRanges: React.FC<
   // only used by the DaysOrYears component
   useEffect(() => {
     if (isSuccess && filterValues === undefined && totalBuckets === 0)
-      setNoData(true);
-    else setNoData(false);
-  }, [filterValues, isSuccess, setNoData, totalBuckets]);
+      setHasData(false);
+    else setHasData(true);
+  }, [filterValues, isSuccess, setHasData, totalBuckets]);
 
   // If no data and no filter values, show the no data message
   // otherwise this facet has some filters set and the custom range
@@ -672,7 +672,7 @@ const DaysOrYears: React.FC<NumericFacetData> = ({
   const [units, setUnits] = useState("years");
   // no data if true means the Day/Year SegmentedControl should not be rendered.
   // TODO: this is not ideal and perhaps should be refactored
-  const [noData, setNoData] = useState(false);
+  const [hasData, setHasData] = useState(true);
   // set up a fixed range -90 to 90 years over 19 buckets
   const rangeMinimum = -32873;
   const rangeMaximum = 32873;
@@ -680,7 +680,7 @@ const DaysOrYears: React.FC<NumericFacetData> = ({
 
   return (
     <div className="flex flex-col w-100 space-y-2 px-2  mt-1 ">
-      {!noData && (
+      {hasData && (
         <SegmentedControl
           data={[
             { label: "Days", value: "days" },
@@ -702,7 +702,7 @@ const DaysOrYears: React.FC<NumericFacetData> = ({
         valueLabel={valueLabel}
         clearValues={clearValues}
         isFacetView={isFacetView}
-        setNoData={(value) => setNoData(value)}
+        setHasData={(value) => setHasData(value)}
       />
     </div>
   );


### PR DESCRIPTION
## Description
Hides the custom range controls when the facet does not have data. There is a change from the ticket:
If the custom range value does not result in data for that facet, the custom range is shown; otherwise, the user can only clear the filters from the query expression.


Note: the Age facets have the Days/Years Segment rendered in the parent component. A handler is now passed to `RangeInputWithPrefixedRanges` to hide it if there are no values. This should be refactored later.

This also includes undefined value fixes with custom facets.

## Checklist

- [ ] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

### Example of Year of Diagnosis with no data
![image](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1093780/55486c30-0f94-461c-823b-41b451da0c69)

### Example of Year of Diagnosis with values that result in no data:
![image](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1093780/caa34f37-cc1c-4121-97e3-95be4b221bc5)

### Age of Diagnosis with no data:
![image](https://github.com/NCI-GDC/gdc-frontend-framework/assets/1093780/c17ae275-76b2-4d9b-8c31-4a3f6f958eee)
