### PR TITLE
PEAR-1990 - Cohort Bar - Clicking on active cohort from dropdown turns the cohort bar blank and creates infinite loading spinner

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager.tsx
@@ -457,7 +457,9 @@ const CohortManager: React.FC = () => {
                 clearable={false}
                 value={cohortId}
                 onChange={(x) => {
-                  coreDispatch(setActiveCohort(x));
+                  if (x !== null) {
+                    coreDispatch(setActiveCohort(x));
+                  }
                 }}
                 renderOption={CustomCohortSelectItem}
                 classNames={{


### PR DESCRIPTION
## Description

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
