### PR TITLE
PEAR-2011: Cohort Comparison Demo - Link “View Venn diagram in Set Operations” leads to an "unexpected error" modal

### DIFF
--- a/packages/portal-proto/src/features/set-operations/SetOperationChartsForCohorts.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationChartsForCohorts.tsx
@@ -36,8 +36,11 @@ const SetOperationChartsForCohorts = ({
     useCreateCaseSetFromFiltersMutation();
 
   const ids = useDeepCompareMemo(
-    () => selectedEntities.map((e) => e.id),
-    [selectedEntities],
+    () =>
+      isCohortComparisonDemo
+        ? [cohortComparisonDemo1.id, cohortComparisonDemo2.id]
+        : selectedEntities.map((e) => e.id),
+    [isCohortComparisonDemo, selectedEntities],
   );
   const cohorts = useCoreSelector((state) =>
     selectMultipleCohortsById(state, ids),


### PR DESCRIPTION
## Description
Resolves error with Veen diagram link when in Cohort Comparision demo
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
