### PR TITLE
PEAR-1379 - Cohort Builder - Inconsistent behavior when removing filters 

### DIFF
--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useDeepCompareMemo } from "use-deep-compare";
 import { useDeepCompareEffect } from "react-use";
 import {
   MdClose as CloseIcon,
@@ -790,7 +791,7 @@ const NumericRangePanel: React.FC<NumericFacetData> = ({
   const adjMaximum = maximum != undefined ? maximum : 999999;
 
   const filter = hooks.useGetFacetFilters(field);
-  const [filterValues] = useMemo(() => {
+  const [filterValues] = useDeepCompareMemo(() => {
     const values = extractRangeValues<number>(filter);
     const key = ClassifyRangeType(values);
     return [values, key];

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -352,7 +352,11 @@ const FromTo: React.FC<FromToProps> = ({
             min={lowerUnitRange}
             max={upperUnitRange}
             // units are always days
-            value={adjustDaysToYearsIfUnitsAreYears(fromValue, units)}
+            value={
+              fromValue
+                ? adjustDaysToYearsIfUnitsAreYears(fromValue, units)
+                : ""
+            }
             onChange={(value) => {
               if (value === "" || typeof value === "string") return;
               setFromValue(
@@ -399,7 +403,9 @@ const FromTo: React.FC<FromToProps> = ({
               );
               changedCallback();
             }}
-            value={adjustDaysToYearsIfUnitsAreYears(toValue, units)}
+            value={
+              toValue ? adjustDaysToYearsIfUnitsAreYears(toValue, units) : ""
+            }
             hideControls
             aria-label="input to value"
           />
@@ -782,12 +788,21 @@ const NumericRangePanel: React.FC<NumericFacetData> = ({
 }: NumericFacetData) => {
   const adjMinimum = minimum != undefined ? minimum : 0;
   const adjMaximum = maximum != undefined ? maximum : 999999;
+
+  const filter = hooks.useGetFacetFilters(field);
+  const [filterValues] = useMemo(() => {
+    const values = extractRangeValues<number>(filter);
+    const key = ClassifyRangeType(values);
+    return [values, key];
+  }, [filter]);
+
   return (
     <div>
       <FromTo
         field={field}
         minimum={adjMinimum}
         maximum={adjMaximum}
+        values={filterValues}
         units="range"
         {...hooks}
         clearValues={clearValues}


### PR DESCRIPTION
## Description
Value for NumberInput needs to be an empty string instead of undefined to clear out the value according to mantine 🤷‍♀️ https://github.com/mantinedev/mantine/issues/6483

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
