### PR TITLE
update the proteinpaint-client version to 2.50.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.49.0.tgz",
-      "integrity": "sha512-9xw/4+pBaTU926ZkH4wZEZbnytm1FgzPYZgB1vNVdN/CLLFf0Y2HsLOoQMPmT8b/zFAPh5YMLkhA7p6FFhwftg=="
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.50.0.tgz",
+      "integrity": "sha512-g+jm/WqbS0AEfumzy3BI8vNx+3wPFkZkp674UBGLgjhnTnqVDoUOweBZny+ORQrtfZbgCW5+Q/1Arsu5Fpy5UA=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27192,7 +27192,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.49.0",
+        "@sjcrh/proteinpaint-client": "^2.50.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32411,9 +32411,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.49.0.tgz",
-      "integrity": "sha512-9xw/4+pBaTU926ZkH4wZEZbnytm1FgzPYZgB1vNVdN/CLLFf0Y2HsLOoQMPmT8b/zFAPh5YMLkhA7p6FFhwftg=="
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.50.0.tgz",
+      "integrity": "sha512-g+jm/WqbS0AEfumzy3BI8vNx+3wPFkZkp674UBGLgjhnTnqVDoUOweBZny+ORQrtfZbgCW5+Q/1Arsu5Fpy5UA=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -42265,7 +42265,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.49.0",
+        "@sjcrh/proteinpaint-client": "^2.50.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.49.0",
+    "@sjcrh/proteinpaint-client": "^2.50.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/CohortLevelMafWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CohortLevelMafWrapper.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, FC } from "react";
+import { useRef, FC } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import { runproteinpaint } from "@sjcrh/proteinpaint-client";
 import {
   useCoreSelector,
@@ -23,7 +24,7 @@ export const CohortLevelMafWrapper: FC<PpProps> = (props: PpProps) => {
   const filter0 = buildCohortGqlOperator(currentCohort);
   const userDetails = useFetchUserDetailsQuery();
 
-  useEffect(
+  useDeepCompareEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
       const data = getMafUi(props, filter0);

--- a/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/GeneExpressionWrapper.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useCallback, useState, FC } from "react";
+import { useRef, useCallback, useState, FC } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import { runproteinpaint } from "@sjcrh/proteinpaint-client";
 import { useIsDemoApp } from "@/hooks/useIsDemoApp";
 import {
@@ -75,7 +76,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
   );
 
   // a set for the new cohort is created, now show the save cohort modal
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (response.isSuccess) {
       const filters: FilterSet = {
         mode: "and",
@@ -108,7 +109,7 @@ export const GeneExpressionWrapper: FC<PpProps> = (props: PpProps) => {
     "postRender.gdcPlotApp": hideLoadingOverlay,
   };
 
-  useEffect(
+  useDeepCompareEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
       // debounce until one of these is true

--- a/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/OncoMatrixWrapper.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useCallback, useState, FC } from "react";
+import { useRef, useCallback, useState, FC } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import { runproteinpaint } from "@sjcrh/proteinpaint-client";
 import { useIsDemoApp } from "@/hooks/useIsDemoApp";
 import {
@@ -76,7 +77,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
   );
 
   // a set for the new cohort is created, now show the save cohort modal
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (response.isSuccess) {
       const filters: FilterSet = {
         mode: "and",
@@ -105,7 +106,7 @@ export const OncoMatrixWrapper: FC<PpProps> = (props: PpProps) => {
     "postRender.gdcPlotApp": hideLoadingOverlay,
   };
 
-  useEffect(
+  useDeepCompareEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
       // debounce until one of these is true

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useCallback, useState, FC } from "react";
+import { useRef, useCallback, useState, FC } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import { runproteinpaint } from "@sjcrh/proteinpaint-client";
 import { useIsDemoApp } from "@/hooks/useIsDemoApp";
 import {
@@ -69,7 +70,7 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
   );
 
   // a set for the new cohort is created, now show the save cohort modal
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (response.isSuccess) {
       const filters: FilterSet = {
         mode: "and",
@@ -86,7 +87,7 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
     }
   }, [response.isSuccess, coreDispatch, response.data]);
 
-  useEffect(
+  useDeepCompareEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
       const data = getLollipopTrack(props, filter0, callback);

--- a/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, FC } from "react";
+import { useRef, useState, FC } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import { runproteinpaint } from "@sjcrh/proteinpaint-client";
 import {
   useCoreSelector,
@@ -31,7 +32,7 @@ export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
   const ppRef = useRef<PpApi>();
   const prevArg = useRef<any>();
 
-  useEffect(
+  useDeepCompareEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
       const isAuthorized = userDetails?.data?.username && true;

--- a/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
@@ -34,7 +34,7 @@ export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
   useEffect(
     () => {
       const rootElem = divRef.current as HTMLElement;
-      const isAuthorized = userDetails?.data.username && true;
+      const isAuthorized = userDetails?.data?.username && true;
       setAlertDisplay(isAuthorized ? "none" : "block");
       setRootDisplay(isAuthorized ? "block" : "none");
       if (!isAuthorized) return;


### PR DESCRIPTION
## Description

Also,  handle empty userDetails.data in sequence read app

Features:
- include auth test status in server healthcheck
- Hide synonymous mutations by default for GDC oncoMatrix
- Improve the matrix sorting options to easily toggle sorting by cnv and/or consequence

Fixes:
- fix the error from genomic alterations rendering when there are no mutations or CNV data
- In GDC query, do not supply empty "case_filters{content[]}" that will slow down API. lollipop and oncomatrix are now faster when there's no cohort
- at GDC bam slicing UI, the table listing available cases and bam files can be filtered by assay types
- Add to GDC oncoMatrix mutation/cnv buttons all available mutation/cnv classes in GDC instead of all available mutation/cnv classes in the current matrix

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
