### PR TITLE
PEAR-2021: Fix for Left panel of Mutation Frequency disappears at smaller widths

### DIFF
--- a/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
+++ b/packages/portal-proto/src/features/genomic/GenesAndMutationFrequencyAnalysisTool.tsx
@@ -170,7 +170,7 @@ const GenesAndMutationFrequencyAnalysisTool: React.FC = () => {
           classNames={{
             tab: SecondaryTabStyle,
             list: "px-2 mt-2 border-0 gap-0",
-            root: "bg-base-max border-0 w-full overflow-x-clip",
+            root: "bg-base-max border-0 w-full overflow-x-hidden",
           }}
           onChange={handleTabChanged}
           keepMounted={false}


### PR DESCRIPTION
## Description

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
### 1280 px 
![lMutationFrequencyApp](https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/5339c587-38a9-4f13-a925-ff43c910c03a)
