### PR TITLE
PEAR-1999: Fix for Customize Column - Rapidly clicking options causes "Unexpected Error" modal to appear

### DIFF
--- a/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
+++ b/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
@@ -75,10 +75,11 @@ function ColumnOrdering<TData>({
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
-    if (active?.id !== over?.id) {
+    if (active?.id && over?.id && active?.id !== over?.id) {
+      console.log({ active, over });
       setColumnOrder((items) => {
-        const oldIndex = items.indexOf(active.id as string);
-        const newIndex = items.indexOf(over.id as string);
+        const oldIndex = items.indexOf(active?.id as string);
+        const newIndex = items.indexOf(over?.id as string);
 
         return arrayMove(items, oldIndex, newIndex);
       });

--- a/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
+++ b/packages/portal-proto/src/components/Table/ColumnOrdering.tsx
@@ -76,7 +76,6 @@ function ColumnOrdering<TData>({
     const { active, over } = event;
 
     if (active?.id && over?.id && active?.id !== over?.id) {
-      console.log({ active, over });
       setColumnOrder((items) => {
         const oldIndex = items.indexOf(active?.id as string);
         const newIndex = items.indexOf(over?.id as string);


### PR DESCRIPTION
## Description
In some scenario ids of `active` and `over` were null. 
@bpierce01 verified the branch that it's not happening anymore.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
