### PR TITLE
PEAR-1899 Adjust annotations table

### DIFF
--- a/packages/core/src/features/files/filesSlice.ts
+++ b/packages/core/src/features/files/filesSlice.ts
@@ -36,7 +36,7 @@ export interface GdcCartFile {
   readonly submitterId: string;
   readonly md5sum: string;
 }
-export type FileAnnontationsType = {
+export type FileAnnotationsType = {
   readonly annotation_id: string;
   readonly case_id?: string;
   readonly case_submitter_id?: string;
@@ -125,7 +125,7 @@ export interface GdcFile {
   readonly version?: string;
   readonly experimental_strategy?: string;
   readonly project_id?: string;
-  readonly annotations?: ReadonlyArray<FileAnnontationsType>;
+  readonly annotations?: ReadonlyArray<FileAnnotationsType>;
   readonly cases?: FileCaseType;
   readonly associated_entities?: ReadonlyArray<{
     readonly entity_submitter_id: string;

--- a/packages/portal-proto/src/features/files/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/files/AnnotationsTable.tsx
@@ -46,7 +46,7 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
   const [filteredTableData, setFilteredTableData] = useState([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    case_id: false,
+    case_submitter_id: false,
     entity_id: false,
     status: false,
     notes: false,
@@ -76,15 +76,11 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
         id: "case_id",
         header: "Case UUID",
         enableSorting: false,
-        cell: ({ getValue }) => getValue() ?? "--",
-      }),
-      annotationsTableColumnHelper.accessor("case_submitter_id", {
-        id: "case_submitter_id",
-        header: "Case ID",
+        // cell: ({ getValue }) => getValue() ?? "--",
         cell: ({ getValue, row }) =>
           getValue() ? (
             <Link
-              href={`cases/${row.original.case_id}`}
+              href={`/cases/${row.original.case_id}`}
               className="text-utility-link underline font-content"
             >
               {getValue()}
@@ -92,6 +88,22 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
           ) : (
             "--"
           ),
+      }),
+      annotationsTableColumnHelper.accessor("case_submitter_id", {
+        id: "case_submitter_id",
+        header: "Case ID",
+        // cell: ({ getValue, row }) =>
+        //   getValue() ? (
+        //     <Link
+        //       href={`cases/${row.original.case_id}`}
+        //       className="text-utility-link underline font-content"
+        //     >
+        //       {getValue()}
+        //     </Link>
+        //   ) : (
+        //     "--"
+        //   ),
+        cell: ({ getValue }) => getValue() ?? "--",
       }),
       annotationsTableColumnHelper.accessor("entity_type", {
         id: "entity_type",

--- a/packages/portal-proto/src/features/files/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/files/AnnotationsTable.tsx
@@ -6,7 +6,7 @@ import {
   ColumnDef,
 } from "@tanstack/react-table";
 import Link from "next/link";
-import { FileAnnontationsType, useCoreDispatch } from "@gff/core";
+import { FileAnnotationsType, useCoreDispatch } from "@gff/core";
 import { createColumnHelper, SortingState } from "@tanstack/react-table";
 import { convertDateToString } from "src/utils/date";
 import download from "src/utils/download";
@@ -18,11 +18,11 @@ import useStandardPagination from "@/hooks/useStandardPagination";
 import { downloadTSV } from "@/components/Table/utils";
 
 interface AnnotationsTableProps {
-  readonly annotations: ReadonlyArray<FileAnnontationsType>;
+  readonly annotations: ReadonlyArray<FileAnnotationsType>;
 }
 // TODO when DEV-2653 is fixed, re-add case ID col, hide case UUID col by default
 type AnnotationTableData = Pick<
-  FileAnnontationsType,
+  FileAnnotationsType,
   | "annotation_id"
   | "case_id"
   // | "case_submitter_id"

--- a/packages/portal-proto/src/features/files/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/files/AnnotationsTable.tsx
@@ -25,7 +25,7 @@ type AnnotationTableData = Pick<
   FileAnnotationsType,
   | "annotation_id"
   | "case_id"
-  // | "case_submitter_id"
+  | "case_submitter_id"
   | "entity_type"
   | "entity_id"
   | "entity_submitter_id"
@@ -46,7 +46,7 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
   const [filteredTableData, setFilteredTableData] = useState([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    case_submitter_id: false,
+    // case_id: false,
     entity_id: false,
     status: false,
     notes: false,

--- a/packages/portal-proto/src/features/files/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/files/AnnotationsTable.tsx
@@ -20,12 +20,12 @@ import { downloadTSV } from "@/components/Table/utils";
 interface AnnotationsTableProps {
   readonly annotations: ReadonlyArray<FileAnnontationsType>;
 }
-
+// TODO when DEV-2653 is fixed, re-add case ID col, hide case UUID col by default
 type AnnotationTableData = Pick<
   FileAnnontationsType,
   | "annotation_id"
   | "case_id"
-  | "case_submitter_id"
+  // | "case_submitter_id"
   | "entity_type"
   | "entity_id"
   | "entity_submitter_id"
@@ -89,22 +89,21 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
             "--"
           ),
       }),
-      annotationsTableColumnHelper.accessor("case_submitter_id", {
-        id: "case_submitter_id",
-        header: "Case ID",
-        // cell: ({ getValue, row }) =>
-        //   getValue() ? (
-        //     <Link
-        //       href={`cases/${row.original.case_id}`}
-        //       className="text-utility-link underline font-content"
-        //     >
-        //       {getValue()}
-        //     </Link>
-        //   ) : (
-        //     "--"
-        //   ),
-        cell: ({ getValue }) => getValue() ?? "--",
-      }),
+      // annotationsTableColumnHelper.accessor("case_submitter_id", {
+      //   id: "case_submitter_id",
+      //   header: "Case ID",
+      //   cell: ({ getValue, row }) =>
+      //     getValue() ? (
+      //       <Link
+      //         href={`/cases/${row.original.case_id}`}
+      //         className="text-utility-link underline font-content"
+      //       >
+      //         {getValue()}
+      //       </Link>
+      //     ) : (
+      //       "--"
+      //     ),
+      // }),
       annotationsTableColumnHelper.accessor("entity_type", {
         id: "entity_type",
         header: "Entity Type",

--- a/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FilesTable.tsx
@@ -14,7 +14,7 @@ import {
   SortBy,
   AccessType,
   FileCaseType,
-  FileAnnontationsType,
+  FileAnnotationsType,
 } from "@gff/core";
 import { MdSave, MdPerson } from "react-icons/md";
 import { useAppSelector } from "@/features/repositoryApp/appApi";
@@ -55,7 +55,7 @@ export type FilesTableDataType = {
   experimental_strategy?: string;
   platform: string;
   file_size: string;
-  annotations: FileAnnontationsType[];
+  annotations: FileAnnotationsType[];
 };
 
 const filesTableColumnHelper = createColumnHelper<FilesTableDataType>();


### PR DESCRIPTION
## Description

- adjusted annotations table in file summary page to work around the submitter_id not being returned from API. We'll revert the changes once the BE fix is made. basically displaying Case UUID instead of Case ID and shifted links to Case UUID. also prevented users from adding Case ID.
- fixed typo staring me in the face
- fixed link for future

## Checklist

- [N/A] Added proper unit tests
- [/] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1588" alt="Screenshot 2024-05-21 at 4 14 54 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/e047859b-bd2e-49f5-bb88-7621f966961e">
<img width="330" alt="Screenshot 2024-05-21 at 4 15 02 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/0c68d07a-2bea-49e3-9941-2290c1ea5372">
