### PR TITLE
PEAR-1863 - Spinner fix

### DIFF
--- a/packages/portal-proto/src/components/DownloadButtons/DownloadButton.tsx
+++ b/packages/portal-proto/src/components/DownloadButtons/DownloadButton.tsx
@@ -56,7 +56,7 @@ interface DownloadButtonProps {
   Modal403?: Modals;
   Modal400?: Modals;
   toolTip?: string;
-  variant?: FunctionButtonVariants;
+  displayVariant?: FunctionButtonVariants;
 }
 
 /**
@@ -114,7 +114,7 @@ export const DownloadButton = forwardRef<
       Modal400,
       Modal403,
       toolTip,
-      variant,
+      displayVariant,
       ...buttonProps
     }: DownloadButtonProps,
     ref,
@@ -130,13 +130,14 @@ export const DownloadButton = forwardRef<
     return (
       <Tooltip disabled={!toolTip} label={toolTip}>
         <FunctionButton
-          $variant={variant}
+          $variant={displayVariant}
           ref={ref}
           leftIcon={
             showIcon && inactiveText && <FiDownload aria-label="download" />
           }
           disabled={disabled}
           loading={showLoading && active}
+          variant="outline"
           onClick={() => {
             if (!preventClickEvent && onClick) {
               onClick();

--- a/packages/portal-proto/src/components/DownloadButtons/DownloadFile.tsx
+++ b/packages/portal-proto/src/components/DownloadButtons/DownloadFile.tsx
@@ -17,7 +17,7 @@ interface DownloadFileProps {
   inactiveText?: string;
   setfileToDownload?: React.Dispatch<React.SetStateAction<GdcFile>>;
   showLoading?: boolean;
-  variant?: FunctionButtonVariants;
+  displayVariant?: FunctionButtonVariants;
 }
 
 export const DownloadFile: React.FC<DownloadFileProps> = ({
@@ -26,7 +26,7 @@ export const DownloadFile: React.FC<DownloadFileProps> = ({
   inactiveText,
   setfileToDownload,
   showLoading = true,
-  variant,
+  displayVariant,
 }: DownloadFileProps) => {
   const dispatch = useCoreDispatch();
   const [fetchUserDetails] = useLazyFetchUserDetailsQuery();
@@ -72,7 +72,7 @@ export const DownloadFile: React.FC<DownloadFileProps> = ({
         setActive={setActive}
         active={active}
         showLoading={showLoading}
-        variant={variant}
+        displayVariant={displayVariant}
       />
     );
   }
@@ -85,7 +85,7 @@ export const DownloadFile: React.FC<DownloadFileProps> = ({
       setActive={setActive}
       active={active}
       showLoading={showLoading}
-      variant={variant}
+      displayVariant={displayVariant}
     />
   );
 };

--- a/packages/portal-proto/src/components/Modals/AgreementModal.tsx
+++ b/packages/portal-proto/src/components/Modals/AgreementModal.tsx
@@ -59,7 +59,7 @@ export const AgreementModal = ({
           method="GET"
           setActive={setActive}
           active={active}
-          variant="filled"
+          displayVariant="filled"
         />
       </div>
     </BaseModal>

--- a/packages/portal-proto/src/components/Modals/CartDownloadModal.tsx
+++ b/packages/portal-proto/src/components/Modals/CartDownloadModal.tsx
@@ -112,7 +112,7 @@ const CartDownloadModal = ({
           }}
           method="POST"
           setActive={setActive}
-          variant="filled"
+          displayVariant="filled"
         />
         {!user?.username && <LoginButton />}
       </div>

--- a/packages/portal-proto/src/components/TableActionButtons/index.tsx
+++ b/packages/portal-proto/src/components/TableActionButtons/index.tsx
@@ -46,7 +46,7 @@ export const TableActionButtons = ({
         file={downloadFile}
         showLoading={false}
         setfileToDownload={setFileToDownload}
-        variant="icon"
+        displayVariant="icon"
       />
     </div>
   );

--- a/packages/portal-proto/src/features/biospecimen/utils.tsx
+++ b/packages/portal-proto/src/features/biospecimen/utils.tsx
@@ -167,7 +167,7 @@ export const formatEntityInfo = (
             <DownloadFile
               file={mapFileData(selectedSlide)[0]}
               showLoading={false}
-              variant="icon"
+              displayVariant="icon"
             />
           </div>
         </Tooltip>

--- a/packages/portal-proto/src/features/cart/CartHeader.tsx
+++ b/packages/portal-proto/src/features/cart/CartHeader.tsx
@@ -195,7 +195,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
             <Menu.Item
               component={DownloadButton}
               classNames={{ inner: "font-normal" }}
-              variant="subtle"
+              displayVariant="subtle"
               activeText="Processing"
               inactiveText="Clinical: TSV"
               preventClickEvent
@@ -226,7 +226,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
             <Menu.Item
               component={DownloadButton}
               classNames={{ inner: "font-normal" }}
-              variant="subtle"
+              displayVariant="subtle"
               activeText="Processing"
               inactiveText="Clinical: JSON"
               preventClickEvent
@@ -257,7 +257,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
             <Menu.Item
               component={DownloadButton}
               classNames={{ inner: "font-normal" }}
-              variant="subtle"
+              displayVariant="subtle"
               activeText="Processing"
               inactiveText="Biospecimen: TSV"
               preventClickEvent
@@ -287,7 +287,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
             <Menu.Item
               component={DownloadButton}
               classNames={{ inner: "font-normal" }}
-              variant="subtle"
+              displayVariant="subtle"
               activeText="Processing"
               inactiveText="Biospecimen: JSON"
               preventClickEvent
@@ -317,7 +317,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
             <Menu.Item
               component={DownloadButton}
               classNames={{ inner: "font-normal" }}
-              variant="subtle"
+              displayVariant="subtle"
               activeText="Processing"
               inactiveText="Sample Sheet"
               preventClickEvent
@@ -362,7 +362,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
               activeText="Processing"
               inactiveText="Metadata"
               showIcon={true}
-              variant="subtle"
+              displayVariant="subtle"
               preventClickEvent
               endpoint="files"
               setActive={setMetadataDownloadActive}

--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -64,7 +64,7 @@ const LeftSideElementForHeader: React.FC<LeftSideElementForHeaderProps> = ({
       inactiveText="Download"
       activeText="Processing"
       file={file}
-      variant="header"
+      displayVariant="header"
       setfileToDownload={setFileToDownload}
     />
   </div>

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -150,7 +150,7 @@ export const RepositoryApp = (): JSX.Element => {
                     <Menu.Item
                       component={DownloadButton}
                       classNames={{ inner: "font-normal" }}
-                      variant="subtle"
+                      displayVariant="subtle"
                       activeText="Processing"
                       inactiveText="Sample Sheet"
                       setActive={setSampleSheetDownloadActive}
@@ -187,7 +187,7 @@ export const RepositoryApp = (): JSX.Element => {
                       setActive={setMetadataDownloadActive}
                       active={metadataDownloadActive}
                       showIcon={true}
-                      variant="subtle"
+                      displayVariant="subtle"
                       preventClickEvent
                       endpoint="files"
                       filename={`metadata.repository.${new Date()


### PR DESCRIPTION
## Description
This is an addendum to this [PR](https://github.com/NCI-GDC/gdc-frontend-framework/pull/1044), fixes the spinner not appearing issue that Wendy noted. The spinner still will not disappear after the download is complete, that's a general issue with downloads on local development. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1416" alt="Screenshot 2024-04-01 at 4 03 55 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/5d03357d-f98b-4ef1-a2cd-a4054b256770">

