### PR TITLE
PEAR-1962 - Attempting to load a non-existent case summary pages results in an infinite loading spinner

### DIFF
--- a/packages/portal-proto/src/features/cases/CaseSummary.tsx
+++ b/packages/portal-proto/src/features/cases/CaseSummary.tsx
@@ -58,13 +58,9 @@ export const CaseSummary = ({
 
   return (
     <>
-      {isFetching ||
-      isAnnotationCallFetching ||
-      (data && data?.hits?.[0]?.case_id !== case_id) ? (
+      {isFetching || isAnnotationCallFetching ? (
         <LoadingOverlay visible data-testid="loading-spinner" />
-      ) : data &&
-        Object.keys(data).length > 0 &&
-        annotationCountData !== undefined ? (
+      ) : data && data.hits.length > 0 && annotationCountData !== undefined ? (
         <CaseView
           case_id={case_id}
           bio_id={bio_id}


### PR DESCRIPTION
## Description

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
