### PR TITLE
PEAR-1965 change case_filters to filters for annotations

### DIFF
--- a/packages/core/src/features/cases/casesSlice.ts
+++ b/packages/core/src/features/cases/casesSlice.ts
@@ -152,7 +152,7 @@ export const fetchAllCases = createAsyncThunk<
 
     if (casesResponse.data.hits.length > 0) {
       const annotationsResponse = await fetchGdcAnnotations({
-        case_filters: {
+        filters: {
           op: "in",
           content: {
             field: "annotations.case_id",


### PR DESCRIPTION
## Description
- fixes the Annotations count in the cases table. `case_filters` wasn't returning the expected annotations. 

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1797" alt="Screenshot 2024-06-03 at 11 10 36 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/c9926a55-b38d-4de7-85c8-504dfb2181b5">
