### PR TITLE
PEAR-1951: Disable select for 0 cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "@reactour/tour": "^2.9.0",
         "dom-to-svg": "^0.12.2",
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "file-saver": "^2.0.5",
         "isomorphic-fetch": "^3.0.0",
         "lodash": "^4.17.21",
@@ -10655,11 +10655,12 @@
       "license": "MIT"
     },
     "node_modules/echarts": {
-      "version": "5.4.3",
-      "license": "Apache-2.0",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.4"
+        "zrender": "5.5.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -26036,15 +26037,17 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.4.4",
-      "license": "BSD-3-Clause",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
       "dependencies": {
         "tslib": "2.3.0"
       }
     },
     "node_modules/zrender/node_modules/tslib": {
       "version": "2.3.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "packages/core": {
       "name": "@gff/core",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "lint-staged": {
     "!(**/*.png)": [
-      "prettier --write --ignore-unknown",
-      "eslint --fix"
+      "prettier --write --ignore-unknown"
     ]
   },
   "repository": {
@@ -40,7 +39,7 @@
   "dependencies": {
     "@reactour/tour": "^2.9.0",
     "dom-to-svg": "^0.12.2",
-    "echarts": "^5.4.3",
+    "echarts": "^5.5.0",
     "file-saver": "^2.0.5",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.21",

--- a/packages/portal-proto/src/components/Modals/SetModals/SavedSets.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/SavedSets.tsx
@@ -22,6 +22,7 @@ import { UserInputContext } from "../UserInputModal";
 import { createColumnHelper } from "@tanstack/react-table";
 import { HandleChangeInput } from "@/components/Table/types";
 import VerticalTable from "@/components/Table/VerticalTable";
+import { useDeepCompareMemo } from "use-deep-compare";
 
 interface SavedSetsProps {
   readonly setType: SetTypes;
@@ -35,6 +36,14 @@ interface SavedSetsProps {
   readonly facetField: string;
   readonly existingFiltersHook: () => FilterSet;
 }
+
+interface TableData {
+  setId: string;
+  name: string;
+  count: number;
+}
+
+const savedSetsTableColumnHelper = createColumnHelper<TableData>();
 
 const SavedSets: React.FC<SavedSetsProps> = ({
   setType,
@@ -60,19 +69,17 @@ const SavedSets: React.FC<SavedSetsProps> = ({
     return Object.entries(sets).map(([setId, name]) => ({
       setId,
       name,
-      count: isSuccess ? (counts?.[setId] || 0).toLocaleString() : "...",
+      count: counts?.[setId] || 0,
     }));
-  }, [sets, counts, isSuccess]);
+  }, [sets, counts]);
 
-  const savedSetsTableColumnHelper = createColumnHelper<typeof tableData[0]>();
-
-  const getRowId = (originalRow: typeof tableData[0]) => {
+  const getRowId = (originalRow: TableData) => {
     return originalRow.setId;
   };
   const [rowSelection, setRowSelection] = useState({});
   const selectedSets = Object.entries(rowSelection)?.map(([setId]) => setId);
 
-  const savedSetsColumns = useMemo(
+  const savedSetsColumns = useDeepCompareMemo(
     () => [
       savedSetsTableColumnHelper.display({
         id: "select",
@@ -80,7 +87,7 @@ const SavedSets: React.FC<SavedSetsProps> = ({
         cell: ({ row }) => (
           <Tooltip
             label="Set is either empty or deprecated"
-            disabled={row.original.count !== "0"}
+            disabled={row.original.count !== 0}
             zIndex={400}
             position="right"
           >
@@ -94,7 +101,7 @@ const SavedSets: React.FC<SavedSetsProps> = ({
                 checked: row.getIsSelected(),
                 onChange: row.getToggleSelectedHandler(),
               }}
-              disabled={row.original.count === "0"}
+              disabled={row.original.count === 0}
             />
           </Tooltip>
         ),
@@ -106,9 +113,12 @@ const SavedSets: React.FC<SavedSetsProps> = ({
       savedSetsTableColumnHelper.accessor("count", {
         id: "count",
         header: `# ${upperFirst(setTypeLabel)}s`,
+        cell: ({ row }) => (
+          <>{isSuccess ? row.original.count.toLocaleString() : "..."}</>
+        ),
       }),
     ],
-    [savedSetsTableColumnHelper, setTypeLabel],
+    [isSuccess, setTypeLabel],
   );
 
   useEffect(() => {

--- a/packages/portal-proto/src/components/Modals/SetModals/SavedSets.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/SavedSets.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect, useContext } from "react";
 import { UseQuery } from "@reduxjs/toolkit/dist/query/react/buildHooks";
 import { QueryDefinition } from "@reduxjs/toolkit/dist/query";
 import { upperFirst } from "lodash";
-import { Checkbox } from "@mantine/core";
+import { Checkbox, Tooltip } from "@mantine/core";
 import { AiOutlineFileAdd as FileAddIcon } from "react-icons/ai";
 import {
   useCoreSelector,
@@ -78,17 +78,25 @@ const SavedSets: React.FC<SavedSetsProps> = ({
         id: "select",
         header: "Select",
         cell: ({ row }) => (
-          <Checkbox
-            size="xs"
-            classNames={{
-              input: "checked:bg-accent checked:border-accent",
-            }}
-            aria-label={`${row.original.setId}`}
-            {...{
-              checked: row.getIsSelected(),
-              onChange: row.getToggleSelectedHandler(),
-            }}
-          />
+          <Tooltip
+            label="Set is either empty or deprecated"
+            disabled={row.original.count !== "0"}
+            zIndex={400}
+            position="right"
+          >
+            <Checkbox
+              size="xs"
+              classNames={{
+                input: "checked:bg-accent checked:border-accent",
+              }}
+              aria-label={`${row.original.setId}`}
+              {...{
+                checked: row.getIsSelected(),
+                onChange: row.getToggleSelectedHandler(),
+              }}
+              disabled={row.original.count === "0"}
+            />
+          </Tooltip>
         ),
       }),
       savedSetsTableColumnHelper.accessor("name", {

--- a/packages/portal-proto/src/features/charts/EChartWrapper.tsx
+++ b/packages/portal-proto/src/features/charts/EChartWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef } from "react";
 import { init, EChartsOption, ECharts } from "echarts";
 import { useDeepCompareEffect } from "use-deep-compare";
 
@@ -7,7 +7,6 @@ export interface EChartWrapperProps {
   readonly chartRef?: React.MutableRefObject<HTMLElement>;
   readonly height: number;
   readonly width: number;
-  readonly disableCursor?: boolean;
 }
 
 const EChartWrapper: React.FC<EChartWrapperProps> = ({
@@ -15,7 +14,6 @@ const EChartWrapper: React.FC<EChartWrapperProps> = ({
   chartRef,
   height,
   width,
-  disableCursor = false,
 }: EChartWrapperProps) => {
   const ref = useRef<HTMLElement>(null);
   const wrapperRef = chartRef ?? ref;
@@ -35,17 +33,13 @@ const EChartWrapper: React.FC<EChartWrapperProps> = ({
       });
 
       chart.setOption(option);
-      console.log({ disableCursor });
-      if (disableCursor) {
-        chart.getZr().setCursorStyle("not-allowed");
-      }
       chart.resize();
     }
 
     return () => {
       chart?.dispose();
     };
-  }, [wrapperRef, height, width, option, disableCursor]);
+  }, [wrapperRef, height, width, option]);
 
   return (
     <div

--- a/packages/portal-proto/src/features/charts/EChartWrapper.tsx
+++ b/packages/portal-proto/src/features/charts/EChartWrapper.tsx
@@ -1,11 +1,13 @@
 import React, { useRef, useEffect } from "react";
 import { init, EChartsOption, ECharts } from "echarts";
+import { useDeepCompareEffect } from "use-deep-compare";
 
 export interface EChartWrapperProps {
   readonly option: EChartsOption;
   readonly chartRef?: React.MutableRefObject<HTMLElement>;
   readonly height: number;
   readonly width: number;
+  readonly disableCursor?: boolean;
 }
 
 const EChartWrapper: React.FC<EChartWrapperProps> = ({
@@ -13,11 +15,12 @@ const EChartWrapper: React.FC<EChartWrapperProps> = ({
   chartRef,
   height,
   width,
+  disableCursor = false,
 }: EChartWrapperProps) => {
   const ref = useRef<HTMLElement>(null);
   const wrapperRef = chartRef ?? ref;
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     let chart: ECharts | undefined;
 
     if (
@@ -30,14 +33,19 @@ const EChartWrapper: React.FC<EChartWrapperProps> = ({
         height,
         width,
       });
+
       chart.setOption(option);
+      console.log({ disableCursor });
+      if (disableCursor) {
+        chart.getZr().setCursorStyle("not-allowed");
+      }
       chart.resize();
     }
 
     return () => {
       chart?.dispose();
     };
-  }, [wrapperRef, height, width, option]);
+  }, [wrapperRef, height, width, option, disableCursor]);
 
   return (
     <div

--- a/packages/portal-proto/src/features/charts/VennDiagram/VennDiagram.tsx
+++ b/packages/portal-proto/src/features/charts/VennDiagram/VennDiagram.tsx
@@ -15,7 +15,7 @@ const VennDiagram: React.FC<VennDiagramProps> = ({
     [chartData],
   );
 
-  const { option, disableCursor } = useLayout({
+  const option = useLayout({
     chartData,
     highlightedIndices,
     labels,
@@ -24,14 +24,7 @@ const VennDiagram: React.FC<VennDiagramProps> = ({
     interactable,
   });
 
-  return (
-    <EChartWrapper
-      option={option}
-      disableCursor={disableCursor}
-      height={400}
-      width={400}
-    />
-  );
+  return <EChartWrapper option={option} height={400} width={400} />;
 };
 
 export default VennDiagram;

--- a/packages/portal-proto/src/features/charts/VennDiagram/VennDiagram.tsx
+++ b/packages/portal-proto/src/features/charts/VennDiagram/VennDiagram.tsx
@@ -15,7 +15,7 @@ const VennDiagram: React.FC<VennDiagramProps> = ({
     [chartData],
   );
 
-  const option = useLayout({
+  const { option, disableCursor } = useLayout({
     chartData,
     highlightedIndices,
     labels,
@@ -24,7 +24,14 @@ const VennDiagram: React.FC<VennDiagramProps> = ({
     interactable,
   });
 
-  return <EChartWrapper option={option} height={400} width={400} />;
+  return (
+    <EChartWrapper
+      option={option}
+      disableCursor={disableCursor}
+      height={400}
+      width={400}
+    />
+  );
 };
 
 export default VennDiagram;

--- a/packages/portal-proto/src/features/charts/VennDiagram/types.ts
+++ b/packages/portal-proto/src/features/charts/VennDiagram/types.ts
@@ -1,13 +1,13 @@
 import { GroupProps, ElementProps, PathStyleProps } from "zrender";
 
-export interface chartData {
+export interface ChartData {
   readonly key: string;
   readonly value: number | string;
   readonly highlighted: boolean;
 }
 
 export interface VennDiagramProps {
-  readonly chartData: chartData[];
+  readonly chartData: ChartData[];
   readonly labels: string[];
   readonly ariaLabel: string;
   readonly onClickHandler?: (key: string) => void;

--- a/packages/portal-proto/src/features/charts/VennDiagram/useLayouts.ts
+++ b/packages/portal-proto/src/features/charts/VennDiagram/useLayouts.ts
@@ -1,9 +1,17 @@
 import { useState, useCallback, useEffect } from "react";
 import { useDeepCompareCallback, useDeepCompareEffect } from "use-deep-compare";
-import { EChartsOption, ElementEvent, GraphicComponentOption } from "echarts";
+import {
+  CustomSeriesRenderItemAPI,
+  CustomSeriesRenderItemParams,
+  EChartsOption,
+  ElementEvent,
+  GraphicComponentOption,
+} from "echarts";
 import { GraphicComponentGroupOption, VennDiagramProps } from "./types";
 
 const HIGHLIGHT_COLOR = "#a5d5d9";
+const NOT_ALLOWED_HIGHLIGHT_COLOR = "#9b9b9b";
+const NOT_ALLOWED_TEXT = "#0A0A0A";
 
 // Coordinates where circles intersect, calculated with this: https://gist.github.com/jupdike/bfe5eb23d1c395d8a0a1a4ddd94882ac
 const c1c2I = [
@@ -460,6 +468,7 @@ const chartConfig: EChartsOption = {
 const addHighlight = (
   chartLayout: GraphicComponentOption[],
   highlightedIndices: string[],
+  isCursorAllowed: boolean = true,
 ) => {
   return chartLayout.map((group: GraphicComponentGroupOption) => {
     if (highlightedIndices.includes(group.id)) {
@@ -468,18 +477,24 @@ const addHighlight = (
           ...group,
           children: group.children.map((child) => ({
             ...child,
+            ...(!isCursorAllowed && { cursor: "not-allowed" }),
             style: {
               ...child.style,
-              fill: HIGHLIGHT_COLOR,
+              fill: isCursorAllowed
+                ? HIGHLIGHT_COLOR
+                : NOT_ALLOWED_HIGHLIGHT_COLOR,
             },
           })),
         };
       } else {
         return {
           ...group,
+          ...(!isCursorAllowed && { cursor: "not-allowed" }),
           style: {
             ...group.style,
-            fill: HIGHLIGHT_COLOR,
+            fill: isCursorAllowed
+              ? HIGHLIGHT_COLOR
+              : NOT_ALLOWED_HIGHLIGHT_COLOR,
           },
         };
       }
@@ -487,6 +502,20 @@ const addHighlight = (
       return group;
     }
   });
+};
+
+const getLayout = (
+  twoCircles: boolean,
+  highlightedIndices: string[],
+  id: string = null,
+  isCursorAllowed: boolean = true,
+) => {
+  const layout = twoCircles ? twoCircleLayout : threeCircleLayout;
+  return addHighlight(
+    layout,
+    id ? [...highlightedIndices, id] : highlightedIndices,
+    isCursorAllowed,
+  );
 };
 
 type UseLayoutProps = VennDiagramProps & {
@@ -502,14 +531,9 @@ export const useLayout = ({
   interactable,
 }: UseLayoutProps): EChartsOption => {
   const twoCircles = chartData.length === 3;
-  const [chartLayout, setChartLayout] = useState<GraphicComponentOption[]>(
-    twoCircles
-      ? addHighlight(twoCircleLayout, highlightedIndices)
-      : addHighlight(threeCircleLayout, highlightedIndices),
-  );
+  const [chartLayout, setChartLayout] = useState<GraphicComponentOption[]>([]);
   const [option, setOption] = useState<EChartsOption>({});
-  const [disableCursor, setDisableCursor] = useState(false);
-
+  const [currentMouseOver, setCurrentMouseOver] = useState("");
   const labelLayout = twoCircles
     ? twoCircleLabelLayout
     : threeCircleLabelLayout;
@@ -517,68 +541,44 @@ export const useLayout = ({
     ? twoCircleOuterLabelLayout
     : threeCircleOuterLabelLayout;
 
-  const onmouseover = useDeepCompareCallback(
-    (event: ElementEvent) => {
-      // If the event is from a child element, parse the parent id to use
+  const handleEvent = useDeepCompareCallback(
+    (event: ElementEvent, type: "mouseover" | "mouseout" | "click") => {
       const eventId = String(event.target.id);
       const id = eventId.includes(".") ? eventId.split(".")[0] : eventId;
+      const element = chartData.find((datum) => datum.key === id);
+      const isCursorAllowed = element?.value !== 0;
 
-      setChartLayout(
-        twoCircles
-          ? addHighlight(twoCircleLayout, [...highlightedIndices, id])
-          : addHighlight(threeCircleLayout, [...highlightedIndices, id]),
-      );
-      const element = chartData.filter((datum) => datum.key === id);
-      if (element[0].value === 0) {
-        console.log("HEREEEEEE!!!");
-        setDisableCursor(true);
+      if (type === "mouseover") {
+        setCurrentMouseOver(id);
+        setChartLayout(
+          getLayout(twoCircles, highlightedIndices, id, isCursorAllowed),
+        );
+      } else if (type === "mouseout") {
+        setChartLayout(getLayout(twoCircles, highlightedIndices));
+        setCurrentMouseOver("");
+      } else if (type === "click" && isCursorAllowed) {
+        onClickHandler(id);
       }
     },
-    [highlightedIndices, twoCircles, chartData],
-  );
-
-  const onmouseout = useDeepCompareCallback(() => {
-    setChartLayout(
-      twoCircles
-        ? addHighlight(twoCircleLayout, highlightedIndices)
-        : addHighlight(threeCircleLayout, highlightedIndices),
-    );
-    setDisableCursor(false);
-  }, [twoCircles, highlightedIndices]);
-
-  const onclick = useDeepCompareCallback(
-    (event: ElementEvent) => {
-      // If the event is from a child element, parse the parent id to use
-      const eventId = String(event.target.id);
-
-      const id = eventId.includes(".") ? eventId.split(".")[0] : eventId;
-      const element = chartData.filter((datum) => datum.key === id);
-      if (element[0].value === 0) return;
-      onClickHandler(id);
-    },
-    [onClickHandler, chartData],
+    [highlightedIndices, twoCircles, chartData, onClickHandler],
   );
 
   const addEvents = useCallback(
-    (chartLayout: GraphicComponentOption[], interactable: boolean) => {
-      return interactable
-        ? chartLayout.map((section) => ({
+    (layout: GraphicComponentOption[]) =>
+      interactable
+        ? layout.map((section) => ({
             ...section,
-            onmouseover,
-            onmouseout,
-            onclick,
+            onmouseover: (event: ElementEvent) =>
+              handleEvent(event, "mouseover"),
+            onmouseout: (event: ElementEvent) => handleEvent(event, "mouseout"),
+            onclick: (event: ElementEvent) => handleEvent(event, "click"),
           }))
-        : chartLayout;
-    },
-    [onmouseover, onmouseout, onclick],
+        : layout,
+    [handleEvent, interactable],
   );
 
   useEffect(() => {
-    setChartLayout(
-      twoCircles
-        ? addHighlight(twoCircleLayout, highlightedIndices)
-        : addHighlight(threeCircleLayout, highlightedIndices),
-    );
+    setChartLayout(getLayout(twoCircles, highlightedIndices));
   }, [highlightedIndices, twoCircles]);
 
   useDeepCompareEffect(() => {
@@ -590,7 +590,7 @@ export const useLayout = ({
         },
       },
       graphic: [
-        ...addEvents(chartLayout, interactable),
+        ...addEvents(chartLayout),
         ...outerLabelLayout.map((labelConfig, idx) => ({
           ...labelConfig,
           style: {
@@ -606,15 +606,26 @@ export const useLayout = ({
         {
           type: "custom" as const,
           z: 300,
-          renderItem: (params, api) => {
+          renderItem: (
+            params: CustomSeriesRenderItemParams,
+            api: CustomSeriesRenderItemAPI,
+          ) => {
+            const dataIndex = params?.dataIndex;
+            const key = chartData[dataIndex]?.key;
+            const dataValue = chartData[dataIndex]?.value;
             return {
               type: "text",
-              ...labelLayout[chartData[params.dataIndex].key],
+              ...labelLayout[key],
               style: {
                 text: api.value(0).toLocaleString(),
                 textAlign: "middle",
-                fill: "#333333",
+                fill:
+                  dataValue === 0 && currentMouseOver === key
+                    ? NOT_ALLOWED_TEXT
+                    : "#333333",
               },
+              scaleX: 1.5,
+              scaleY: 1.5,
             };
           },
           data: chartData,
@@ -622,9 +633,10 @@ export const useLayout = ({
             formatter: (params) => {
               const dataIndex = params?.dataIndex;
               const dataValue = chartData[dataIndex]?.value;
-              if (dataValue === 0) return `This region contains 0 items`;
+              return dataValue === 0
+                ? `This region contains 0 items`
+                : undefined;
             },
-            // position: ["50%", "50%"],
             borderWidth: 0,
             backgroundColor: "black",
             textStyle: {
@@ -634,7 +646,6 @@ export const useLayout = ({
         },
       ],
     };
-    // console.log({ fullChartOption });
     setOption(fullChartOption);
   }, [
     chartLayout,
@@ -646,7 +657,8 @@ export const useLayout = ({
     chartData,
     labelLayout,
     ariaLabel,
+    currentMouseOver,
   ]);
 
-  return { option, disableCursor };
+  return option;
 };

--- a/packages/portal-proto/src/features/cohortComparison/AdditionalCohortSelection.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/AdditionalCohortSelection.tsx
@@ -49,6 +49,8 @@ const AdditionalCohortSelection: React.FC<AdditionalCohortSelectionProps> = ({
           <Tooltip
             label="Cohort is empty"
             disabled={row.original?.counts.caseCount !== 0}
+            position="right"
+            className="cursor-not-allowed"
           >
             <input
               data-testid={`button-${row.original.name}-cohort-comparison`}

--- a/packages/portal-proto/src/features/set-operations/SetOperationTable.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationTable.tsx
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-table";
 import { useMemo, useState, useId } from "react";
 import CountButtonWrapperForSetsAndCases from "./CountButtonWrapperForSetsAndCases";
-import { Checkbox } from "@mantine/core";
+import { Checkbox, Tooltip } from "@mantine/core";
 import { createSetFiltersByKey, ENTITY_TYPE_TO_CREATE_SET_HOOK } from "./utils";
 import { GqlOperation } from "@gff/core";
 import { pickBy } from "lodash";
@@ -87,21 +87,28 @@ export const SetOperationTable = ({
         id: "select",
         header: "Select",
         cell: ({ row }) => (
-          <Checkbox
-            size="xs"
-            classNames={{
-              input: "checked:bg-accent checked:border-accent",
-            }}
-            value={row.original.operationKey}
-            id={`${componentId}-setOperation-${row.original.operationKey}`}
-            checked={selectedSets[row.original.operationKey]}
-            onChange={(e) => {
-              setSelectedSets({
-                ...selectedSets,
-                [e.target.value]: !selectedSets[e.target.value],
-              });
-            }}
-          />
+          <Tooltip
+            label="This region contains 0 items"
+            disabled={row.original.count !== 0}
+            position="right"
+          >
+            <Checkbox
+              size="xs"
+              classNames={{
+                input: "checked:bg-accent checked:border-accent",
+              }}
+              value={row.original.operationKey}
+              id={`${componentId}-setOperation-${row.original.operationKey}`}
+              checked={selectedSets[row.original.operationKey]}
+              onChange={(e) => {
+                setSelectedSets({
+                  ...selectedSets,
+                  [e.target.value]: !selectedSets[e.target.value],
+                });
+              }}
+              disabled={row.original.count === 0}
+            />
+          </Tooltip>
         ),
       },
       setOperationTableColumnsHelper.accessor("setOperation", {


### PR DESCRIPTION
## Description
1. Updated Venn Diagram to include checking for values and changing cursor type, background color and text color
2. Updated echarts to `5.5.0`
3. Updated Saved Sets Table to include disable for checkbox with 0 sets
4. Updated Set Ops Table to include disable for checkbox with 0 sets

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [X] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![Set Ops](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/6697a05f-e4eb-4765-ad36-0ea37ddf0b68)
