### PR TITLE
PEAR-1923 fix case link in annotations table

### DIFF
--- a/packages/portal-proto/src/features/projects/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/projects/AnnotationsTable.tsx
@@ -189,7 +189,7 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
         cell: ({ getValue, row }) =>
           getValue() ? (
             <Link
-              href={`cases/${row.original.case_id}`}
+              href={`/cases/${row.original.case_id}`}
               className="text-utility-link underline font-content"
             >
               {getValue()}


### PR DESCRIPTION
## Description
Fixes the Case ID link in the annotations table of the project summary page.

## Checklist

- [N/A ] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
