### PR TITLE
PEAR-1771: Fix for Slide Image Viewer - Selecting an image seems to be loading slower

### DIFF
--- a/packages/portal-proto/src/components/ImageViewer/ImageViewer.tsx
+++ b/packages/portal-proto/src/components/ImageViewer/ImageViewer.tsx
@@ -28,6 +28,7 @@ const InitOpenseadragon = (
     showNavigator: true,
     minZoomLevel: 0,
     showFullPageControl: false,
+    imageLoaderLimit: 1,
   });
 
   const fullPageButton = new OpenSeadragon.Button({


### PR DESCRIPTION
## Description

**imageLoaderLimit**
> The maximum number of image requests to make concurrently. By default it is set to 0 allowing the browser to make the maximum number of image requests in parallel as allowed by the browsers policy.

We might get rid of this feature hence I didn't do a lot. Adding this option helped reduce the number of simultaneous calls when not needed. 

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
