### PR TITLE
PEAR-1578: Fix for Query Expressions, scrolling, vertical collapse default, and vertical expand button not working

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
@@ -28,7 +28,7 @@ const QueryExpressionContainer = tw.div`
   mx-3
 `;
 
-// const MAX_COLLAPSED_ROWS = 3;
+const MAX_HEIGHT_QE_SECTION = 120;
 
 interface CollapsedStateReducerAction {
   type: "expand" | "collapse" | "clear" | "init" | "expandAll" | "collapseAll";
@@ -102,14 +102,15 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
   const [expandedState, setExpandedState] = useReducer(reducer, {});
   const [filtersSectionCollapsed, setFiltersSectionCollapsed] = useState(true);
   const filtersRef = useRef<HTMLDivElement>(null);
-  const [maxHeight, setMaxHeight] = useState(0);
+  const [QESectionHeight, setQESectionHeight] = useState(0);
   const dispatch = useCoreDispatch();
 
   useDeepCompareEffect(() => {
     if (filtersRef.current) {
       const height = filtersRef.current.scrollHeight;
-      console.log({ height });
-      setMaxHeight(height > 100 ? 100 : height);
+      setQESectionHeight(
+        height > MAX_HEIGHT_QE_SECTION ? MAX_HEIGHT_QE_SECTION : height,
+      );
     }
   }, [expandedState, filters, filtersRef]);
 
@@ -205,14 +206,11 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
 
                 <Tooltip
                   label={
-                    // filtersSectionCollapsed
-                    //   ? numOfRows <= MAX_COLLAPSED_ROWS
-                    //     ? "All rows are already displayed"
-                    //     : "Display all rows"
-                    //   : numOfRows <= MAX_COLLAPSED_ROWS
-                    //   ? `A maximum of ${MAX_COLLAPSED_ROWS} rows is already displayed`
-                    //   : `Display a maximum of ${MAX_COLLAPSED_ROWS} rows`
-                    ""
+                    noFilters
+                      ? "No filters to show/hide"
+                      : filtersSectionCollapsed
+                      ? "Show all filters"
+                      : "Hide some filters"
                   }
                 >
                   <button
@@ -223,7 +221,7 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
                     }
                     aria-label="Expand/collapse filters section"
                     aria-expanded={!filtersSectionCollapsed}
-                    disabled={noFilters || maxHeight < 100}
+                    disabled={noFilters || QESectionHeight < 100}
                     className={getCombinedClassesForRowCollapse(
                       filtersSectionCollapsed,
                     )}
@@ -249,7 +247,7 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
             }`}
             style={
               filtersSectionCollapsed
-                ? { maxHeight: `${maxHeight}px`, overflowY: "auto" }
+                ? { maxHeight: `${QESectionHeight}px`, overflowY: "auto" }
                 : undefined
             }
             ref={filtersRef}

--- a/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
@@ -242,12 +242,10 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
           </div>
           <div
             data-testid="text-cohort-filters"
-            className={`flex flex-wrap bg-base-max w-full p-2 overflow-x-hidden ${
-              filtersSectionCollapsed ? "overflow-y-auto" : "h-full"
-            }`}
+            className="flex flex-wrap bg-base-max w-full p-2 overflow-x-hidden"
             style={
               filtersSectionCollapsed
-                ? { maxHeight: `${QESectionHeight}px`, overflowY: "auto" }
+                ? { maxHeight: `${QESectionHeight}px`, overflowY: "scroll" }
                 : undefined
             }
             ref={filtersRef}

--- a/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
@@ -206,11 +206,12 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
 
                 <Tooltip
                   label={
-                    noFilters
-                      ? "No filters to show/hide"
+                    noFilters ||
+                    filtersRef?.current?.scrollHeight <= MAX_HEIGHT_QE_SECTION
+                      ? "All rows are already displayed"
                       : filtersSectionCollapsed
-                      ? "Show all filters"
-                      : "Hide some filters"
+                      ? "Display all rows"
+                      : "Display fewer rows"
                   }
                 >
                   <button
@@ -222,7 +223,8 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
                     aria-label="Expand/collapse filters section"
                     aria-expanded={!filtersSectionCollapsed}
                     disabled={
-                      noFilters || QESectionHeight <= MAX_HEIGHT_QE_SECTION
+                      noFilters ||
+                      filtersRef?.current?.scrollHeight <= MAX_HEIGHT_QE_SECTION
                     }
                     className={getCombinedClassesForRowCollapse(
                       filtersSectionCollapsed,

--- a/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
@@ -221,7 +221,9 @@ const QueryExpressionSection: React.FC<QueryExpressionSectionProps> = ({
                     }
                     aria-label="Expand/collapse filters section"
                     aria-expanded={!filtersSectionCollapsed}
-                    disabled={noFilters || QESectionHeight < 100}
+                    disabled={
+                      noFilters || QESectionHeight <= MAX_HEIGHT_QE_SECTION
+                    }
                     className={getCombinedClassesForRowCollapse(
                       filtersSectionCollapsed,
                     )}


### PR DESCRIPTION
## Description

Capping the max height of the QE section at 120 px.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/c0efea47-75dc-43d0-bc06-618d76c9632d

