### PR TITLE
update the proteinpaint-client version to 2.52.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.50.0.tgz",
-      "integrity": "sha512-g+jm/WqbS0AEfumzy3BI8vNx+3wPFkZkp674UBGLgjhnTnqVDoUOweBZny+ORQrtfZbgCW5+Q/1Arsu5Fpy5UA=="
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.52.0.tgz",
+      "integrity": "sha512-Pl5tdDTl19kZtweRn2N49FAtyxLRZEzJ8OaaJGAUSilHjSj3Lg3I6dtUlDIzW4NsCiCuw+j8UMuilE38ZiiGWQ=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27192,7 +27192,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.50.0",
+        "@sjcrh/proteinpaint-client": "^2.52.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32411,9 +32411,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.50.0.tgz",
-      "integrity": "sha512-g+jm/WqbS0AEfumzy3BI8vNx+3wPFkZkp674UBGLgjhnTnqVDoUOweBZny+ORQrtfZbgCW5+Q/1Arsu5Fpy5UA=="
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.52.0.tgz",
+      "integrity": "sha512-Pl5tdDTl19kZtweRn2N49FAtyxLRZEzJ8OaaJGAUSilHjSj3Lg3I6dtUlDIzW4NsCiCuw+j8UMuilE38ZiiGWQ=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -42265,7 +42265,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.50.0",
+        "@sjcrh/proteinpaint-client": "^2.52.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.50.0",
+    "@sjcrh/proteinpaint-client": "^2.52.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Features:
- Enable downloading data for oncoMatrix

Fixes:
- Fix position errors after oncoMatrix/hierCluster zooming in/out caused by outdated imgBox
- Oncomatrix do not allow to hide all the alteration groups

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
