### PR TITLE
PEAR-1863 - Add Metadata and Sample Sheet downloads to Repository

### DIFF
--- a/packages/portal-proto/src/components/DownloadButtons/DownloadButton.tsx
+++ b/packages/portal-proto/src/components/DownloadButtons/DownloadButton.tsx
@@ -1,8 +1,11 @@
-import { Button, ButtonProps, Loader, Tooltip } from "@mantine/core";
+import { ButtonProps, Loader, Tooltip } from "@mantine/core";
 import { FiDownload } from "react-icons/fi";
 import download from "src/utils/download";
 import { hideModal, Modals, useCoreDispatch } from "@gff/core";
 import { Dispatch, SetStateAction, forwardRef } from "react";
+import FunctionButton, {
+  FunctionButtonVariants,
+} from "@/components/FunctionButton";
 
 /**
  * Properties for the DownloadButton component.
@@ -53,6 +56,7 @@ interface DownloadButtonProps {
   Modal403?: Modals;
   Modal400?: Modals;
   toolTip?: string;
+  variant?: FunctionButtonVariants;
 }
 
 /**
@@ -101,7 +105,6 @@ export const DownloadButton = forwardRef<
       activeText,
       extraParams,
       method = "POST",
-      customStyle,
       setActive,
       onClick,
       showLoading = true,
@@ -111,6 +114,7 @@ export const DownloadButton = forwardRef<
       Modal400,
       Modal403,
       toolTip,
+      variant,
       ...buttonProps
     }: DownloadButtonProps,
     ref,
@@ -125,18 +129,13 @@ export const DownloadButton = forwardRef<
 
     return (
       <Tooltip disabled={!toolTip} label={toolTip}>
-        <Button
+        <FunctionButton
+          $variant={variant}
           ref={ref}
           leftIcon={
             showIcon && inactiveText && <FiDownload aria-label="download" />
           }
           disabled={disabled}
-          className={
-            customStyle ||
-            `text-base-lightest ${
-              disabled ? "bg-base" : "bg-primary hover:bg-primary-darker"
-            } `
-          }
           loading={showLoading && active}
           onClick={() => {
             if (!preventClickEvent && onClick) {
@@ -169,7 +168,7 @@ export const DownloadButton = forwardRef<
           {...buttonProps}
         >
           {text || Icon}
-        </Button>
+        </FunctionButton>
       </Tooltip>
     );
   },

--- a/packages/portal-proto/src/components/DownloadButtons/DownloadFile.tsx
+++ b/packages/portal-proto/src/components/DownloadButtons/DownloadFile.tsx
@@ -9,14 +9,15 @@ import {
 import { DownloadButton } from "./DownloadButton";
 import { useState } from "react";
 import { useDeepCompareCallback } from "use-deep-compare";
+import { FunctionButtonVariants } from "../FunctionButton";
 
 interface DownloadFileProps {
   file: GdcFile;
   activeText?: string;
   inactiveText?: string;
   setfileToDownload?: React.Dispatch<React.SetStateAction<GdcFile>>;
-  customStyle?: string;
   showLoading?: boolean;
+  variant?: FunctionButtonVariants;
 }
 
 export const DownloadFile: React.FC<DownloadFileProps> = ({
@@ -24,19 +25,13 @@ export const DownloadFile: React.FC<DownloadFileProps> = ({
   activeText,
   inactiveText,
   setfileToDownload,
-  customStyle,
   showLoading = true,
+  variant,
 }: DownloadFileProps) => {
   const dispatch = useCoreDispatch();
   const [fetchUserDetails] = useLazyFetchUserDetailsQuery();
 
   const [active, setActive] = useState(false);
-
-  const customStyleFile = inactiveText
-    ? "text-base-lightest bg-primary hover:bg-primary-darker"
-    : `bg-base-max text-primary border border-primary rounded hover:bg-primary hover:text-base-max ${
-        !inactiveText && !activeText ? "w-8 p-0 h-6" : "p-2"
-      }`;
 
   const onClick = useDeepCompareCallback(async () => {
     fetchUserDetails()
@@ -76,21 +71,21 @@ export const DownloadFile: React.FC<DownloadFileProps> = ({
         method="GET"
         setActive={setActive}
         active={active}
-        customStyle={customStyle || customStyleFile}
         showLoading={showLoading}
+        variant={variant}
       />
     );
   }
 
   return (
     <DownloadButton
-      customStyle={customStyle || customStyleFile}
       inactiveText={inactiveText}
       activeText={activeText}
       onClick={onClick}
       setActive={setActive}
       active={active}
       showLoading={showLoading}
+      variant={variant}
     />
   );
 };

--- a/packages/portal-proto/src/components/FunctionButton.tsx
+++ b/packages/portal-proto/src/components/FunctionButton.tsx
@@ -1,29 +1,41 @@
 import tw from "tailwind-styled-components";
 import { Button } from "@mantine/core";
 
+export type FunctionButtonVariants = "filled" | "subtle" | "header" | "icon";
+
 interface FunctionButtonProps {
   disabled: boolean;
+  $variant: FunctionButtonVariants;
 }
 
 /**
  * Function button component
+ * @param variant - display variant
  * @param disabled - whether the button is disabled
  * @category Buttons
  */
 export default tw(Button)<FunctionButtonProps>`
- ${(p) =>
+ ${(p: FunctionButtonProps) =>
    p.disabled
      ? "opacity-60 border-opacity-60 text-opacity-60 aria-disabled"
      : null}
-flex
-flex-row
-items-center
-bg-white
-text-primary
-border
-border-solid
-border-primary
-font-heading
-hover:bg-primary
+${(p: FunctionButtonProps) =>
+  p.$variant !== "icon" ? "flex flex-row items-center" : undefined}
+${(p: FunctionButtonProps) =>
+  p.$variant === "filled" ? "bg-primary text-white" : "bg-white text-primary"}
+${(p: FunctionButtonProps) =>
+  p.$variant === "header" ? "font-medium text-sm" : "font-heading"}
+${(p: FunctionButtonProps) =>
+  p.$variant === "subtle"
+    ? "border-none"
+    : "border border-solid border-primary"}
+${(p: FunctionButtonProps) =>
+  p.$variant === "filled"
+    ? "hover:bg-primary-darker"
+    : p.$variant === "header"
+    ? "hover:bg-primary-darkest"
+    : "hover:bg-primary"}
 hover:text-base-max
+${(p: FunctionButtonProps) =>
+  p.$variant === "icon" ? "w-8 p-0 h-6" : undefined}
 `;

--- a/packages/portal-proto/src/components/Modals/AgreementModal.tsx
+++ b/packages/portal-proto/src/components/Modals/AgreementModal.tsx
@@ -59,6 +59,7 @@ export const AgreementModal = ({
           method="GET"
           setActive={setActive}
           active={active}
+          variant="filled"
         />
       </div>
     </BaseModal>

--- a/packages/portal-proto/src/components/Modals/CartDownloadModal.tsx
+++ b/packages/portal-proto/src/components/Modals/CartDownloadModal.tsx
@@ -102,7 +102,7 @@ const CartDownloadModal = ({
           activeText=""
           disabled={
             numFilesCanAccess === 0 ||
-            (user.username && dbGapList.length > 0 && !checked)
+            (user?.username && dbGapList.length > 0 && !checked)
           }
           endpoint="data"
           extraParams={{
@@ -112,8 +112,9 @@ const CartDownloadModal = ({
           }}
           method="POST"
           setActive={setActive}
+          variant="filled"
         />
-        {!user.username && <LoginButton />}
+        {!user?.username && <LoginButton />}
       </div>
     </BaseModal>
   );

--- a/packages/portal-proto/src/components/TableActionButtons/index.tsx
+++ b/packages/portal-proto/src/components/TableActionButtons/index.tsx
@@ -46,6 +46,7 @@ export const TableActionButtons = ({
         file={downloadFile}
         showLoading={false}
         setfileToDownload={setFileToDownload}
+        variant="icon"
       />
     </div>
   );

--- a/packages/portal-proto/src/features/biospecimen/utils.tsx
+++ b/packages/portal-proto/src/features/biospecimen/utils.tsx
@@ -167,6 +167,7 @@ export const formatEntityInfo = (
             <DownloadFile
               file={mapFileData(selectedSlide)[0]}
               showLoading={false}
+              variant="icon"
             />
           </div>
         </Tooltip>

--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -23,7 +23,7 @@ import { NoAccessToProjectModal } from "@/components/Modals/NoAccessToProjectMod
 import { BAMSlicingButton } from "@/features/files/BAMSlicingButton";
 import { DownloadFile } from "@/components/DownloadButtons";
 import { AgreementModal } from "@/components/Modals/AgreementModal";
-import { fileInCart, focusStyles } from "src/utils";
+import { fileInCart } from "src/utils";
 import { GeneralErrorModal } from "@/components/Modals/GeneraErrorModal";
 import { HeaderTitle } from "@/components/tailwindComponents";
 import { SummaryCard } from "@/components/Summary/SummaryCard";
@@ -64,7 +64,7 @@ const LeftSideElementForHeader: React.FC<LeftSideElementForHeaderProps> = ({
       inactiveText="Download"
       activeText="Processing"
       file={file}
-      customStyle={`text-primary bg-base-max hover:bg-primary-darkest hover:text-base-max font-medium text-sm ${focusStyles}`}
+      variant="header"
       setfileToDownload={setFileToDownload}
     />
   </div>

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -33,7 +33,7 @@ import {
   useClearAllRepositoryFilters,
 } from "@/features/repositoryApp/hooks";
 import { useImageCounts } from "@/features/repositoryApp/slideCountSlice";
-import { Tooltip } from "@mantine/core";
+import { Tooltip, Menu } from "@mantine/core";
 import FilesTables from "../repositoryApp/FilesTable";
 import { persistStore } from "redux-persist";
 import { PersistGate } from "redux-persist/integration/react";
@@ -123,6 +123,10 @@ export const RepositoryApp = (): JSX.Element => {
 
   useClearLocalFilterWhenCohortChanges();
 
+  const [metadataDownloadActive, setMetadataDownloadActive] = useState(false);
+  const [sampleSheetDownloadActive, setSampleSheetDownloadActive] =
+    useState(false);
+
   const viewImageDisabled =
     imagesCount.slidesCount <= 0 && imagesCount.casesWithImagesCount <= 0;
   return (
@@ -138,24 +142,125 @@ export const RepositoryApp = (): JSX.Element => {
           >
             <div className="flex justify-end align-center">
               <div className="flex justify-end gap-2 mt-9 mb-4">
+                <Menu width="target">
+                  <Menu.Target>
+                    <FunctionButton>Download Associated Data</FunctionButton>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Item
+                      component={DownloadButton}
+                      classNames={{ inner: "font-normal" }}
+                      variant="subtle"
+                      activeText="Processing"
+                      inactiveText="Sample Sheet"
+                      setActive={setSampleSheetDownloadActive}
+                      active={sampleSheetDownloadActive}
+                      preventClickEvent
+                      showIcon={true}
+                      endpoint="files"
+                      filename={`gdc_sample_sheet.${new Date()
+                        .toISOString()
+                        .slice(0, 10)}.tsv`}
+                      format="tsv"
+                      method="POST"
+                      fields={[
+                        "file_id",
+                        "file_name",
+                        "data_category",
+                        "data_type",
+                        "cases.project.project_id",
+                        "cases.submitter_id",
+                        "cases.samples.submitter_id",
+                        "cases.samples.sample_type",
+                      ]}
+                      caseFilters={buildCohortGqlOperator(caseFilters)}
+                      filters={buildCohortGqlOperator(localFilters)}
+                      extraParams={{
+                        tsv_format: "sample-sheet",
+                      }}
+                    />
+                    <Menu.Item
+                      component={DownloadButton}
+                      classNames={{ inner: "font-normal" }}
+                      activeText="Processing"
+                      inactiveText="Metadata"
+                      setActive={setMetadataDownloadActive}
+                      active={metadataDownloadActive}
+                      showIcon={true}
+                      variant="subtle"
+                      preventClickEvent
+                      endpoint="files"
+                      filename={`metadata.repository.${new Date()
+                        .toISOString()
+                        .slice(0, 10)}.json`}
+                      method="POST"
+                      caseFilters={buildCohortGqlOperator(caseFilters)}
+                      filters={buildCohortGqlOperator(localFilters)}
+                      fields={[
+                        "state",
+                        "access",
+                        "md5sum",
+                        "data_format",
+                        "data_type",
+                        "data_category",
+                        "file_name",
+                        "file_size",
+                        "file_id",
+                        "platform",
+                        "experimental_strategy",
+                        "center.short_name",
+                        "annotations.annotation_id",
+                        "annotations.entity_id",
+                        "tags",
+                        "submitter_id",
+                        "archive.archive_id",
+                        "archive.submitter_id",
+                        "archive.revision",
+                        "associated_entities.entity_id",
+                        "associated_entities.entity_type",
+                        "associated_entities.case_id",
+                        "analysis.analysis_id",
+                        "analysis.workflow_type",
+                        "analysis.updated_datetime",
+                        "analysis.input_files.file_id",
+                        "analysis.metadata.read_groups.read_group_id",
+                        "analysis.metadata.read_groups.is_paired_end",
+                        "analysis.metadata.read_groups.read_length",
+                        "analysis.metadata.read_groups.library_name",
+                        "analysis.metadata.read_groups.sequencing_center",
+                        "analysis.metadata.read_groups.sequencing_date",
+                        "downstream_analyses.output_files.access",
+                        "downstream_analyses.output_files.file_id",
+                        "downstream_analyses.output_files.file_name",
+                        "downstream_analyses.output_files.data_category",
+                        "downstream_analyses.output_files.data_type",
+                        "downstream_analyses.output_files.data_format",
+                        "downstream_analyses.workflow_type",
+                        "downstream_analyses.output_files.file_size",
+                        "index_files.file_id",
+                      ]}
+                      extraParams={{
+                        expand: [
+                          "metadata_files",
+                          "annotations",
+                          "archive",
+                          "associated_entities",
+                          "center",
+                          "analysis",
+                          "analysis.input_files",
+                          "analysis.metadata",
+                          "analysis.metadata_files",
+                          "analysis.downstream_analyses",
+                          "analysis.downstream_analyses.output_files",
+                          "reference_genome",
+                          "index_file",
+                        ].join(","),
+                      }}
+                    />
+                  </Menu.Dropdown>
+                </Menu>
                 <DownloadButton
                   data-testid="button-manifest-files-table"
-                  customStyle={`
-                  flex
-                  flex-row
-                  items-center
-                  bg-base-lightest
-                  text-base-contrast-max
-                  border
-                  border-solid
-                  border-primary-darker
-                  hover:bg-primary-darker
-                  font-heading
-                  hover:text-primary-contrast-darker
-                  disabled:opacity-60
-                  disabled:border-opacity-60
-                  disabled:text-opacity-60
-                  `}
                   activeText="Processing"
                   inactiveText="Manifest"
                   toolTip="Download a manifest for use with the GDC Data Transfer Tool. The GDC Data Transfer Tool is recommended for transferring large volumes of data."


### PR DESCRIPTION
## Description
\+ Consolidating the download button styles into variants and removing customStyle prop, prompted by the Manifest button having a style not consistent with the rest of the button styles in the GDC.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1421" alt="Screenshot 2024-03-29 at 9 51 37 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/9b731af5-c2e7-4bce-b009-59c8a0d89db8">
<img width="1415" alt="Screenshot 2024-03-29 at 10 25 19 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/a7886904-1755-430c-ac48-e652e53c5b56">
