### PR TITLE
update the proteinpaint-client version to 2.69.1-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,9 +5798,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.63.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.63.3.tgz",
-      "integrity": "sha512-5lklz7BBO6kA1HaQpTGJDMT25Y34ueVCI/TnWZahkPainVzyQEFuZfNswIuX6pLcP+xBGPTiagNJNOZ3nhq2jA=="
+      "version": "2.69.1-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.69.1-0.tgz",
+      "integrity": "sha512-cuGDxBlOFxue7AI7ajDIj7IJ02S7JJJtn3/XNvQ4RjQh9/EFpf+1knK117ZYJlS4Vq8smDRuJN2eRzs9fe92gw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -26151,7 +26151,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.63.3",
+        "@sjcrh/proteinpaint-client": "^2.69.1-0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -29,7 +29,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.63.3",
+    "@sjcrh/proteinpaint-client": "^2.69.1-0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Features:
- OncoMatrix and GEC: allow to recompute term shown in continuous mode as zscore
- OncoMatrix: enable edit option for geneVariant terms
- OncoMatrix: handle custom matrix geneset input option
- OncoMatrix: support overall survival data
- OncoMatrix: allow gene expression term to pull data on all cases
- GEC: allow the drag/drop of rows from non-clustered row groups
- GEC: when screening user-defined gene sets, use a close-to-zero min_median_log2_uqfpkm parameter to keep more genes expressed at low level
- GEC: allow switching to other color scheme for heatmap

Fixes:
- OncoMatrix: hover/click menu over geneexp/metabolite rows should indicate term type, and do not show undefined for missing data
- GEC: speed up top variably expressed genes query from gdc api, directly submit case filter and do not first retrieve list of cases
- GEC: fix the error with group Add_Rows UI, which can only add compatible terms
- GEC: allow GDC gene exp scatter plot to show case name
- GEC: refactored not to pretend geneVariant term type
- GEC: set missing term type based on data type
- Barchart: pass filter0 in barchart request to work for gdc data
- Violin: fix error when clicking labels on violin plot breaks
- SingleCell native gene exp data is loaded from rds file; no longer grep

General:
- may handle geneExpression and metabolite as float terms

Devops:
- Improve OncoMatrix non-ci test to include gene expression and survival, and CNV-only cohort


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
