### PR TITLE
(PEAR-1810): disable buttons while loading for Analysis cards and Cases View

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -291,6 +291,7 @@ const ContextBar = ({
                 <CohortCountButton countName="fileCount" label="Files" />
               }
               LeftIcon={<DownloadIcon size="1rem" aria-hidden="true" />}
+              targetButtonDisabled={cohortCounts.status !== "fulfilled"}
             />
 
             <DropdownWithIcon
@@ -321,6 +322,7 @@ const ContextBar = ({
               LeftIcon={<CohortFilterIcon size="1rem" aria-hidden="true" />}
               menuLabelText="Filter your cohort by:"
               menuLabelCustomClass="font-bold text-primary"
+              targetButtonDisabled={cohortCounts.status !== "fulfilled"}
             />
 
             {activeTab === "summary" && (
@@ -348,6 +350,7 @@ const ContextBar = ({
                       <DownloadIcon size="1rem" aria-hidden="true" />
                     )
                   }
+                  targetButtonDisabled={cohortCounts.status !== "fulfilled"}
                 />
 
                 <DropdownWithIcon
@@ -373,6 +376,7 @@ const ContextBar = ({
                       <DownloadIcon size="1rem" aria-hidden="true" />
                     )
                   }
+                  targetButtonDisabled={cohortCounts.status !== "fulfilled"}
                 />
               </>
             )}


### PR DESCRIPTION
## Description
- disable Files, Custom Filters, Biospecimen, and Clinical buttons when data is loading

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
