### PR TITLE
PEAR-2094 - Cohort Comparison Selection Screen - When hovering over a cohort radio button, a little 'no' symbol appears on the mouse

### DIFF
--- a/packages/portal-proto/src/features/cohortComparison/AdditionalCohortSelection.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/AdditionalCohortSelection.tsx
@@ -50,7 +50,6 @@ const AdditionalCohortSelection: React.FC<AdditionalCohortSelectionProps> = ({
             label="Cohort is empty"
             disabled={row.original?.counts.caseCount !== 0}
             position="right"
-            className="cursor-not-allowed"
           >
             <input
               data-testid={`button-${row.original.name}-cohort-comparison`}
@@ -63,6 +62,11 @@ const AdditionalCohortSelection: React.FC<AdditionalCohortSelectionProps> = ({
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={selectedCohort?.id === row.original.id}
               disabled={!row.original?.counts.caseCount}
+              className={
+                !row.original?.counts.caseCount
+                  ? "cursor-not-allowed"
+                  : undefined
+              }
             />
           </Tooltip>
         ),


### PR DESCRIPTION
## Description

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
