### PR TITLE
PEAR-1509: resolve core rollup warnings by adding modules to globals/externals in rollup config

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -20,6 +20,9 @@ const globals = {
   immer: "immer",
   "redux-persist/integration/react": "integration",
   "react-cookie": "reactCookie",
+  "js-cookie": "jsCookie",
+  queue: "queue",
+  "blueimp-md5": "blueimp-md5",
 };
 
 const config = [
@@ -57,6 +60,9 @@ const config = [
       "redux",
       "redux-toolkit",
       "react-cookie",
+      "js-cookie",
+      "blueimp-md5",
+      "queue",
     ],
     plugins: [
       peerDepsExternal(),

--- a/packages/core/src/features/genomic/ssmsTableSlice.ts
+++ b/packages/core/src/features/genomic/ssmsTableSlice.ts
@@ -16,7 +16,7 @@ import {
 import { appendFilterToOperation, getSSMTestedCases } from "./utils";
 import { joinFilters } from "../cohort";
 import { Reducer } from "@reduxjs/toolkit";
-import { DataStatus } from "src/dataAccess";
+import { DataStatus } from "../../dataAccess";
 
 const SSMSTableGraphQLQuery = `query SsmsTable(
   $ssmTested: FiltersArgument


### PR DESCRIPTION
Fixes the warnings issued by rollup when @gdc/core is built

## Description

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
