### PR TITLE
STJUDE: update PP to 2.55.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6333,8 +6333,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.52.0",
-      "license": "SEE LICENSE IN ./LICENSE"
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.58.0.tgz",
+      "integrity": "sha512-iJTsMpSCtpqKNzoB5ipVhm0hxKBzw3y2mwGrhLfyqEsfaq3BxnNAVhTFekOmfHvpJqQubynzCu4ZL7cAirFxlw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -28191,7 +28192,7 @@
         "@mantine/notifications": "^6.0.21",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.52.0",
+        "@sjcrh/proteinpaint-client": "^2.55.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^6.0.21",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.52.0",
+    "@sjcrh/proteinpaint-client": "^2.55.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description
Updates Prortiem Paint client to 2.55.0 to match the version in `release/kepler`. 
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
