### PR TITLE
PEAR-1970: Display '0 days' correctly in case summary follow-up (and other places)

### DIFF
--- a/packages/portal-proto/src/utils/index.ts
+++ b/packages/portal-proto/src/utils/index.ts
@@ -187,6 +187,7 @@ export const ageDisplay = (
   yearsOnly: boolean = false,
   defaultValue: string = "--",
 ): string => {
+  if (ageInDays === 0) return "0 days";
   if (!ageInDays) {
     return defaultValue;
   }

--- a/packages/portal-proto/src/utils/index.ts
+++ b/packages/portal-proto/src/utils/index.ts
@@ -187,8 +187,7 @@ export const ageDisplay = (
   yearsOnly: boolean = false,
   defaultValue: string = "--",
 ): string => {
-  if (ageInDays === 0) return "0 days";
-  if (!ageInDays) {
+  if (ageInDays !== 0 && !ageInDays) {
     return defaultValue;
   }
   const calculateYearsAndDays = (
@@ -209,6 +208,8 @@ export const ageDisplay = (
   const formattedDays =
     !yearsOnly && remainingDays > 0
       ? `${remainingDays} ${remainingDays === 1 ? "day" : "days"}`
+      : years === 0 && remainingDays === 0
+      ? "0 days"
       : "";
 
   const ageString = [formattedYears, formattedDays].filter(Boolean).join(" ");

--- a/packages/portal-proto/src/utils/tests/index.unit.test.ts
+++ b/packages/portal-proto/src/utils/tests/index.unit.test.ts
@@ -44,6 +44,7 @@ describe("calculatePercentageAsString", () => {
 
 describe("ageDisplay", () => {
   it("should return correct years, day format for non leap year", () => {
+    expect(ageDisplay(0)).toEqual("0 days");
     expect(ageDisplay(12345)).toEqual("33 years 292 days");
     expect(ageDisplay(12345, true)).toEqual("33 years");
   });


### PR DESCRIPTION
## Description
Fixed issue where ageInDays value of 0 was not displayed correctly in case summaries. Added a check to ensure '0 days' is shown accurately.

## Checklist
- [X] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
