### PR TITLE
PEAR-1894: Fix for TSV button width in QQ plot.

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/BoxQQSection.tsx
@@ -308,7 +308,7 @@ const BoxQQSection: React.FC<BoxQQPlotProps> = ({
       </div>
       <Button
         data-testid="button-stats-tsv-cdave-card"
-        className="bg-base-max text-primary border-primary mb-2"
+        className="bg-base-max text-primary border-primary mb-2 w-fit"
         onClick={downloadTableTSVFile}
       >
         TSV


### PR DESCRIPTION
## Description
Added a width class to the button.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Screenshot 2024-04-16 at 11 12 41 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/e0dac4e9-f9e8-4f88-905b-c635736cc1b4)
