### PR TITLE
Updated test automation for 2.14.0 round 1 QA-2122

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/header/quick_search.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/quick_search.spec
@@ -10,28 +10,28 @@ tags: gdc-data-portal-v2, regression, search-bar, smoke-test
 ## Search - File
 * On GDC Data Portal V2 app
 * Quick search for "63690169-ccdd-47dd-a298-696187c79c4c"
-* Validate the quick search bar result in position "1" of the result list has the abbreviation "FL"
+* Validate the quick search bar result in position "1" of the result list has the category "File"
 * Select the quick search bar result in position "1"
 * Is text "File Properties" present on the page
 * Is text "63690169-ccdd-47dd-a298-696187c79c4c" present on the page
 
 ## Search - Case
 * Quick search for "HCM-BROD-0254-C49"
-* Validate the quick search bar result in position "1" of the result list has the abbreviation "CA"
+* Validate the quick search bar result in position "1" of the result list has the category "Case"
 * Select the quick search bar result in position "1"
 * Is text "Case UUID" present on the page
 * Is text "300223b2-7479-4849-8de5-14b30c586c3a" present on the page
 
 ## Search - Project
 * Quick search for "BEATAML1.0-COHORT"
-* Validate the quick search bar result in position "1" of the result list has the abbreviation "PR"
+* Validate the quick search bar result in position "1" of the result list has the category "Project"
 * Select the quick search bar result in position "1"
 * Is text "Functional Genomic Landscape of Acute Myeloid Leukemia" present on the page
 * Is text "phs001657" present on the page
 
 ## Search - Gene
 * Quick search for "ENSG00000168702"
-* Validate the quick search bar result in position "1" of the result list has the abbreviation "GN"
+* Validate the quick search bar result in position "1" of the result list has the category "Gene"
 * Select the quick search bar result in position "1"
 * Is text "LRP1B" present on the page
 * Is text "LDL receptor related protein 1B" present on the page
@@ -39,13 +39,21 @@ tags: gdc-data-portal-v2, regression, search-bar, smoke-test
 
 ## Search - Mutation
 * Quick search for "chr2:g.208248388C>T"
-* Validate the quick search bar result in position "1" of the result list has the abbreviation "MU"
+* Validate the quick search bar result in position "1" of the result list has the category "Mutation"
 * Select the quick search bar result in position "1"
 * Is text "fa9713e8-ce92-5413-aacc-ed3d95ab7906" present on the page
 * Is text "Single base substitution" present on the page
 
+## Search - Annotation
+* Quick search for "b6a6a805-b621-4337-9692-bc738ba1b313"
+* Validate the quick search bar result in position "1" of the result list has the category "Annotation"
+* Select the quick search bar result in position "1"
+* Is text "eaaf2dd8-9fdf-4004-bb41-82a7e44e7d21" present on the page
+* Is text "annotated_somatic_mutation" present on the page
+* Is text "Real somatic mutations were mistakenly labeled as LOH (Loss of Heterozygosity) in certain SomaticSniper VCF files." present on the page
+
 ## Search - Last Result
 * Quick search for "321"
-* Validate the quick search bar result in position "5" of the result list has the abbreviation "GN"
+* Validate the quick search bar result in position "5" of the result list has the category "Gene"
 * Select the quick search bar result in position "5"
 * Is text "Cancer Distribution" present on the page

--- a/holmes-py/specs/gdc_data_portal_v2/repository/add_all_remove_all_files.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/add_all_remove_all_files.spec
@@ -15,11 +15,11 @@ tags: gdc-data-portal-v2, repository, regression
 * Select "Add All" on the Repository page
 * Is modal with text "The cart is limited to 10,000" present on the page and "Remove Modal"
 * The cart should have "0" files
-* Expand or contract a filter
+* Expand or contract a filter on the Repository page
   |facet_name       |label                |
   |-----------------|---------------------|
   |Data Type        |plus-icon            |
-* Make the following selections on a filter card
+* Make the following selections on a filter card on the Repository page
   |facet_name       |selection                            |
   |-----------------|-------------------------------------|
   |Data Type        |Allele-specific Copy Number Segment  |
@@ -30,15 +30,15 @@ tags: gdc-data-portal-v2, repository, regression
 * Is modal with text "Removed 0 files from the cart." present on the page and "Remove Modal"
 
 ## Add All Files and Remove All Files buttons
-* Perform the following actions on a filter card
+* Perform the following actions on a filter card on the Repository page
   |filter_name      |action               |
   |-----------------|---------------------|
   |Data Type        |clear selection      |
-* Expand or contract a filter
+* Expand or contract a filter on the Repository page
   |facet_name             |label                |
   |-----------------------|---------------------|
   |Workflow Type          |plus-icon            |
-* Make the following selections on a filter card
+* Make the following selections on a filter card on the Repository page
   |facet_name             |label                |
   |-----------------------|---------------------|
   |Workflow Type          |VCF LiftOver         |
@@ -51,14 +51,14 @@ tags: gdc-data-portal-v2, repository, regression
 * The cart should have "0" files
 * Select "Remove All" on the Repository page
 * Is modal with text "Removed 0 files from the cart." present on the page and "Remove Modal"
-* Make the following selections on a filter card
+* Make the following selections on a filter card on the Repository page
   |facet_name             |label                |
   |-----------------------|---------------------|
   |Workflow Type          |VCF LiftOver         |
 
 A separate specification ensures the cart has 0 files
 ## Remove All Files from Cart
-* Perform the following actions on a filter card
+* Perform the following actions on a filter card on the Repository page
   |filter_name      |action               |
   |-----------------|---------------------|
   |Workflow Type    |clear selection      |

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/repository_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/repository_page.py
@@ -6,7 +6,7 @@ from ....base.base_page import GenericLocators
 
 class RepositoryPageLocators:
     TITLE = lambda title_name: f'div[data-testid="{title_name}-title"]'
-    FILTERS_FACETS = '//div[@data-testid="filters-facets"]/div'
+    FILTERS_FACETS = '//div[@data-testid="filters-facets"]/div/div'
     FACET_BY_NAME = '//div[@data-testid="filters-facets"]//div[text()="Data Category"]/../../..//input[@value="biospecimen"]'
     FILTER_BUTTON_IDENT = lambda button_name: f"[data-testid='button-{button_name}']"
     REPO_BUTTON_IDENT = (
@@ -15,6 +15,17 @@ class RepositoryPageLocators:
     MODAL_ADD_CUSTOM_FILTER_IDENT = "[data-testid='modal-repository-add-custom-filter']"
     LIST_IDENT = lambda list_name: f"//div[@data-testid='list-{list_name}']"
     FILE_FILTER_SEARCH_BOX = '[data-testid="textbox-search-for-a-property"]'
+
+    FILTER_GROUP_SELECTION_IDENT = (
+        lambda group_name, selection: f'[data-testid="filters-facets"] >> div >> div:has-text("{group_name}") >> [data-testid="checkbox-{selection}"]'
+    )
+    FILTER_GROUP_ACTION_IDENT = (
+        lambda group_name, action: f'[data-testid="filters-facets"] >> div >> div:has-text("{group_name}") >> button[aria-label="{action}"]'
+    )
+    FILTER_GROUP_SHOW_MORE_LESS_IDENT = (
+        lambda group_name, more_or_less: f'[data-testid="filters-facets"] >> div >> div:has-text("{group_name}") >> button[data-testid="{more_or_less}"]'
+    )
+
 
     IMAGE_VIEWER_IDENT = (
         lambda data_testid: f"[data-testid='{data_testid}-image-viewer']"
@@ -68,6 +79,25 @@ class RepositoryPage(BasePage):
             nth_inner_element = nth_inner_element[0].split("\n")[0]
             filter_names.append(nth_inner_element)
         return filter_names
+
+    def make_selection_within_filter_group_repository(self, filter_group_name, selection):
+        """Clicks a checkbox within a filter group"""
+        locator = RepositoryPageLocators.FILTER_GROUP_SELECTION_IDENT(
+            filter_group_name, selection
+        )
+        self.click(locator)
+
+    def perform_action_within_filter_card_repository(self, filter_group_name, action):
+        """Performs an action in a filter group e.g sorting, resetting, flipping the chart, etc."""
+        locator = RepositoryPageLocators.FILTER_GROUP_ACTION_IDENT(filter_group_name, action)
+        self.click(locator)
+
+    def click_show_more_less_within_filter_card_repository(self, filter_group_name, label):
+        """Clicks the show more or show less object"""
+        locator = RepositoryPageLocators.FILTER_GROUP_SHOW_MORE_LESS_IDENT(
+            filter_group_name, label
+        )
+        self.click(locator)
 
     def click_button(self, button_name: str):
         """Clicks file filter button and file filter options"""

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -683,12 +683,12 @@ def click_undo_in_message():
     APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
 
 
-# These 3 functions are for filter cards (like on projects or repository page).
+# These 3 functions are for filter cards (like on projects page).
 # The filter cards depend on a specific data-testid "filters-facets" that
 # is common across a couple of filter sets in the data portal.
 @step("Make the following selections on a filter card <table>")
 def filter_card_selections(table):
-    """Trio of actions for the filter cards and filters on the repository page"""
+    """Trio of actions for the filter cards and filters on the projects page"""
     for k, v in enumerate(table):
         APP.shared.make_selection_within_filter_group(v[0], v[1])
         APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
@@ -778,16 +778,16 @@ def global_quick_search(text: str):
 
 
 @step(
-    "Validate the quick search bar result in position <result_in_list> of the result list has the abbreviation <abbreviation>"
+    "Validate the quick search bar result in position <result_in_list> of the result list has the category <category>"
 )
-def validate_global_quick_search_result_abbreviation(
-    result_in_list: str, abbreviation: str
+def validate_global_quick_search_result_category(
+    result_in_list: str, category: str
 ):
     """
-    Specifies a result from the quick search bar result list. Validates the result abbreviation is the one we expect.
+    Specifies a result from the quick search bar result list. Validates the result category is the one we expect.
     """
-    APP.shared.validate_global_quick_search_result_abbreviation(
-        result_in_list, abbreviation
+    APP.shared.validate_global_quick_search_result_category(
+        result_in_list, category
     )
 
 

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/repository_page_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/repository_page_steps.py
@@ -35,6 +35,31 @@ def select_file_filter_and_validate(filter_name: str, nth: int):
     except:
         repository.select_nth_file_filters_result(int(nth) - 1)
 
+# These 3 functions are for filter cards on the repository page.
+@step("Make the following selections on a filter card on the Repository page <table>")
+def filter_card_selections(table):
+    """Trio of actions for the filter cards and filters on the repository page"""
+    for k, v in enumerate(table):
+        APP.repository_page.make_selection_within_filter_group_repository(v[0], v[1])
+        APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
+        APP.shared.wait_for_loading_spinner_table_to_detatch()
+        APP.shared.wait_for_loading_spinner_to_detatch()
+        time.sleep(0.1)
+
+@step("Perform the following actions on a filter card on the Repository page <table>")
+def perform_filter_card_action(table):
+    for k, v in enumerate(table):
+        APP.repository_page.perform_action_within_filter_card_repository(v[0], v[1])
+        APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
+        APP.shared.wait_for_loading_spinner_table_to_detatch()
+        APP.shared.wait_for_loading_spinner_to_detatch()
+        time.sleep(0.1)
+
+@step("Expand or contract a filter on the Repository page <table>")
+def click_show_more_or_show_less(table):
+    for k, v in enumerate(table):
+        APP.repository_page.click_show_more_less_within_filter_card_repository(v[0], v[1])
+
 
 @step("Verify cohort case count equals repository table case count")
 def compare_cohort_case_count_and_repo_table_case_count():

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -49,8 +49,8 @@ class GenericLocators:
     QUICK_SEARCH_BAR_NUMBERED_RESULT = (
         lambda result_in_list: f'[data-testid="text-search-result"] >> nth={result_in_list}'
     )
-    QUICK_SEARCH_BAR_RESULT_ABBREVIATION = (
-        lambda result_in_list, abbreviation: f'[data-testid="text-search-result"] >> nth={result_in_list} >> text="{abbreviation}"'
+    QUICK_SEARCH_BAR_RESULT_CATEGORY = (
+        lambda result_in_list, category: f'[data-testid="text-search-result"] >> nth={result_in_list} >> text="{category}"'
     )
 
     RADIO_BUTTON_IDENT = lambda radio_name: f'//input[@id="{radio_name}"]'
@@ -579,17 +579,17 @@ class BasePage:
         """Sends text into the quick search bar in the upper-right corner of the data portal."""
         self.send_keys(GenericLocators.QUICK_SEARCH_BAR_IDENT, text)
 
-    def validate_global_quick_search_result_abbreviation(
-        self, result_in_list, abbreviation
+    def validate_global_quick_search_result_category(
+        self, result_in_list, category
     ):
-        """Specifies a result from the quick search bar result list. Validates the result abbreviation is the one we expect."""
+        """Specifies a result from the quick search bar result list. Validates the result category is the one we expect."""
         result_in_list = self.make_input_0_index(result_in_list)
-        locator_result_abbreviation = (
-            GenericLocators.QUICK_SEARCH_BAR_RESULT_ABBREVIATION(
-                result_in_list, abbreviation
+        locator_result_category = (
+            GenericLocators.QUICK_SEARCH_BAR_RESULT_CATEGORY(
+                result_in_list, category
             )
         )
-        self.wait_until_locator_is_visible(locator_result_abbreviation)
+        self.wait_until_locator_is_visible(locator_result_category)
 
     def click_global_quick_search_result(self, result_in_list):
         """Specifies a result from the quick search bar result list. Clicks that result."""


### PR DESCRIPTION
## Description
- Updated test automation for 2.14.0 changes
- Changes to filter selection on repository page and text checking on quick search test

All tests pass. Use VPN2, qa-int. Affected tests here:
gauge run specs/gdc_data_portal_v2/repository/add_all_remove_all_files.spec
gauge run specs/gdc_data_portal_v2/repository/table_download.spec       
gauge run specs/gdc_data_portal_v2/header/quick_search.spec