### PR TITLE
PEAR-2005 -  Set Operations - Saving an unsaved cohort causes "Unexpected Error" modal to appear

### DIFF
--- a/packages/core/src/features/cohort/index.ts
+++ b/packages/core/src/features/cohort/index.ts
@@ -62,6 +62,7 @@ import {
   selectHasUnsavedCohorts,
   selectUnsavedCohortName,
   UNSAVED_COHORT_NAME,
+  selectMultipleCohortsById,
 } from "./availableCohortsSlice";
 
 import {
@@ -158,4 +159,5 @@ export {
   selectHasUnsavedCohorts,
   selectUnsavedCohortName,
   UNSAVED_COHORT_NAME,
+  selectMultipleCohortsById,
 };

--- a/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
@@ -12,6 +12,8 @@ import {
   availableCohortsReducer,
   addNewUnsavedCohort,
   divideCurrentCohortFilterSetFilterByPrefix,
+  selectCohortById,
+  selectMultipleCohortsById,
 } from "../availableCohortsSlice";
 import { NullCountsData } from "../cohortCountsQuery";
 import * as cohortSlice from "../availableCohortsSlice";
@@ -860,5 +862,26 @@ describe("add, update, and remove cohort", () => {
         },
       },
     });
+  });
+});
+
+describe("selecting cohorts", () => {
+  test("should return cohort by id", () => {
+    const cohort = selectCohortById(APP_INITIAL_STATE, "0000-0000-1003-0000");
+    expect(cohort).toEqual(MOCK_COHORTS[4]);
+  });
+
+  test("should return cohort by its unsaved id", () => {
+    const cohort = selectCohortById(APP_INITIAL_STATE, "abc-def");
+    expect(cohort).toEqual(MOCK_COHORTS[6]);
+  });
+
+  test("should return multiple cohorts", () => {
+    const cohorts = selectMultipleCohortsById(APP_INITIAL_STATE, [
+      "0000-0000-1000-0000",
+      "abc-def",
+      "made-up-one",
+    ]);
+    expect(cohorts).toEqual([MOCK_COHORTS[1], MOCK_COHORTS[6]]);
   });
 });

--- a/packages/core/src/features/cohort/tests/mockData.ts
+++ b/packages/core/src/features/cohort/tests/mockData.ts
@@ -156,4 +156,30 @@ export const MOCK_COHORTS: Cohort[] = [
     saved: false,
     modified_datetime: new Date(2020, 1, 6).toISOString(),
   },
+  {
+    name: "Lung",
+    id: "0000-0000-0000-2222",
+    unsavedCohortId: "abc-def",
+    filters: {
+      root: {
+        "cases.primary_site": {
+          field: "cases.primary_site",
+          operands: ["lung"],
+          operator: "includes",
+        },
+      },
+      mode: "and",
+    },
+    modified_datetime: new Date(2020, 1, 9).toISOString(),
+    caseSet: { status: "uninitialized" },
+    counts: {
+      caseCount: 4456,
+      fileCount: 76000,
+      genesCount: 1290,
+      mutationCount: 2877,
+      status: "fulfilled" as DataStatus,
+    },
+    saved: false,
+    modified: false,
+  },
 ];

--- a/packages/portal-proto/src/features/set-operations/SetOperationChartsForCohorts.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationChartsForCohorts.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import {
   useCoreSelector,
   useCreateCaseSetFromFiltersMutation,
@@ -6,7 +5,7 @@ import {
   useSetOperationsCasesTotalQuery,
   useCaseSetCountsQuery,
   getCohortFilterForAPI,
-  selectAllCohorts,
+  selectMultipleCohortsById,
 } from "@gff/core";
 import { SetOperationsChartInputProps } from "@/features/set-operations/types";
 import { Loader } from "@mantine/core";
@@ -36,12 +35,13 @@ const SetOperationChartsForCohorts = ({
   const [createSet2, createSet2Response] =
     useCreateCaseSetFromFiltersMutation();
 
-  // get all cohorts, and filter down to the ones that are selected
-  const allCohorts = useCoreSelector((state) => selectAllCohorts(state));
-
-  const cohorts = useMemo(() => {
-    return selectedEntities?.map((se) => allCohorts[se.id]);
-  }, [selectedEntities, allCohorts]);
+  const ids = useDeepCompareMemo(
+    () => selectedEntities.map((e) => e.id),
+    [selectedEntities],
+  );
+  const cohorts = useCoreSelector((state) =>
+    selectMultipleCohortsById(state, ids),
+  );
 
   // if the cohorts are not already case sets, create them
   useDeepCompareEffect(() => {


### PR DESCRIPTION
## Description
This was caused by two issues:
1) the set operations app was not updating correctly when cohorts changed (SV-2474). Pari updated the set operations app to update correctly with PEAR-1787, revealing the second issue. 
2) The id of the cohort changes when it is saved because we receive an id back from the API that we need to refer to the cohort by. Fix is to keep the old unsaved cohort id around so the set operation app can find the cohort associated with the id that the user initially selected. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
