### PR TITLE
PEAR-1960 - Investigate and fix: New filter cards not showing up sometimes? (Repository)

### DIFF
--- a/packages/core/src/features/gdcapps/GdcApp.tsx
+++ b/packages/core/src/features/gdcapps/GdcApp.tsx
@@ -121,9 +121,7 @@ export const createAppID = (name: string, version: string): string =>
 // Apps with Local Storage
 //
 
-export const createAppStore = (
-  options: CreateGDCAppStore,
-): Record<any, any> => {
+export const createAppStore = (options: CreateGDCAppStore) => {
   const { name, version, reducers } = options;
   const nameVersion = `${name}::${version}`;
   const id = createAppID(name, version);

--- a/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useState, useCallback } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import {
   FacetDefinition,
   selectFacetDefinitionsByName,
   useCoreSelector,
   useFacetDictionary,
-  usePrevious,
   fieldNameToTitle,
 } from "@gff/core";
 import {
@@ -12,17 +12,17 @@ import {
   useAppDispatch,
 } from "@/features/repositoryApp/appApi";
 import {
-  selectRepositoryConfig,
+  selectCustomFacets,
   addFilter,
   removeFilter,
   resetToDefault,
   getDefaultFacets,
+  selectRepositoryConfigFacets,
 } from "@/features/repositoryApp/repositoryConfigSlice";
 import FacetSelection from "@/components/FacetSelection";
 import { Group, Button, LoadingOverlay, Text, Modal } from "@mantine/core";
 import { MdAdd as AddAdditionalIcon } from "react-icons/md";
 import { FaUndo as UndoIcon } from "react-icons/fa";
-import isEqual from "lodash/isEqual";
 import partial from "lodash/partial";
 
 import {
@@ -45,15 +45,15 @@ const useRepositoryEnumData = (field: string) =>
   useLocalFilters(field, useRepositoryEnumValues, useRepositoryFilters);
 
 export const FileFacetPanel = (): JSX.Element => {
-  const config = useAppSelector(selectRepositoryConfig);
+  const customFacets = useAppSelector(selectCustomFacets);
+  const facetsConfig = useAppSelector(selectRepositoryConfigFacets);
   const { isSuccess: isDictionaryReady } = useFacetDictionary();
   const facets = useCoreSelector((state) =>
-    selectFacetDefinitionsByName(state, config.facets),
+    selectFacetDefinitionsByName(state, facetsConfig),
   );
 
   const [facetDefinitions, setFacetDefinitions] =
     useState<ReadonlyArray<FacetDefinition>>(facets);
-  const prevCustomFacets = usePrevious(facets);
   const [opened, setOpened] = useState(false);
   const dispatch = useAppDispatch();
 
@@ -78,15 +78,13 @@ export const FileFacetPanel = (): JSX.Element => {
   }, [dispatch]);
 
   // rebuild customFacets
-  useEffect(() => {
-    if (isDictionaryReady && !isEqual(prevCustomFacets, facets)) {
+  useDeepCompareEffect(() => {
+    if (isDictionaryReady) {
       setFacetDefinitions(facets);
     }
-  }, [facets, isDictionaryReady, prevCustomFacets]);
+  }, [facets, isDictionaryReady]);
 
-  const showReset = facetDefinitions.some(
-    (facetDef) => !getDefaultFacets().includes(facetDef.full),
-  );
+  const showReset = customFacets?.length > 0;
 
   const FileFacetHooks: FacetRequiredHooks = {
     useGetEnumFacetData: useRepositoryEnumData,
@@ -148,7 +146,7 @@ export const FileFacetPanel = (): JSX.Element => {
             <FacetSelection
               facetType="files"
               handleFilterSelected={handleFilterSelected}
-              usedFacets={config.facets}
+              usedFacets={customFacets}
             />
           </div>
         </Modal>

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -28,7 +28,10 @@ import { selectFilters } from "@/features/repositoryApp/repositoryFiltersSlice";
 import FunctionButton from "@/components/FunctionButton";
 import { DownloadButton } from "@/components/DownloadButtons";
 import FunctionButtonRemove from "@/components/FunctionButtonRemove";
-import { useClearAllRepositoryFilters } from "@/features/repositoryApp/hooks";
+import {
+  useClearLocalFilterWhenCohortChanges,
+  useClearAllRepositoryFilters,
+} from "@/features/repositoryApp/hooks";
 import { useImageCounts } from "@/features/repositoryApp/slideCountSlice";
 import { Tooltip, Menu, Button } from "@mantine/core";
 import FilesTables from "../repositoryApp/FilesTable";
@@ -118,6 +121,8 @@ export const RepositoryApp = (): JSX.Element => {
   useEffect(() => {
     return () => clearAllFilters();
   }, [clearAllFilters]);
+
+  useClearLocalFilterWhenCohortChanges();
 
   const [metadataDownloadActive, setMetadataDownloadActive] = useState(false);
   const [sampleSheetDownloadActive, setSampleSheetDownloadActive] =

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -28,10 +28,7 @@ import { selectFilters } from "@/features/repositoryApp/repositoryFiltersSlice";
 import FunctionButton from "@/components/FunctionButton";
 import { DownloadButton } from "@/components/DownloadButtons";
 import FunctionButtonRemove from "@/components/FunctionButtonRemove";
-import {
-  useClearLocalFilterWhenCohortChanges,
-  useClearAllRepositoryFilters,
-} from "@/features/repositoryApp/hooks";
+import { useClearAllRepositoryFilters } from "@/features/repositoryApp/hooks";
 import { useImageCounts } from "@/features/repositoryApp/slideCountSlice";
 import { Tooltip, Menu, Button } from "@mantine/core";
 import FilesTables from "../repositoryApp/FilesTable";
@@ -121,8 +118,6 @@ export const RepositoryApp = (): JSX.Element => {
   useEffect(() => {
     return () => clearAllFilters();
   }, [clearAllFilters]);
-
-  useClearLocalFilterWhenCohortChanges();
 
   const [metadataDownloadActive, setMetadataDownloadActive] = useState(false);
   const [sampleSheetDownloadActive, setSampleSheetDownloadActive] =

--- a/packages/portal-proto/src/features/repositoryApp/appApi.ts
+++ b/packages/portal-proto/src/features/repositoryApp/appApi.ts
@@ -48,8 +48,7 @@ export const { id, AppStore, AppContext, useAppSelector, useAppDispatch } =
   createAppStore({
     reducers: persistReducer(persistConfig, downloadAppReducers),
     name: REPOSITORY_APP_NAME,
-    //version: "0.0.1",
-    version: "1.0.0",
+    version: "0.0.1",
   });
 
 export type AppState = ReturnType<typeof downloadAppReducers>;

--- a/packages/portal-proto/src/features/repositoryApp/appApi.ts
+++ b/packages/portal-proto/src/features/repositoryApp/appApi.ts
@@ -20,16 +20,7 @@ const downloadAppReducers = combineReducers({
 });
 
 const migrations = {
-  //"0.0.1": (state : AppState) => {
-  //  return {
-  //    ...state,
-  //    facets: {
-  //      ...RepositoryDefaultConfig,
-  //      facets: [...RepositoryDefaultConfig.facets, ...state.facets.customFacets]
-  //    }
-  //  }
-  //},
-  "1.0.0": (state) => {
+  2: (state) => {
     return {
       ...state,
       facets: {
@@ -43,7 +34,7 @@ const migrations = {
 
 const persistConfig = {
   key: REPOSITORY_APP_NAME,
-  version: 1,
+  version: 2,
   storage,
   whitelist: ["facets", "filters"],
   migrate: createMigrate(migrations),

--- a/packages/portal-proto/src/features/repositoryApp/repositoryConfigSlice.ts
+++ b/packages/portal-proto/src/features/repositoryApp/repositoryConfigSlice.ts
@@ -2,42 +2,41 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import RepositoryDefaultConfig from "./config/filters.json";
 import { AppState } from "./appApi";
 
-export interface RepositoryFilters {
-  readonly label: string;
-  readonly docType: string;
-  readonly index: string;
-  readonly facets: Array<string>;
-}
-
 export interface RepositoryFacet {
   readonly facetName: string;
 }
 
-const initialState: RepositoryFilters = RepositoryDefaultConfig;
+const initialState = { customFacets: [] };
 
 const slice = createSlice({
   name: "repository/appConfig",
   initialState,
   reducers: {
     addFilter: (state, action: PayloadAction<RepositoryFacet>) => {
-      if (!state.facets.includes(action.payload.facetName))
-        state.facets = [action.payload.facetName, ...state.facets];
+      if (!state.customFacets.includes(action.payload.facetName))
+        state.customFacets = [action.payload.facetName, ...state.customFacets];
     },
     removeFilter: (state, action: PayloadAction<RepositoryFacet>) => {
-      state.facets = state.facets.filter((x) => x != action.payload.facetName);
+      state.customFacets = state.customFacets.filter(
+        (x) => x != action.payload.facetName,
+      );
     },
-    resetToDefault: () => initialState,
+    resetToDefault: (state) => {
+      state.customFacets = [];
+    },
   },
 });
 
 export const repositoryConfigReducer = slice.reducer;
 export const { addFilter, removeFilter, resetToDefault } = slice.actions;
 
-export const selectRepositoryConfig = (state: AppState): RepositoryFilters =>
-  state.facets;
-
 export const getDefaultFacets = (): string[] => RepositoryDefaultConfig.facets;
 
+export const selectCustomFacets = (state: AppState) =>
+  state.facets.customFacets;
 export const selectRepositoryConfigFacets = (
   state: AppState,
-): ReadonlyArray<string> => state.facets.facets;
+): ReadonlyArray<string> => [
+  ...state.facets.customFacets,
+  ...RepositoryDefaultConfig.facets,
+];

--- a/packages/portal-proto/src/features/repositoryApp/repositoryConfigSlice.unit.test.ts
+++ b/packages/portal-proto/src/features/repositoryApp/repositoryConfigSlice.unit.test.ts
@@ -3,14 +3,10 @@ import {
   removeFilter,
   resetToDefault,
   repositoryConfigReducer,
-  selectRepositoryConfig,
 } from "./repositoryConfigSlice";
-import DownloadFiltersDefault from "./config/filters.json";
-import { getInitialAppState } from "./store.unit.test";
 
 const defaultState = {
-  label: "Repository Default",
-  facets: [
+  customFacets: [
     "files.experimental_strategy",
     "files.wgs_coverage",
     "files.data_category",
@@ -24,13 +20,10 @@ const defaultState = {
     "cases.samples.specimen_type",
     "cases.samples.preservation_method",
   ],
-  docType: "files",
-  index: "repository",
 };
 
 const alteredConfig = {
-  label: "Repository Default",
-  facets: [
+  customFacets: [
     "file.test_facet",
     "files.experimental_strategy",
     "files.wgs_coverage",
@@ -45,13 +38,10 @@ const alteredConfig = {
     "cases.samples.specimen_type",
     "cases.samples.preservation_method",
   ],
-  docType: "files",
-  index: "repository",
 };
 
 const removeFacetTestState = {
-  label: "Repository Default",
-  facets: [
+  customFacets: [
     "files.experimental_strategy",
     "files.wgs_coverage",
     "files.data_category",
@@ -66,8 +56,6 @@ const removeFacetTestState = {
     "cases.samples.preservation_method",
     "example.facet_type",
   ],
-  docType: "files",
-  index: "repository",
 };
 
 describe("repository config reduce", () => {
@@ -108,15 +96,6 @@ describe("repository config reduce", () => {
 
   test("resetCohortBuilderToDefault action should return builderConfig to the default configuration", () => {
     const state = repositoryConfigReducer(alteredConfig, resetToDefault());
-    expect(state).toEqual(DownloadFiltersDefault);
-  });
-});
-
-const state = getInitialAppState();
-
-describe("selectRepositoryConfig", () => {
-  test("should select the default configuration", () => {
-    const builderConfig = selectRepositoryConfig(state);
-    expect(builderConfig).toEqual(DownloadFiltersDefault);
+    expect(state).toEqual({ customFacets: [] });
   });
 });


### PR DESCRIPTION
## Description
The issue was caused by combining the default facets and user custom facets into one and throwing everything into the store. Due to that, filters cards aren't getting updated because we are pulling the facet information from the persisted store. The fix I implemented was to only store a user's custom filters in the store and pull the default facet information from the JSON file so it will properly update when the JSON is updated. 

This only fixes the repository, I'll need to do something similar to fix cohort builder (mutation frequency and projects are fine, they don't follow this pattern).

To test:
1) On develop: try to update filters.json in the repository app and see that your change isn't reflected :( Add some custom filters to test that they will survive this change.
2) Switch over to this branch: update filters.json, see that your custom filters are still there.
 
## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
