### PR TITLE
PEAR-1957: Fix for BAM Slicing description has a different styling

### DIFF
--- a/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/AnalysisCard.tsx
@@ -134,7 +134,7 @@ const AnalysisCard: React.FC<AnalysisCardProps> = ({
         <div
           data-testid="text-description-tool"
           style={{ height: descriptionVisible ? descHeight : 0 }}
-          className="transition-[height] duration-300 bg-primary-lightest overflow-hidden -mx-1.5 mb-1"
+          className="transition-[height] duration-300 bg-primary-lightest overflow-hidden w-full mb-1"
           aria-hidden={!descriptionVisible}
         >
           <div


### PR DESCRIPTION
## Description
After talking to @cemile-ctds we decided not to extend the description to the full width of the card. It created a messy look and made it not aligned. 
Now the description takes the full width of the card minus the margin.

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="183" alt="Screenshot 2024-07-10 at 10 56 58 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/6ee579e4-af5d-43a7-b201-b61b87e23db7">
<img width="195" alt="Screenshot 2024-07-10 at 10 57 06 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/837fe735-ffa1-4b5b-8ece-0851850c06ed">
<img width="196" alt="Screenshot 2024-07-10 at 10 57 11 AM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/5f759ef3-d138-46e8-8cb5-e0069dabb3df">
