### PR TITLE
PEAR-1311+1881: Limit height of custom filters and string cards, scrollbars

### DIFF
--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -147,7 +147,8 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
             : remainingValues > 0
             ? Math.min(96, remainingValues * 5 + 40)
             : 24;
-        return `flex-none  h-${cardHeight} overflow-y-scroll `;
+        /* h-96 is max height for the content of ExactValueFacet, EnumFacet, UploadFacet */
+        return `flex-none h-${cardHeight} overflow-y-scroll `;
       } else {
         return "overflow-hidden h-auto";
       }

--- a/packages/portal-proto/src/features/facets/ExactValueFacet.tsx
+++ b/packages/portal-proto/src/features/facets/ExactValueFacet.tsx
@@ -115,7 +115,7 @@ const ExactValueFacet: React.FC<ExactValueProps> = ({
     <div
       className={`flex flex-col ${
         width ? width : "mx-0"
-      } bg-base-max relative shadow-lg border-base-lighter border-1 rounded-b-md text-xs transition`}
+      } bg-base-max relative border-base-lighter border-1 rounded-b-md text-xs transition`}
     >
       <FacetHeader>
         <Tooltip
@@ -173,7 +173,12 @@ const ExactValueFacet: React.FC<ExactValueProps> = ({
           <PlusIcon />
         </ActionIcon>
       </div>
-      <Group gap="xs" className="px-2 py-1" data-testid="values group">
+      {/* h-96 is max height for the content of ExactValueFacet, EnumFacet, UploadFacet */}
+      <Group
+        gap="xs"
+        className="px-2 py-1 max-h-96 overflow-y-auto"
+        data-testid="values group"
+      >
         {textValues.map((x) => (
           <Badge
             size="sm"

--- a/packages/portal-proto/src/features/facets/ExactValueFacet.tsx
+++ b/packages/portal-proto/src/features/facets/ExactValueFacet.tsx
@@ -176,7 +176,7 @@ const ExactValueFacet: React.FC<ExactValueProps> = ({
       {/* h-96 is max height for the content of ExactValueFacet, EnumFacet, UploadFacet */}
       <Group
         gap="xs"
-        className="px-2 py-1 max-h-96 overflow-y-auto"
+        className="px-2 py-2 max-h-96 overflow-y-auto"
         data-testid="values group"
       >
         {textValues.map((x) => (

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -868,148 +868,147 @@ const NumericRangeFacet: React.FC<NumericFacetProps> = ({
     }
   }, [clearValues]);
   return (
-    <div id={field}>
-      <div
-        className={`flex flex-col ${
-          width ? width : "mx-0"
-        } bg-base-max relative border-base-lighter border-1 rounded-b-md text-xs transition`}
-      >
-        <FacetHeader>
-          <Tooltip
-            disabled={!description}
-            label={description}
-            position="bottom-start"
-            multiline
-            w={220}
-            withArrow
-            transitionProps={{ duration: 200, transition: "fade" }}
-          >
-            <FacetText>
-              {facetName ? facetName : fieldNameToTitle(field)}
-            </FacetText>
-          </Tooltip>
-          <div className="flex flex-row">
-            {rangeDatatype !== "range" && (
-              <Tooltip label={isFacetView ? "Chart view" : "Selection view"}>
-                <FacetIconButton
-                  onClick={toggleFlip}
-                  aria-pressed={!isFacetView}
-                  aria-label={isFacetView ? "Chart view" : "Selection view"}
-                >
-                  <FlipIcon size="1.45em" className={controlsIconStyle} />
-                </FacetIconButton>
-              </Tooltip>
-            )}
-            <Tooltip label="Clear selection">
+    <div
+      className={`flex flex-col ${
+        width ? width : "mx-0"
+      } bg-base-max relative border-base-lighter border-1 rounded-b-md text-xs transition`}
+      id={field}
+    >
+      <FacetHeader>
+        <Tooltip
+          disabled={!description}
+          label={description}
+          position="bottom-start"
+          multiline
+          w={220}
+          withArrow
+          transitionProps={{ duration: 200, transition: "fade" }}
+        >
+          <FacetText>
+            {facetName ? facetName : fieldNameToTitle(field)}
+          </FacetText>
+        </Tooltip>
+        <div className="flex flex-row">
+          {rangeDatatype !== "range" && (
+            <Tooltip label={isFacetView ? "Chart view" : "Selection view"}>
               <FacetIconButton
-                onClick={() => {
-                  clearFilters(field);
-                  setClearValues(true);
-                }}
-                aria-label="clear selection"
+                onClick={toggleFlip}
+                aria-pressed={!isFacetView}
+                aria-label={isFacetView ? "Chart view" : "Selection view"}
               >
-                <UndoIcon size="1.15em" />
+                <FlipIcon size="1.45em" className={controlsIconStyle} />
               </FacetIconButton>
             </Tooltip>
-            {dismissCallback ? (
-              <Tooltip label="Remove the facet">
-                <FacetIconButton
-                  onClick={() => {
-                    dismissCallback(field);
-                  }}
-                  aria-label="Remove the facet"
-                >
-                  <CloseIcon size="1.25em" />
-                </FacetIconButton>
-              </Tooltip>
-            ) : null}
-          </div>
-        </FacetHeader>
+          )}
+          <Tooltip label="Clear selection">
+            <FacetIconButton
+              onClick={() => {
+                clearFilters(field);
+                setClearValues(true);
+              }}
+              aria-label="clear selection"
+            >
+              <UndoIcon size="1.15em" />
+            </FacetIconButton>
+          </Tooltip>
+          {dismissCallback ? (
+            <Tooltip label="Remove the facet">
+              <FacetIconButton
+                onClick={() => {
+                  dismissCallback(field);
+                }}
+                aria-label="Remove the facet"
+              >
+                <CloseIcon size="1.25em" />
+              </FacetIconButton>
+            </Tooltip>
+          ) : null}
+        </div>
+      </FacetHeader>
+      {
         {
-          {
-            age: (
-              <DaysOrYears
-                valueLabel={valueLabel}
-                field={field}
-                rangeDatatype={rangeDatatype}
-                hooks={{ ...hooks }}
-                minimum={minimum}
-                maximum={maximum}
-                clearValues={clearValues}
-                isFacetView={isFacetView}
-              />
-            ),
-            age_in_years: (
-              <DaysOrYears
-                valueLabel={valueLabel}
-                field={field}
-                rangeDatatype={rangeDatatype}
-                hooks={{ ...hooks }}
-                minimum={minimum}
-                maximum={maximum}
-                clearValues={clearValues}
-                isFacetView={isFacetView}
-              />
-            ),
-            year: (
-              <Year
-                valueLabel={valueLabel}
-                field={field}
-                hooks={{ ...hooks }}
-                minimum={minimum}
-                maximum={maximum}
-                clearValues={clearValues}
-                isFacetView={isFacetView}
-              />
-            ),
-            years: (
-              <Years
-                valueLabel={valueLabel}
-                field={field}
-                hooks={{ ...hooks }}
-                minimum={minimum}
-                maximum={maximum}
-                clearValues={clearValues}
-                isFacetView={isFacetView}
-              />
-            ),
-            days: (
-              <DaysOrYears
-                valueLabel={valueLabel}
-                field={field}
-                rangeDatatype={rangeDatatype}
-                hooks={{ ...hooks }}
-                minimum={minimum}
-                maximum={maximum}
-                clearValues={clearValues}
-                isFacetView={isFacetView}
-              />
-            ),
-            percent: (
-              <PercentRange
-                valueLabel={valueLabel}
-                field={field}
-                hooks={{ ...hooks }}
-                minimum={minimum}
-                maximum={maximum}
-                clearValues={clearValues}
-                isFacetView={isFacetView}
-              />
-            ),
-            range: (
-              <NumericRangePanel
-                valueLabel={valueLabel}
-                field={field}
-                hooks={{ ...hooks }}
-                minimum={minimum}
-                maximum={maximum}
-                clearValues={clearValues}
-                isFacetView={isFacetView}
-              />
-            ),
-          }[rangeDatatype as string]
-        }
-      </div>
+          age: (
+            <DaysOrYears
+              valueLabel={valueLabel}
+              field={field}
+              rangeDatatype={rangeDatatype}
+              hooks={{ ...hooks }}
+              minimum={minimum}
+              maximum={maximum}
+              clearValues={clearValues}
+              isFacetView={isFacetView}
+            />
+          ),
+          age_in_years: (
+            <DaysOrYears
+              valueLabel={valueLabel}
+              field={field}
+              rangeDatatype={rangeDatatype}
+              hooks={{ ...hooks }}
+              minimum={minimum}
+              maximum={maximum}
+              clearValues={clearValues}
+              isFacetView={isFacetView}
+            />
+          ),
+          year: (
+            <Year
+              valueLabel={valueLabel}
+              field={field}
+              hooks={{ ...hooks }}
+              minimum={minimum}
+              maximum={maximum}
+              clearValues={clearValues}
+              isFacetView={isFacetView}
+            />
+          ),
+          years: (
+            <Years
+              valueLabel={valueLabel}
+              field={field}
+              hooks={{ ...hooks }}
+              minimum={minimum}
+              maximum={maximum}
+              clearValues={clearValues}
+              isFacetView={isFacetView}
+            />
+          ),
+          days: (
+            <DaysOrYears
+              valueLabel={valueLabel}
+              field={field}
+              rangeDatatype={rangeDatatype}
+              hooks={{ ...hooks }}
+              minimum={minimum}
+              maximum={maximum}
+              clearValues={clearValues}
+              isFacetView={isFacetView}
+            />
+          ),
+          percent: (
+            <PercentRange
+              valueLabel={valueLabel}
+              field={field}
+              hooks={{ ...hooks }}
+              minimum={minimum}
+              maximum={maximum}
+              clearValues={clearValues}
+              isFacetView={isFacetView}
+            />
+          ),
+          range: (
+            <NumericRangePanel
+              valueLabel={valueLabel}
+              field={field}
+              hooks={{ ...hooks }}
+              minimum={minimum}
+              maximum={maximum}
+              clearValues={clearValues}
+              isFacetView={isFacetView}
+            />
+          ),
+        }[rangeDatatype as string]
+      }
     </div>
   );
 };

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet.tsx
@@ -563,7 +563,11 @@ const RangeInputWithPrefixedRanges: React.FC<
   // otherwise this facet has some filters set and the custom range
   // should be shown
   if (isSuccess && filterValues === undefined && totalBuckets === 0) {
-    return <div className="mx-4 font-content pb-2">No data for this field</div>;
+    return (
+      <div className="mx-4 font-content pb-2 text-sm">
+        No data for this field
+      </div>
+    );
   }
 
   return (
@@ -683,7 +687,7 @@ const DaysOrYears: React.FC<NumericFacetData> = ({
   const numBuckets = 18;
 
   return (
-    <div className="flex flex-col w-100 space-y-2 px-2  mt-1 ">
+    <div className="flex flex-col w-100 space-y-2 px-2 mt-1 ">
       {hasData && (
         <SegmentedControl
           data={[
@@ -727,7 +731,7 @@ const Year: React.FC<NumericFacetData> = ({
   const numBuckets = Math.round((adjMaximum - adjMinimum) / 10);
 
   return (
-    <div className="flex flex-col w-100 space-y-2 px-2  mt-1 ">
+    <div className="flex flex-col w-100 space-y-2 px-2 mt-1 ">
       <RangeInputWithPrefixedRanges
         hooks={{ ...hooks }}
         units="year"

--- a/packages/portal-proto/src/features/facets/UploadFacet.tsx
+++ b/packages/portal-proto/src/features/facets/UploadFacet.tsx
@@ -124,7 +124,8 @@ const UploadFacet: React.FC<UploadFacetProps> = ({
             </Button>
           </Tooltip>
         </div>
-        <div className="mt-2">
+        {/* h-96 is max height for the content of ExactValueFacet, EnumFacet, UploadFacet */}
+        <div className="mt-2 max-h-96 overflow-y-auto">
           {noFilters ? null : (
             <div className="flex flex-wrap gap-1">
               {renderBadges(items as string[], field)}


### PR DESCRIPTION
## Description
Set max height to: h-96 (for all the facet cards)

Also, fixed https://gdc-ctds.atlassian.net/browse/PEAR-1881

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1440" alt="Screenshot 2024-07-10 at 3 32 52 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/d89a653c-8697-465e-a616-f93fc1140ee1">
<img width="1440" alt="Screenshot 2024-07-10 at 3 33 21 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/f7156d8a-4a0a-4dcb-a21e-ee854ce427d5">
<img width="1439" alt="Screenshot 2024-07-10 at 3 34 34 PM" src="https://github.com/NCI-GDC/gdc-frontend-framework/assets/101295912/5263916d-908e-4b93-8237-09bde31300c3">

![1881](https://github.com/user-attachments/assets/e49dbab5-a4ea-474d-86a5-8a7e73a10782)

