### PR TITLE
PEAR-1804 - fix using incorrect file UUID in the link on Quick Search

### DIFF
--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -49,10 +49,13 @@ export const QuickSearch = (): JSX.Element => {
       setMatchedSearchList([]);
     } else if (query === debounced) {
       if (fileHistory !== undefined) {
+        const latestVersion = fileHistory.find(
+          (f) => f.file_change === "released",
+        )?.uuid;
         setMatchedSearchList([
           {
-            value: fileHistory[0].uuid,
-            label: fileHistory[0].uuid,
+            value: latestVersion,
+            label: latestVersion,
             obj: fileHistory,
             superseded: true,
             entity: "File",


### PR DESCRIPTION
## Description
Fixes the issue noted in this comment: https://gdc-ctds.atlassian.net/browse/PEAR-1804?focusedCommentId=61891

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
