### PR TITLE
PEAR-1986 - Change cohort dropdown behavior to suit automation

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -477,6 +477,9 @@ const CohortManager: React.FC = () => {
                 }
                 rightSectionWidth={cohortModified ? 45 : 30}
                 styles={{ section: { pointerEvents: "none" } }}
+                comboboxProps={{
+                  withinPortal: false,
+                }}
               />
               <div
                 className={`ml-auto text-heading text-sm font-semibold mt-0.85 text-primary-contrast ${


### PR DESCRIPTION
## Description
Fixes change from mantine upgrade where select dropdown was now being rendering in a portal by default, automation couldn't select the dropdown with that change.

https://cdis.slack.com/archives/C03NVF9B05C/p1717518179944829

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
