### PR TITLE
PEAR-1980 adds page to handle v1 urls

### DIFF
--- a/packages/portal-proto/src/pages/v1/[[...v1]].tsx
+++ b/packages/portal-proto/src/pages/v1/[[...v1]].tsx
@@ -20,30 +20,32 @@ const V1RetiredPage: NextPage = () => {
           key="gdc-portal-1.0-retired"
         />
       </Head>
-      <div className="flex flex-col justify-center items-center h-full p-8 gap-2">
-        <h1 className="text-2xl">
-          The GDC Data Portal 1.0 has been retired and is no longer available.
-        </h1>
-        <p className="font-content">
-          Access GDC 2.0{" "}
-          <Link href="/" className="text-primary underline">
-            here
-          </Link>
-          .<br></br>
-          For assistance, contact the GDC Help Desk at{" "}
-          <a
-            href="mailto:support@nci-gdc.datacommons.io"
-            className="text-primary-darker underline"
-            target="blank"
-          >
-            support@nci-gdc.datacommons.io
-          </a>
-          .<br></br>
-          <br></br>
-          Thank you,
-          <br></br>
-          The GDC Team
-        </p>
+      <div className="flex justify-center h-full p-8 gap-2">
+        <div className="flex flex-col items-start gap-2">
+          <h1 className="text-2xl">
+            The GDC Data Portal 1.0 has been retired and is no longer available.
+          </h1>
+          <p className="font-content">
+            Access GDC 2.0{" "}
+            <Link href="/" className="text-primary underline">
+              here
+            </Link>
+            .<br></br>
+            For assistance, contact the GDC Help Desk at{" "}
+            <a
+              href="mailto:support@nci-gdc.datacommons.io"
+              className="text-primary-darker underline"
+              target="blank"
+            >
+              support@nci-gdc.datacommons.io
+            </a>
+            .<br></br>
+            <br></br>
+            Thank you,
+            <br></br>
+            The GDC Team
+          </p>
+        </div>
       </div>
     </UserFlowVariedPages>
   );

--- a/packages/portal-proto/src/pages/v1/[[...v1]].tsx
+++ b/packages/portal-proto/src/pages/v1/[[...v1]].tsx
@@ -40,7 +40,7 @@ const V1RetiredPage: NextPage = () => {
           </a>
           .<br></br>
           <br></br>
-          Thank you
+          Thank you,
           <br></br>
           The GDC Team
         </p>

--- a/packages/portal-proto/src/pages/v1/[[...v1]].tsx
+++ b/packages/portal-proto/src/pages/v1/[[...v1]].tsx
@@ -21,7 +21,7 @@ const V1RetiredPage: NextPage = () => {
         />
       </Head>
       <div className="flex justify-center h-full p-8 gap-2">
-        <div className="flex flex-col items-start gap-2">
+        <div className="flex flex-col gap-2">
           <h1 className="text-2xl">
             The GDC Data Portal 1.0 has been retired and is no longer available.
           </h1>

--- a/packages/portal-proto/src/pages/v1/[[...v1]].tsx
+++ b/packages/portal-proto/src/pages/v1/[[...v1]].tsx
@@ -20,7 +20,7 @@ const V1RetiredPage: NextPage = () => {
           key="gdc-portal-1.0-retired"
         />
       </Head>
-      <div className="flex justify-center h-full p-8 gap-2">
+      <div className="flex justify-center p-8">
         <div className="flex flex-col gap-2">
           <h1 className="text-2xl">
             The GDC Data Portal 1.0 has been retired and is no longer available.

--- a/packages/portal-proto/src/pages/v1/[[...v1]].tsx
+++ b/packages/portal-proto/src/pages/v1/[[...v1]].tsx
@@ -1,0 +1,52 @@
+import { NextPage } from "next";
+import Head from "next/head";
+import { datadogRum } from "@datadog/browser-rum";
+import { UserFlowVariedPages } from "@/features/layout/UserFlowVariedPages";
+import { headerElements } from "@/features/user-flow/workflow/navigation-utils";
+import Link from "next/link";
+
+const V1RetiredPage: NextPage = () => {
+  datadogRum.startView({
+    name: "1.0 Retired",
+  });
+
+  return (
+    <UserFlowVariedPages {...{ indexPath: "/", headerElements }}>
+      <Head>
+        <title>The GDC Data Portal 1.0 has been retired</title>
+        <meta
+          property="og:title"
+          content="GDC Data Portal 1.0 has been retired"
+          key="gdc-portal-1.0-retired"
+        />
+      </Head>
+      <div className="flex flex-col justify-center items-center h-full p-8 gap-2">
+        <h1 className="text-2xl">
+          The GDC Data Portal 1.0 has been retired and is no longer available.
+        </h1>
+        <p className="font-content">
+          Access GDC 2.0{" "}
+          <Link href="/" className="text-primary underline">
+            here
+          </Link>
+          .<br></br>
+          For assistance, contact the GDC Help Desk at{" "}
+          <a
+            href="mailto:support@nci-gdc.datacommons.io"
+            className="text-primary-darker underline"
+            target="blank"
+          >
+            support@nci-gdc.datacommons.io
+          </a>
+          .<br></br>
+          <br></br>
+          Thank you
+          <br></br>
+          The GDC Team
+        </p>
+      </div>
+    </UserFlowVariedPages>
+  );
+};
+
+export default V1RetiredPage;


### PR DESCRIPTION
## Description
- adds a v1 retirement page. It should be loaded for URLs such as portal.gdc.cancer.gov/v1 and portal.gdc.cancer.gov/v1/...

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [/] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

<img width="1647" alt="Screenshot 2024-06-11 at 10 29 50 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/f856c251-4d0a-4b54-baa9-897a89a04325">
<img width="1629" alt="Screenshot 2024-06-11 at 10 29 34 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/73256434/e3e06a10-1a1b-4e31-aa4c-116eff019d77">
