### PR TITLE
PEAR-1852: Fix for cDAVE - Survival plot resets what is plotted when switching from days to years (or vice-versa)

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
@@ -55,6 +55,8 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
       : DATA_DIMENSIONS?.[field]?.unit,
   );
 
+  console.log({ dataDimension });
+
   const continuous = CONTINUOUS_FACET_TYPES.includes(facet?.type);
   const noData = continuous
     ? (data as Stats)?.stats?.count === 0
@@ -152,7 +154,7 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
             disabled={noData || downloadInProgress}
           />
           <Tooltip
-            label={"Remove Card"}
+            label="Remove Card"
             position="bottom-end"
             withArrow
             arrowSize={7}

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
@@ -55,8 +55,6 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
       : DATA_DIMENSIONS?.[field]?.unit,
   );
 
-  console.log({ dataDimension });
-
   const continuous = CONTINUOUS_FACET_TYPES.includes(facet?.type);
   const noData = continuous
     ? (data as Stats)?.stats?.count === 0

--- a/packages/portal-proto/src/features/cDave/CDaveCard/ContinuousData.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ContinuousData.tsx
@@ -101,7 +101,6 @@ const ContinuousData: React.FC<ContinuousDataProps> = ({
   const [selectedFacets, setSelectedFacets] = useState<SelectedFacet[]>([]);
   const [yTotal, setYTotal] = useState(0);
 
-  console.log({ selectedSurvivalPlots });
   const ranges = useDeepCompareMemo(
     () =>
       isInterval(customBinnedData)
@@ -151,7 +150,6 @@ const ContinuousData: React.FC<ContinuousDataProps> = ({
   );
 
   useDeepCompareEffect(() => {
-    console.log({ displayedData });
     selectedSurvivalPlots.length === 0 &&
       setSelectedSurvivalPlots(
         displayedData

--- a/packages/portal-proto/src/features/cDave/CDaveCard/ContinuousData.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ContinuousData.tsx
@@ -101,6 +101,7 @@ const ContinuousData: React.FC<ContinuousDataProps> = ({
   const [selectedFacets, setSelectedFacets] = useState<SelectedFacet[]>([]);
   const [yTotal, setYTotal] = useState(0);
 
+  console.log({ selectedSurvivalPlots });
   const ranges = useDeepCompareMemo(
     () =>
       isInterval(customBinnedData)
@@ -150,16 +151,18 @@ const ContinuousData: React.FC<ContinuousDataProps> = ({
   );
 
   useDeepCompareEffect(() => {
-    setSelectedSurvivalPlots(
-      displayedData
-        .filter(
-          ({ count, key }) =>
-            key !== MISSING_KEY && count >= SURVIVAL_PLOT_MIN_COUNT,
-        )
-        .sort((a, b) => b.count - a.count)
-        .map(({ key }) => key)
-        .slice(0, 2),
-    );
+    console.log({ displayedData });
+    selectedSurvivalPlots.length === 0 &&
+      setSelectedSurvivalPlots(
+        displayedData
+          .filter(
+            ({ count, key }) =>
+              key !== MISSING_KEY && count >= SURVIVAL_PLOT_MIN_COUNT,
+          )
+          .sort((a, b) => b.count - a.count)
+          .map(({ key }) => key)
+          .slice(0, 2),
+      );
 
     if (customBinnedData === null) {
       setYTotal(displayedData.reduce((a, b) => a + b.count, 0));


### PR DESCRIPTION
## Description

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
