### PR TITLE
Added data-testids to bar graph QA-2107

### DIFF
--- a/packages/sapien/src/sapien.ts
+++ b/packages/sapien/src/sapien.ts
@@ -137,6 +137,7 @@ export const createHumanBody: TCreateHumanBody = ({
     .data(data)
     .enter()
     .append("text")
+    .attr("data-testid", (d: any) => `Label-${toClassName(d[primarySiteKey])}`)
     .attr(
       "class",
       (d: any) => `primary-site-label-${toClassName(d[primarySiteKey])}`,
@@ -241,6 +242,10 @@ export const createHumanBody: TCreateHumanBody = ({
       d.color = colorCodes[d[primarySiteKey]];
       return d.color;
     })
+    .attr(
+      "data-testid",
+      (d: any) => `Bar-Graph-${toClassName(d[primarySiteKey])}`,
+    )
     .attr("class", (d: any) => `bar-${toClassName(d[primarySiteKey])}`)
     .on("mouseover", function (event: any, d: any) {
       const organSelector = toClassName(d[primarySiteKey] as string);


### PR DESCRIPTION
## Description
- Added IDs to the bar graph on home page

I used upper-cases, because that's how the IDs are going to be presented. So in the spec file I can just write the whole command using upper case. Otherwise it would be a mixture of upper and lower case and that would be more annoying to work with. 
![Screenshot 2024-05-09 at 11 23 53 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/103586536/90fd9858-8cdd-4aec-b0f9-5d1ae2069972)
![Screenshot 2024-05-09 at 11 23 42 AM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/103586536/bdac044b-03f0-4fc3-9956-7da302c013ff)