### PR TITLE
PEAR-1967: Hide the Reference Genome section in the file summary page for some types of files

### DIFF
--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -161,6 +161,7 @@ export const FileView: React.FC<FileViewProps> = ({
       ]),
     [file],
   );
+
   const formattedDataForAnalysis = useDeepCompareMemo(
     () =>
       formatDataForHorizontalTable(file, [
@@ -171,7 +172,7 @@ export const FileView: React.FC<FileViewProps> = ({
         {
           field: "analysis.updated_datetime",
           name: "Workflow Completion Date",
-          modifier: (v) => v.split("T")[0],
+          modifier: (v) => v?.split("T")[0],
         },
       ]),
     [file],

--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useDeepCompareCallback } from "use-deep-compare";
+import { useDeepCompareMemo } from "use-deep-compare";
 import {
   GdcFile,
   HistoryDefaults,
@@ -99,8 +99,9 @@ export const FileView: React.FC<FileViewProps> = ({
   const [bamActive, setBamActive] = useState(false);
   const [fileToDownload, setFileToDownload] = useState(file);
   const isFileInCart = fileInCart(currentCart, file.file_id);
+  const shouldDisplayRefGenome = shouldDisplayReferenceGenome(file);
 
-  const formatDataForFileProperties = useDeepCompareCallback(
+  const formattedDataForFileProperties = useDeepCompareMemo(
     () =>
       formatDataForHorizontalTable(file, [
         {
@@ -138,7 +139,7 @@ export const FileView: React.FC<FileViewProps> = ({
     [file],
   );
 
-  const formatDataForDataInformation = useDeepCompareCallback(
+  const formattedDataForDataInformation = useDeepCompareMemo(
     () =>
       formatDataForHorizontalTable(file, [
         {
@@ -160,8 +161,7 @@ export const FileView: React.FC<FileViewProps> = ({
       ]),
     [file],
   );
-
-  const formatDataForAnalysis = useDeepCompareCallback(
+  const formattedDataForAnalysis = useDeepCompareMemo(
     () =>
       formatDataForHorizontalTable(file, [
         {
@@ -199,13 +199,13 @@ export const FileView: React.FC<FileViewProps> = ({
             <SummaryCard
               customDataTestID="table-file-properties-file-summary"
               title="File Properties"
-              tableData={formatDataForFileProperties()}
+              tableData={formattedDataForFileProperties}
             />
           </div>
           <div className="flex-1">
             <SummaryCard
               customDataTestID="table-data-information-file-summary"
-              tableData={formatDataForDataInformation()}
+              tableData={formattedDataForDataInformation}
               title="Data Information"
             />
           </div>
@@ -241,25 +241,41 @@ export const FileView: React.FC<FileViewProps> = ({
         {file?.analysis && (
           <>
             <div className="mt-14 flex gap-8">
-              <div className="flex-1">
-                <SummaryCard
-                  customDataTestID="table-analysis-file-summary"
-                  title="Analysis"
-                  tableData={formatDataForAnalysis()}
-                />
+              <div className={`flex-1 ${!shouldDisplayRefGenome && "flex"}`}>
+                <div className="basis-1/2">
+                  <SummaryCard
+                    customDataTestID="table-analysis-file-summary"
+                    title="Analysis"
+                    tableData={
+                      shouldDisplayRefGenome
+                        ? formattedDataForAnalysis
+                        : [formattedDataForAnalysis[0]]
+                    }
+                  />
+                </div>
+                {!shouldDisplayRefGenome && (
+                  <div className="basis-1/2">
+                    <SummaryCard
+                      customDataTestID="table-analysis-file-summary"
+                      title="" // should be empty
+                      tableData={[formattedDataForAnalysis[1]]}
+                    />
+                  </div>
+                )}
               </div>
-              {shouldDisplayReferenceGenome(file) ? (
+
+              {shouldDisplayRefGenome && (
                 <div className="flex-1">
                   <SummaryCard
                     customDataTestID="table-reference-genome-file-summary"
                     title="Reference Genome"
                     tableData={[
-                      { headerName: "Genome Build	", values: ["GRCh38.p0"] },
-                      { headerName: "Genome Name	", values: ["GRCh38.d1.vd1"] },
+                      { headerName: "Genome Build", values: ["GRCh38.p0"] },
+                      { headerName: "Genome Name", values: ["GRCh38.d1.vd1"] },
                     ]}
                   />
                 </div>
-              ) : null}
+              )}
             </div>
             {file?.analysis?.input_files?.length > 0 && (
               <DivWithMargin>

--- a/packages/portal-proto/src/features/files/FileView.tsx
+++ b/packages/portal-proto/src/features/files/FileView.tsx
@@ -17,6 +17,7 @@ import {
   formatDataForHorizontalTable,
   mapGdcFileToCartFile,
   parseSlideDetailsInfo,
+  shouldDisplayReferenceGenome,
 } from "./utils";
 import { BAMSlicingModal } from "@/components/Modals/BAMSlicingModal/BAMSlicingModal";
 import { NoAccessToProjectModal } from "@/components/Modals/NoAccessToProjectModal";
@@ -247,16 +248,18 @@ export const FileView: React.FC<FileViewProps> = ({
                   tableData={formatDataForAnalysis()}
                 />
               </div>
-              <div className="flex-1">
-                <SummaryCard
-                  customDataTestID="table-reference-genome-file-summary"
-                  title="Reference Genome"
-                  tableData={[
-                    { headerName: "Genome Build	", values: ["GRCh38.p0"] },
-                    { headerName: "Genome Name	", values: ["GRCh38.d1.vd1"] },
-                  ]}
-                />
-              </div>
+              {shouldDisplayReferenceGenome(file) ? (
+                <div className="flex-1">
+                  <SummaryCard
+                    customDataTestID="table-reference-genome-file-summary"
+                    title="Reference Genome"
+                    tableData={[
+                      { headerName: "Genome Build	", values: ["GRCh38.p0"] },
+                      { headerName: "Genome Name	", values: ["GRCh38.d1.vd1"] },
+                    ]}
+                  />
+                </div>
+              ) : null}
             </div>
             {file?.analysis?.input_files?.length > 0 && (
               <DivWithMargin>

--- a/packages/portal-proto/src/features/files/utils.ts
+++ b/packages/portal-proto/src/features/files/utils.ts
@@ -152,3 +152,19 @@ export const mapGdcFileToCartFile = (
       "file_name",
     ]),
   );
+
+export const REF_GENOME_EXCLUDED_TYPES = {
+  fileType: ["masked_methylation_array"],
+  workflow_type: ["Birdseed"],
+};
+
+export const shouldDisplayReferenceGenome = (file: GdcFile) => {
+  const isIncluded = (type: string, value: string) => {
+    return REF_GENOME_EXCLUDED_TYPES[type]?.includes(value);
+  };
+
+  return (
+    !isIncluded("fileType", file.fileType) &&
+    !isIncluded("workflow_type", file?.analysis?.workflow_type)
+  );
+};


### PR DESCRIPTION
## Description
To test (file uuid):
for type=masked_methylation_array:
c2d2fef9-49ff-494c-b0ab-b167bbf25611
65222d07-12fe-4a65-b82a-f142e18068a3
89116004-c98f-4c0e-95e2-7ac44efe0368
for Birdseed:
c9abd52d-d9a7-48ca-bdee-80a5911a84c2
8e5188c9-9ed9-44aa-808c-567f18125fa0
353b4340-17e1-445c-bef9-6a14ffc49ab5

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
