### PR TITLE
PEAR-1997: Fix for Cases Table - Customize Columns dropdown is partially cutoff from view

### DIFF
--- a/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
+++ b/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
@@ -92,6 +92,7 @@ function ColumnOrdering<TData>({
       onChange={setShowColumnMenu}
       offset={0}
       zIndex={400}
+      withinPortal={true}
     >
       <Tooltip label="Customize Columns" disabled={showColumnMenu}>
         <Menu.Target>


### PR DESCRIPTION
## Description

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![columnordering](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/490e52ac-3dfe-40ff-8314-d09450a6a9c6)
