### PR TITLE
PEAR-1869 - Keyboard focus not returning to previous element after selecting  "save filtered cohort" button

### DIFF
--- a/packages/portal-proto/src/components/CohortCreationButton.tsx
+++ b/packages/portal-proto/src/components/CohortCreationButton.tsx
@@ -101,6 +101,10 @@ const CohortCreationButton: React.FC<CohortCreationButtonProps> = ({
         <CohortCreationStyledButton
           data-testid="button-save-filtered-cohort"
           onClick={async () => {
+            if (loading) {
+              return;
+            }
+
             if (filtersCallback) {
               setLoading(true);
               const createdFilters = await filtersCallback();
@@ -109,7 +113,7 @@ const CohortCreationButton: React.FC<CohortCreationButtonProps> = ({
             }
             setShowSaveCohort(true);
           }}
-          disabled={disabled || loading}
+          disabled={disabled}
           $fullWidth={React.isValidElement(label)} // if label is JSX.Element take the full width
           aria-label={tooltipText}
         >


### PR DESCRIPTION
\+ PEAR-1871 - Keyboard focus - After clicking on a "save filtered cohort" button, the tooltip persists 

## Description
Ignore click while loading instead of disabling, disabling strands the tooltip and removes the focus

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
https://github.com/NCI-GDC/gdc-frontend-framework/assets/4624053/35d72d81-d6a5-4cd0-98db-b4dd58fd10dd