### PR TITLE
Sjpp client 2.55.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.52.0.tgz",
-      "integrity": "sha512-Pl5tdDTl19kZtweRn2N49FAtyxLRZEzJ8OaaJGAUSilHjSj3Lg3I6dtUlDIzW4NsCiCuw+j8UMuilE38ZiiGWQ=="
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.55.0.tgz",
+      "integrity": "sha512-0o3uYtiKzeZZm6SNtx1Q1TEf9/Rn+kbm2CVwonGN2Jd931okDVGlNTymWBoeQ8LFSe3wXh7HG1S6C6JPatl2sQ=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27183,7 +27183,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.12.0",
+        "@gff/core": "^2.13.0",
         "@mantine/core": "^6.0.21",
         "@mantine/dates": "^6.0.21",
         "@mantine/form": "^6.0.21",
@@ -27192,7 +27192,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.52.0",
+        "@sjcrh/proteinpaint-client": "^2.55.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -32411,9 +32411,9 @@
       }
     },
     "@sjcrh/proteinpaint-client": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.52.0.tgz",
-      "integrity": "sha512-Pl5tdDTl19kZtweRn2N49FAtyxLRZEzJ8OaaJGAUSilHjSj3Lg3I6dtUlDIzW4NsCiCuw+j8UMuilE38ZiiGWQ=="
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.55.0.tgz",
+      "integrity": "sha512-0o3uYtiKzeZZm6SNtx1Q1TEf9/Rn+kbm2CVwonGN2Jd931okDVGlNTymWBoeQ8LFSe3wXh7HG1S6C6JPatl2sQ=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -42253,7 +42253,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.12.0",
+        "@gff/core": "^2.13.0",
         "@iconify/icons-mdi": "^1.1.42",
         "@iconify/react": "^3.1.2",
         "@mantine/core": "^6.0.21",
@@ -42265,7 +42265,7 @@
         "@oncojs/survivalplot": "^0.8.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.52.0",
+        "@sjcrh/proteinpaint-client": "^2.55.0",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.3.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.52.0",
+    "@sjcrh/proteinpaint-client": "^2.55.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Features:
- OncoMatrix: after hiding a category from divideBy term, add an option to divideBy button to bring it back
- Click on protein domain legend to show menu options to toggle visibility and change color.

Fixes:
- numeric setdefaultq() will default to term's own default bin type rather than always hardcoding to regular-bin
- improve GDC cohortMAF ui to add case link and make scrollbar more apparent
- address mds3 mclass legend error by not setting uninitiated flag to true
- fix the token vs sessionid error in gdc portal [SV-2447](https://gdc-ctds.atlassian.net/browse/SV-2447)


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
