### PR TITLE
PEAR-2088: Fix for cDAVE: Search bar 'x' has popped out of format

### DIFF
--- a/packages/portal-proto/src/features/cDave/Controls.tsx
+++ b/packages/portal-proto/src/features/cDave/Controls.tsx
@@ -257,22 +257,26 @@ const Controls: React.FC<ControlPanelProps> = ({
         id="cdave-control-panel"
         data-testid="cdave-control-panel"
       >
-        <Input
-          data-testid="textbox-cdave-search-bar"
-          placeholder="Search"
-          className="py-2 pr-4"
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.currentTarget.value)}
-          rightSectionPointerEvents="all"
-          rightSection={
-            searchTerm && (
-              <ActionIcon onClick={() => setSearchTerm("")} variant="subtle">
-                <CloseIcon aria-label="clear search" />
-              </ActionIcon>
-            )
-          }
-          aria-label="Search fields"
-        />
+        <div className="mr-4">
+          <Input
+            data-testid="textbox-cdave-search-bar"
+            placeholder="Search"
+            className="py-2"
+            value={searchTerm}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setSearchTerm(e.target.value)
+            }
+            rightSectionPointerEvents="all"
+            rightSection={
+              searchTerm && (
+                <ActionIcon onClick={() => setSearchTerm("")} variant="subtle">
+                  <CloseIcon aria-label="clear search" />
+                </ActionIcon>
+              )
+            }
+            aria-label="Search fields"
+          />
+        </div>
         <p
           data-testid="text-fields-with-values"
           className="p-2 font-heading font-medium"


### PR DESCRIPTION
## Description

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![cdave](https://github.com/user-attachments/assets/f5b0f87d-5290-4ac2-920e-a9bd6364eff9)
