### PR TITLE
Sjpp client 2.63.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,9 +5798,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.61.2",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.61.2.tgz",
-      "integrity": "sha512-6hLL5+I2x4pH+Gk0HUY8bNzpjFZeta9RHXZWZW3jgr01VLYREaFxGsnfJE0XRBhGww7tm0kwMcZOBrUoDpXzOw=="
+      "version": "2.63.3",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.63.3.tgz",
+      "integrity": "sha512-5lklz7BBO6kA1HaQpTGJDMT25Y34ueVCI/TnWZahkPainVzyQEFuZfNswIuX6pLcP+xBGPTiagNJNOZ3nhq2jA=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26148,7 +26148,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.61.2",
+        "@sjcrh/proteinpaint-client": "^2.63.3",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -29,7 +29,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.61.2",
+    "@sjcrh/proteinpaint-client": "^2.63.3",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Features
- Add advanced OncoMatrix sorting options for power users
- Added sorting samples options for hierarchical clustering 
- GDC bam app can visualize truncated bam slice when streaming is terminated due to hitting max size
- Supported gene expression filtering

Fixes
- Make OncoMatrix react to divide-by term edits from the label click menu
- Fix the continuous term scale for density plots
- test run on all genome tabix files on server launch to detect old index file issue early
- Limit the css reset to not conflict with embedder styles, by using scoped normalize css rules
- scope PP-specific css resets and styles to the root holder, such as the previously unscoped h2 style

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
