### PR TITLE
PEAR-1945: Fix overwritten responsive grid style and adjust numeric range facet style

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/FacetTabs.tsx
@@ -123,7 +123,7 @@ export const FacetGroup: React.FC<FacetGroupProps> = ({
 
   return (
     <div
-      className="bg-base-max pr-6 grid grid-cols-4 justify-stretch gap-4 my-4 ml-4"
+      className="bg-base-max grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 w-content gap-4 m-4"
       data-testid="title-cohort-builder-facet-groups"
     >
       {children}

--- a/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/QueryExpressionSection.tsx
@@ -24,8 +24,7 @@ const QueryExpressionContainer = tw.div`
   border-secondary-darkest
   border-1
   border-l-4
-  my-4
-  mx-3
+  m-4
 `;
 
 const MAX_HEIGHT_QE_SECTION = 120;

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -326,12 +326,12 @@ const FromTo: React.FC<FromToProps> = ({
 
   return (
     <div className="flex flex-col grow m-2 text-base-contrast-max bg-base-max">
-      <fieldset>
+      <fieldset className="flex flex-col gap-y-1">
         <legend className="sr-only">Numeric from/to filters</legend>
-        <div className="flex flex-row justify-end items-center flex-nowrap border font-content">
+        <div className="flex gap-0.5 items-center flex-nowrap border font-content">
           <div className="basis-1/5 text-center">From</div>
           <SegmentedControl
-            className="basis-2/5"
+            className="flex-1"
             size="sm"
             value={fromOp}
             onChange={(value) => {
@@ -346,7 +346,7 @@ const FromTo: React.FC<FromToProps> = ({
           />
           <NumberInput
             data-testid="textbox-input-from-value"
-            className="text-sm grow"
+            className="text-sm flex-1"
             placeholder={`eg. ${lowerUnitRange}${unitsLabel} `}
             min={lowerUnitRange}
             max={upperUnitRange}
@@ -366,10 +366,10 @@ const FromTo: React.FC<FromToProps> = ({
             aria-label="input from value"
           />
         </div>
-        <div className="flex flex-row mt-1 justify-center items-center flex-nowrap border font-content">
+        <div className="flex gap-0.5 items-center flex-nowrap border font-content">
           <div className="basis-1/5 text-center">To</div>
           <SegmentedControl
-            className="basis-2/5"
+            className="flex-1"
             size="sm"
             value={toOp}
             onChange={(value) => {
@@ -384,7 +384,7 @@ const FromTo: React.FC<FromToProps> = ({
           />
           <NumberInput
             data-testid="textbox-input-to-value"
-            className="grow text-sm"
+            className="flex-1 text-sm"
             placeholder={`eg. ${upperUnitRange}${unitsLabel} `}
             min={lowerUnitRange}
             max={upperUnitRange}


### PR DESCRIPTION
## Description
The issue involved the responsive grid style being overwritten, as well as changes to the Numeric Range Facet style.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
