### PR TITLE
PEAR-1877 updates Mutation Frequency's no data available tooltip

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -72,7 +72,7 @@ export const REGISTERED_APPS = [
     description:
       "Visualize most frequently mutated genes and somatic mutations.",
     noDataTooltip:
-      "Current cohort does not have SSM data available for visualization.",
+      "Current cohort does not have SSM or CNV data available for visualization.",
     optimizeRules: ["something == something"],
   },
   {


### PR DESCRIPTION
## Description
Updates tooltip for Mutation Frequency when zero cases can be used with it.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="360" alt="Screenshot 2024-04-04 at 5 12 49 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/b21af01a-25c5-4642-90f5-6b94b275fa35">
