### PR TITLE
PEAR-1942: Remove link to case for annotations table and summary page if annotations case is a redaction

### DIFF
--- a/packages/portal-proto/src/features/annotations/AnnotationSummary.tsx
+++ b/packages/portal-proto/src/features/annotations/AnnotationSummary.tsx
@@ -95,13 +95,18 @@ const AnnotationSummary: React.FC<AnnotationSummaryProps> = ({
         headerName: "Case UUID",
         values: [
           annotation?.case_id ? (
-            <Link
-              href={`/cases/${annotation?.case_id}`}
-              className="underline text-utility-link"
-              key={`case_link_${annotation?.case_id}`}
-            >
-              {annotation?.case_id}
-            </Link>
+            annotation.classification === "Redaction" &&
+            annotation.entity_type === "case" ? (
+              annotation.case_id
+            ) : (
+              <Link
+                href={`/cases/${annotation.case_id}`}
+                className="underline text-utility-link"
+                key={`case_link_${annotation.case_id}`}
+              >
+                {annotation.case_id}
+              </Link>
+            )
           ) : (
             "--"
           ),

--- a/packages/portal-proto/src/features/annotations/AnnotationSummary.unit.test.tsx
+++ b/packages/portal-proto/src/features/annotations/AnnotationSummary.unit.test.tsx
@@ -83,4 +83,100 @@ describe("<AnnotationSummary />", () => {
 
     expect(getByText("Annotation Not Found")).toBeInTheDocument();
   });
+
+  test("Case UUID link should not be present for entity_type case and classification Redaction", () => {
+    jest.spyOn(core, "useGetAnnotationsQuery").mockReturnValue({
+      data: {
+        hits: [
+          {
+            entity_type: "case",
+            entity_id: "45",
+            case_id: "456",
+            classification: "Redaction",
+          },
+        ],
+      },
+      pagination: { total: 2 },
+    } as any);
+    jest.spyOn(core, "useQuickSearchQuery").mockReturnValue({
+      data: { searchList: [{ id: btoa("Case:111") }] },
+    } as any);
+    const { getByRole } = render(<AnnotationSummary annotationId="2" />);
+
+    expect(
+      within(getByRole("row", { name: "Case UUID 456" })).queryByRole("link"),
+    ).toBeNull();
+  });
+
+  test("Case UUID link should be present for entity_type case and classification other than Redaction", () => {
+    jest.spyOn(core, "useGetAnnotationsQuery").mockReturnValue({
+      data: {
+        hits: [
+          {
+            entity_type: "case",
+            entity_id: "45",
+            case_id: "456",
+            classification: "Notification",
+          },
+        ],
+      },
+      pagination: { total: 2 },
+    } as any);
+    jest.spyOn(core, "useQuickSearchQuery").mockReturnValue({
+      data: { searchList: [{ id: btoa("Case:111") }] },
+    } as any);
+    const { getByRole } = render(<AnnotationSummary annotationId="2" />);
+
+    expect(
+      within(getByRole("row", { name: "Case UUID 456" })).getByRole("link"),
+    ).toHaveAttribute("href", "/cases/456");
+  });
+
+  test("Case UUID link should be present for entity_type other than case and classification as Redaction", () => {
+    jest.spyOn(core, "useGetAnnotationsQuery").mockReturnValue({
+      data: {
+        hits: [
+          {
+            entity_type: "not_case",
+            entity_id: "45",
+            case_id: "456",
+            classification: "Redaction",
+          },
+        ],
+      },
+      pagination: { total: 2 },
+    } as any);
+    jest.spyOn(core, "useQuickSearchQuery").mockReturnValue({
+      data: { searchList: [{ id: btoa("Case:111") }] },
+    } as any);
+    const { getByRole } = render(<AnnotationSummary annotationId="2" />);
+
+    expect(
+      within(getByRole("row", { name: "Case UUID 456" })).getByRole("link"),
+    ).toHaveAttribute("href", "/cases/456");
+  });
+
+  test("Case UUID link should be present for entity_type other than case and classification other than Redaction", () => {
+    jest.spyOn(core, "useGetAnnotationsQuery").mockReturnValue({
+      data: {
+        hits: [
+          {
+            entity_type: "not_case",
+            entity_id: "45",
+            case_id: "456",
+            classification: "Notification",
+          },
+        ],
+      },
+      pagination: { total: 2 },
+    } as any);
+    jest.spyOn(core, "useQuickSearchQuery").mockReturnValue({
+      data: { searchList: [{ id: btoa("Case:111") }] },
+    } as any);
+    const { getByRole } = render(<AnnotationSummary annotationId="2" />);
+
+    expect(
+      within(getByRole("row", { name: "Case UUID 456" })).queryByRole("link"),
+    ).toHaveAttribute("href", "/cases/456");
+  });
 });

--- a/packages/portal-proto/src/features/annotations/AnnotationSummary.unit.test.tsx
+++ b/packages/portal-proto/src/features/annotations/AnnotationSummary.unit.test.tsx
@@ -176,7 +176,7 @@ describe("<AnnotationSummary />", () => {
     const { getByRole } = render(<AnnotationSummary annotationId="2" />);
 
     expect(
-      within(getByRole("row", { name: "Case UUID 456" })).queryByRole("link"),
+      within(getByRole("row", { name: "Case UUID 456" })).getByRole("link"),
     ).toHaveAttribute("href", "/cases/456");
   });
 });

--- a/packages/portal-proto/src/features/annotations/AnnotationTable.tsx
+++ b/packages/portal-proto/src/features/annotations/AnnotationTable.tsx
@@ -198,14 +198,22 @@ const AnnnotationTable: React.FC = () => {
       annotationsTableColumnHelper.accessor("case_submitter_id", {
         id: "case_submitter_id",
         header: "Case ID",
-        cell: ({ getValue, row }) => (
-          <Link
-            href={`cases/${row.original.case_id}`}
-            className="text-utility-link underline font-content"
-          >
-            {getValue()}
-          </Link>
-        ),
+        cell: ({ getValue, row }) =>
+          getValue() ? (
+            row.original.classification === "Redaction" &&
+            row.original.entity_type === "case" ? (
+              getValue()
+            ) : (
+              <Link
+                href={`/cases/${row.original.case_id}`}
+                className="text-utility-link underline font-content"
+              >
+                {getValue()}
+              </Link>
+            )
+          ) : (
+            "--"
+          ),
       }),
       annotationsTableColumnHelper.accessor("program_name", {
         id: "program_name",

--- a/packages/portal-proto/src/features/projects/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/projects/AnnotationsTable.tsx
@@ -190,12 +190,17 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
         header: "Case ID",
         cell: ({ getValue, row }) =>
           getValue() ? (
-            <Link
-              href={`/cases/${row.original.case_id}`}
-              className="text-utility-link underline font-content"
-            >
-              {getValue()}
-            </Link>
+            row.original.classification === "Redaction" &&
+            row.original.entity_type === "case" ? (
+              getValue()
+            ) : (
+              <Link
+                href={`/cases/${row.original.case_id}`}
+                className="text-utility-link underline font-content"
+              >
+                {getValue()}
+              </Link>
+            )
           ) : (
             "--"
           ),


### PR DESCRIPTION
## Description
Added check in the appropriate table columns.

## Checklist
- [X] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![annotation_page](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/2e8a5962-33e6-42ef-9bb3-1d66b1807808)
![Annotation_summary](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/a515c804-9fa2-44e1-9f5a-4f4cbb622b5d)
![project_summary](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/b74a628d-e6f2-47cc-a834-acaedb0d01e6)
