### PR TITLE
update the proteinpaint-client version to 2.61.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,9 +5798,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.61.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.61.0.tgz",
-      "integrity": "sha512-IHTEQjAX4AXOwpUB3f4bLK8/5rm69VY4hxK/YjTNuM/QOeJSoVa4BtDJgBgfH7ly8xlsA8sfxCYCDWgzvIBSHQ=="
+      "version": "2.61.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.61.2.tgz",
+      "integrity": "sha512-6hLL5+I2x4pH+Gk0HUY8bNzpjFZeta9RHXZWZW3jgr01VLYREaFxGsnfJE0XRBhGww7tm0kwMcZOBrUoDpXzOw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26148,7 +26148,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.61.0",
+        "@sjcrh/proteinpaint-client": "^2.61.2",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -29,7 +29,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.61.0",
+    "@sjcrh/proteinpaint-client": "^2.61.2",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -102,7 +102,7 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
       toolContainer.style.backgroundColor = "#fff";
 
       const arg = Object.assign(
-        { holder: rootElem, noheader: true, nobox: true, hide_dsHandles: true },
+        { holder: rootElem, noheader: true, nobox: true },
         cloneDeep(data),
       ) as Mds3Arg;
 

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
@@ -59,7 +59,6 @@ test("SSM lolliplot arguments", () => {
   expect(typeof runpparg.host).toBe("string");
   expect(runpparg.noheader).toEqual(true);
   expect(runpparg.nobox).toEqual(true);
-  expect(runpparg.hide_dsHandles).toEqual(true);
   expect(runpparg.holder instanceof HTMLElement).toBe(true);
   expect(runpparg.genome).toEqual("hg38");
   expect(runpparg.tracks).toEqual([


### PR DESCRIPTION
## Description

@craigrbarnes I based this branch off the 2.14.1 tag, please let me know if I use a different base or target branch for this PR.

This fixes style conflict on `h2` elements.

Before
![Screenshot 2024-06-07 at 1 32 20 PM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/411031/5e3a13cc-84fd-4bd2-8c1d-a58e1a8049dc)

Afer
![Screenshot 2024-06-07 at 1 32 28 PM](https://github.com/NCI-GDC/gdc-frontend-framework/assets/411031/93824ea3-9f6a-44c2-b381-fcf4ae9136df)

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
