### PR TITLE
PEAR-1941: add error message to survival plot when no data to display

### DIFF
--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -494,7 +494,7 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
   );
   // handle errors
   if (!(dataToUse.length > 0 && noDataMessage)) {
-    return <div className="p-1">{noDataMessage}</div>;
+    return <div className="py-1">{noDataMessage}</div>;
   }
 
   return (

--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -492,11 +492,7 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
   );
   // handle errors
   if (!(dataToUse.length > 0)) {
-    return (
-      <div className="p-1">
-        No Survival data available for this Cohort Comparison
-      </div>
-    );
+    return <div className="p-1">Not enough survival data</div>;
   }
 
   return (

--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -493,7 +493,7 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
     DownloadProgressContext,
   );
   // handle errors
-  if (!(dataToUse.length > 0 && noDataMessage)) {
+  if (!(dataToUse.length > 0) && noDataMessage) {
     return <div className="py-1">{noDataMessage}</div>;
   }
 

--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -327,6 +327,7 @@ export interface SurvivalPlotProps {
   readonly field?: string;
   readonly downloadFileName?: string;
   readonly tableTooltip?: boolean;
+  readonly noDataMessage?: string;
 }
 
 const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
@@ -339,6 +340,7 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
   field,
   downloadFileName = "survival-plot",
   tableTooltip = false,
+  noDataMessage = "",
 }: SurvivalPlotProps) => {
   // handle the current range of the xAxis: set to "undefined" to reset
   const [xDomain, setXDomain] = useState(undefined);
@@ -491,8 +493,8 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
     DownloadProgressContext,
   );
   // handle errors
-  if (!(dataToUse.length > 0)) {
-    return <div className="p-1">Not enough survival data</div>;
+  if (!(dataToUse.length > 0 && noDataMessage)) {
+    return <div className="p-1">{noDataMessage}</div>;
   }
 
   return (
@@ -675,6 +677,7 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
  * @param downloadFileName - name of the file to download
  * @param tableTooltip - whether to show the table tooltip
  * @category Charts
+ * @param noDataMessage - message to show when not enough data
  */
 
 const SurvivalPlot = (props: SurvivalPlotProps) => {

--- a/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot.tsx
@@ -490,6 +490,14 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
   const { downloadInProgress, setDownloadInProgress } = useContext(
     DownloadProgressContext,
   );
+  // handle errors
+  if (!(dataToUse.length > 0)) {
+    return (
+      <div className="p-1">
+        No Survival data available for this Cohort Comparison
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col">

--- a/packages/portal-proto/src/features/cohortComparison/SurvivalCard.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/SurvivalCard.tsx
@@ -178,6 +178,7 @@ const SurvivalCard: React.FC<SurvivalCardProps> = ({
               plotType={SurvivalPlotTypes.cohortComparison}
               data={data}
               hideLegend
+              noDataMessage="No Survival data available for this Cohort Comparison"
             />
           )}
           <div className="font-heading mt-[1.5rem]">


### PR DESCRIPTION
## Description
add error message to survival plot when no data to display

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
