### PR TITLE
PEAR-1991 - Dropdown boxes should be children on the select buttons in the DOM

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -477,9 +477,6 @@ const CohortManager: React.FC = () => {
                 }
                 rightSectionWidth={cohortModified ? 45 : 30}
                 styles={{ section: { pointerEvents: "none" } }}
-                comboboxProps={{
-                  withinPortal: false,
-                }}
               />
               <div
                 className={`ml-auto text-heading text-sm font-semibold mt-0.85 text-primary-contrast ${

--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -175,6 +175,14 @@ const PortalApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
           classNames: {
             item: "text-base-min disabled:opacity-50 data-hovered:bg-accent-lightest data-hovered:text-accent-contrast-lightest",
           },
+          withinPortal: false,
+        },
+      },
+      Select: {
+        defaultProps: {
+          comboboxProps: {
+            withinPortal: false,
+          },
         },
       },
       Modal: Modal.extend({


### PR DESCRIPTION
## Description
https://cdis.slack.com/archives/C03NVF9B05C/p1717604620110459

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
