### PR TITLE
PEAR-1938: fix misaligned sections on project and case summery pages

### DIFF
--- a/packages/portal-proto/src/features/cases/CaseView.tsx
+++ b/packages/portal-proto/src/features/cases/CaseView.tsx
@@ -378,7 +378,7 @@ export const CaseView: React.FC<CaseViewProps> = ({
           <FilesTable caseId={case_id} />
         </div>
 
-        <div className="mb-16 mx-4">
+        <div className="mb-16">
           <SMTableContainer
             projectId={data.project.project_id}
             case_id={case_id}

--- a/packages/portal-proto/src/features/projects/ProjectView.tsx
+++ b/packages/portal-proto/src/features/projects/ProjectView.tsx
@@ -407,7 +407,7 @@ export const ProjectView: React.FC<ProjectViewProps> = (
           )}
           {projectData?.annotation?.pagination.count > 0 && (
             <div
-              className={`mb-16 mx-4 ${
+              className={`mb-16 ${
                 projectData.isModal ? "scroll-mt-36" : "scroll-mt-72"
               }`}
               id="annotations"


### PR DESCRIPTION
## Description
fix misaligned sections on project and case summery pages

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
