### PR TITLE
PEAR-2023 - Searching for particular Entity UUID causes application error

### DIFF
--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -53,7 +53,7 @@ export const QuickSearch = (): JSX.Element => {
       setLoading(false);
       setMatchedSearchList([]);
     } else if (query === debounced) {
-      if (fileHistory !== undefined) {
+      if (fileHistory !== undefined && fileHistory.length > 0) {
         const latestVersion = fileHistory.find(
           (f) => f.file_change === "released",
         )?.uuid;

--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -198,9 +198,11 @@ export const QuickSearch = (): JSX.Element => {
       searchable
       nothingFoundMessage={
         //This is so it does not show no results when loading or when user has not entered anything
-        searchText.length > 0 && debounced.length > 0 && !loading
-          ? "No results found"
-          : undefined
+        searchText.length > 0 && debounced.length > 0 && !loading ? (
+          <span data-testid="no-results-quick-search-bar">
+            {"No results found"}
+          </span>
+        ) : undefined
       }
       onSearchChange={(query) => {
         setLoading(true);

--- a/packages/portal-proto/src/components/QuickSearch/tests/QuickSearch.unit.test.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/tests/QuickSearch.unit.test.tsx
@@ -73,4 +73,28 @@ describe("<QuickSearch />", () => {
       "444-555File 111-222 has been updatedCategory: File",
     );
   });
+
+  test("displays no results found if history is empty", async () => {
+    jest.spyOn(core, "useQuickSearchQuery").mockReturnValue({
+      data: {
+        searchList: [],
+        query: "111-222",
+      },
+    } as any);
+    jest.spyOn(core, "useGetHistoryQuery").mockReturnValue({
+      data: [],
+    } as any);
+
+    const { getByTestId } = render(<QuickSearch />);
+    userEvent.click(getByTestId("textbox-quick-search-bar"));
+    userEvent.type(getByTestId("textbox-quick-search-bar"), "111-222");
+
+    await waitFor(
+      () =>
+        expect(getByTestId("no-results-quick-search-bar")).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    const noResults = getByTestId("no-results-quick-search-bar");
+    expect(noResults).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Description
Code was erroneously adding an empty entry to matchedSeartchList when history endpoint returned an empty array 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
