### PR TITLE
PEAR-1864: Case Summary Files Table - Controlled access files won't download + no loading spinners

### DIFF
--- a/packages/portal-proto/src/components/Modals/AgreementModal.tsx
+++ b/packages/portal-proto/src/components/Modals/AgreementModal.tsx
@@ -47,13 +47,13 @@ export const AgreementModal = ({
 
         <DownloadButton
           disabled={!checked}
-          filename={file.file_name}
+          filename={file?.file_name}
           extraParams={{
-            ids: file.file_id,
+            ids: file?.file_id,
             annotations: true,
             related_files: true,
           }}
-          endpoint={`data/${file.file_id}`}
+          endpoint={`data/${file?.file_id}`}
           activeText="Processing"
           inactiveText="Download"
           method="GET"

--- a/packages/portal-proto/src/components/Modals/AgreementModal.tsx
+++ b/packages/portal-proto/src/components/Modals/AgreementModal.tsx
@@ -1,6 +1,6 @@
 import { GdcFile, hideModal, useCoreDispatch } from "@gff/core";
 import { Button, Text } from "@mantine/core";
-import { SetStateAction, useState } from "react";
+import { SetStateAction, useEffect, useState } from "react";
 import { DownloadButton } from "../DownloadButtons";
 import { BaseModal } from "./BaseModal";
 import DownloadAccessAgreement from "./DownloadAccessAgreement";
@@ -20,6 +20,13 @@ export const AgreementModal = ({
 }): JSX.Element => {
   const dispatch = useCoreDispatch();
   const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    if (!openModal) {
+      setChecked(false);
+    }
+  }, [openModal]);
+
   return (
     <BaseModal
       title={
@@ -40,10 +47,7 @@ export const AgreementModal = ({
       </div>
       <div className="flex justify-end mt-2.5 gap-2">
         <Button
-          onClick={() => {
-            setChecked(false);
-            dispatch(hideModal());
-          }}
+          onClick={() => dispatch(hideModal())}
           className="!bg-primary hover:!bg-primary-darker"
         >
           Cancel

--- a/packages/portal-proto/src/components/Modals/AgreementModal.tsx
+++ b/packages/portal-proto/src/components/Modals/AgreementModal.tsx
@@ -28,6 +28,7 @@ export const AgreementModal = ({
         </Text>
       }
       openModal={openModal}
+      onClose={() => setChecked(false)}
       size="xl"
     >
       <div className="border-y border-y-base-darker py-4">
@@ -39,7 +40,10 @@ export const AgreementModal = ({
       </div>
       <div className="flex justify-end mt-2.5 gap-2">
         <Button
-          onClick={() => dispatch(hideModal())}
+          onClick={() => {
+            setChecked(false);
+            dispatch(hideModal());
+          }}
           className="!bg-primary hover:!bg-primary-darker"
         >
           Cancel

--- a/packages/portal-proto/src/components/TableActionButtons/TableActionButton.unit.test.tsx
+++ b/packages/portal-proto/src/components/TableActionButtons/TableActionButton.unit.test.tsx
@@ -20,6 +20,7 @@ describe("<TableActionButtons />", () => {
         isOutputFileInCart={true}
         file={[] as CartFile[]}
         downloadFile={{} as GdcFile}
+        setFileToDownload={jest.fn()}
       />,
     );
 
@@ -36,6 +37,7 @@ describe("<TableActionButtons />", () => {
         isOutputFileInCart={false}
         file={[] as CartFile[]}
         downloadFile={{} as GdcFile}
+        setFileToDownload={jest.fn()}
       />,
     );
 

--- a/packages/portal-proto/src/components/TableActionButtons/index.tsx
+++ b/packages/portal-proto/src/components/TableActionButtons/index.tsx
@@ -19,7 +19,7 @@ export const TableActionButtons = ({
   isOutputFileInCart: boolean;
   file: CartFile[];
   downloadFile: GdcFile;
-  setFileToDownload?: React.Dispatch<React.SetStateAction<GdcFile>>;
+  setFileToDownload: React.Dispatch<React.SetStateAction<GdcFile>>;
 }): JSX.Element => {
   const currentCart = useCoreSelector((state) => selectCart(state));
   const dispatch = useCoreDispatch();

--- a/packages/portal-proto/src/features/cases/FilesTable.tsx
+++ b/packages/portal-proto/src/features/cases/FilesTable.tsx
@@ -11,13 +11,15 @@ import {
 } from "@/utils/index";
 import {
   GdcFile,
+  Modals,
   SortBy,
   selectCart,
+  selectCurrentModal,
   useCoreDispatch,
   useCoreSelector,
   useGetFilesQuery,
 } from "@gff/core";
-import { Tooltip } from "@mantine/core";
+import { Loader, Tooltip } from "@mantine/core";
 import {
   ColumnDef,
   ColumnOrderState,
@@ -33,6 +35,7 @@ import { mapGdcFileToCartFile } from "../files/utils";
 import download from "@/utils/download";
 import { downloadTSV } from "@/components/Table/utils";
 import { convertDateToString } from "@/utils/date";
+import { AgreementModal } from "@/components/Modals/AgreementModal";
 
 interface FilesTableProps {
   caseId: string;
@@ -55,10 +58,14 @@ const caseFilesTableColumnHelper = createColumnHelper<CaseFilesTableDataType>();
 const FilesTable = ({ caseId }: FilesTableProps) => {
   const currentCart = useCoreSelector((state) => selectCart(state));
   const dispatch = useCoreDispatch();
+  const modal = useCoreSelector((state) => selectCurrentModal(state));
   const [tableData, setTableData] = useState<CaseFilesTableDataType[]>([]);
   const [sortBy, setSortBy] = useState<SortBy[]>([
     { field: "experimental_strategy", direction: "asc" },
   ]);
+  const [fileToDownload, setFileToDownload] = useState(null);
+  const [downloadJSONActive, setDownloadJSONActive] = useState(false);
+  const [downloadTSVActive, setDownloadTSVActive] = useState(false);
   const [pageSize, setPageSize] = useState(10);
   const [activePage, setActivePage] = useState(1);
   const [searchTerm, setSearchTerm] = useState("");
@@ -230,6 +237,7 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
               isOutputFileInCart={isOutputFileInCart}
               file={mapGdcFileToCartFile([row.original.file])}
               downloadFile={row.original.file}
+              setFileToDownload={setFileToDownload}
             />
           );
         },
@@ -270,6 +278,7 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
   };
 
   const handleDownloadJSON = async () => {
+    setDownloadJSONActive(true);
     await download({
       endpoint: "files",
       method: "POST",
@@ -300,11 +309,13 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
           "file_size",
         ].join(","),
       },
+      done: () => setDownloadJSONActive(false),
       dispatch,
     });
   };
 
   const handleDownloadTSV = () => {
+    setDownloadTSVActive(true);
     downloadTSV({
       tableData,
       columnOrder,
@@ -319,7 +330,14 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
           },
         },
       },
-    });
+    })
+      .then(() => {
+        setDownloadTSVActive(false);
+      })
+      .catch((error) => {
+        console.error("Error during download:", error);
+        setDownloadTSVActive(false);
+      });
   };
 
   return (
@@ -336,7 +354,7 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
                 onClick={handleDownloadJSON}
                 aria-label="Download JSON"
               >
-                JSON
+                {downloadJSONActive ? <Loader size="sm" /> : "JSON"}
               </FunctionButton>
             </Tooltip>
             <Tooltip label="Download TSV">
@@ -344,7 +362,7 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
                 onClick={handleDownloadTSV}
                 aria-label="Download TSV"
               >
-                TSV
+                {downloadTSVActive ? <Loader size="sm" /> : "TSV"}
               </FunctionButton>
             </Tooltip>
           </div>
@@ -365,6 +383,12 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
         sorting={sorting}
         setSorting={setSorting}
         setColumnOrder={setColumnOrder}
+      />
+
+      <AgreementModal
+        openModal={modal === Modals.AgreementModal && fileToDownload !== null}
+        file={fileToDownload}
+        dbGapList={fileToDownload?.acl}
       />
     </>
   );


### PR DESCRIPTION
## Description

This PR introduces the ability to download controlled access files from the files table in case summary page. A loader will be displayed while the JSON and TSV are being prepared for download.

Please note the following caveats:
1. For JSON downloads, the loader behavior may not be visible during local development due to reason mentioned in this [JIRA](https://gdc-ctds.atlassian.net/browse/PEAR-624). However, it has been implemented consistently with other loaders and will function as expected in the deployed environment.

2. For TSV downloads, the loader may not be visible due to the typically fast download speed. I tested it locally using `setTimeout` to verify the loader is briefly displayed before the download completes.


## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
