### PR TITLE
PEAR-2097 - Set Operations - Cannot select Gene or Mutation set checkbox

### DIFF
--- a/packages/portal-proto/src/features/set-operations/SelectionPanel.tsx
+++ b/packages/portal-proto/src/features/set-operations/SelectionPanel.tsx
@@ -429,7 +429,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
               size,
               from,
               total,
-              label: "sets",
+              label: "set",
             }}
             status={
               isGeneSuccess && isMutationSuccess ? "fulfilled" : "pending"

--- a/packages/portal-proto/src/features/set-operations/SetOperationChartsForCohorts.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationChartsForCohorts.tsx
@@ -41,18 +41,22 @@ const SetOperationChartsForCohorts = ({
     createSet0({
       filters: isCohortComparisonDemo
         ? buildCohortGqlOperator(cohortComparisonDemo1.filter)
-        : buildCohortGqlOperator(getCohortFilterForAPI(cohorts[0])),
+        : buildCohortGqlOperator(
+            cohorts[0] ? getCohortFilterForAPI(cohorts[0]) : undefined,
+          ),
       intent: "portal",
       set_type: "ephemeral",
     });
     createSet1({
       filters: isCohortComparisonDemo
         ? buildCohortGqlOperator(cohortComparisonDemo2.filter)
-        : buildCohortGqlOperator(getCohortFilterForAPI(cohorts[1])),
+        : buildCohortGqlOperator(
+            cohorts[1] ? getCohortFilterForAPI(cohorts[1]) : undefined,
+          ),
       intent: "portal",
       set_type: "ephemeral",
     });
-    if (cohorts?.length == 3)
+    if (cohorts?.length == 3 && cohorts[2])
       // if there are 3 cohorts, create the third one
       createSet2({
         filters: buildCohortGqlOperator(getCohortFilterForAPI(cohorts[2])),

--- a/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
@@ -50,10 +50,20 @@ const SetOperationsSelection = (): JSX.Element => {
   const isCohortComparisonDemo =
     cohort1Id === "demoCohort1Id" && cohort2Id === "demoCohort2Id";
 
+  useEffect(() => {
+    if (cohorts.length > 0 || isCohortComparisonDemo) {
+      setSelectedEntityType("cohort");
+
+      // A cohort has been deleted, kick user back to selection screen
+      if (cohorts.length < 2 && !isCohortComparisonDemo) {
+        setSelectionScreenOpen(true);
+      }
+    }
+  }, [cohorts, isCohortComparisonDemo, setSelectionScreenOpen]);
+
   return !ready ? (
     <LoadingOverlay data-testid="loading-spinner" visible />
-  ) : (!cohort1Id && !cohort2Id && selectionScreenOpen) ||
-    (cohorts.length < 2 && !isCohortComparisonDemo) ? (
+  ) : selectionScreenOpen ? (
     <SelectionPanel
       app={app}
       setActiveApp={setActiveApp}
@@ -70,7 +80,7 @@ const SetOperationsSelection = (): JSX.Element => {
       selectedEntityType={selectedEntityType}
       setSelectedEntityType={setSelectedEntityType}
     />
-  ) : !cohort1Id && !cohort2Id && selectedEntityType !== "cohort" ? ( // not a cohort, so presumably an existing gene or mutation set
+  ) : selectedEntityType !== "cohort" ? ( // not a cohort, so presumably an existing gene or mutation set
     // use the set operations panel as usual
     <SetOperationsChartsForGeneSSMS
       selectedEntities={selectedEntities}

--- a/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
@@ -53,15 +53,19 @@ const SetOperationsSelection = (): JSX.Element => {
   return !ready ? (
     <LoadingOverlay data-testid="loading-spinner" visible />
   ) : (!cohort1Id && !cohort2Id && selectionScreenOpen) ||
-    cohorts.length < 2 ? (
+    (cohorts.length < 2 && !isCohortComparisonDemo) ? (
     <SelectionPanel
       app={app}
       setActiveApp={setActiveApp}
       setOpen={setSelectionScreenOpen}
-      selectedEntities={cohorts.map((cohort) => ({
-        id: cohort.id,
-        name: cohort.name,
-      }))}
+      selectedEntities={
+        selectedEntityType === "cohort"
+          ? cohorts.map((cohort) => ({
+              id: cohort.id,
+              name: cohort.name,
+            }))
+          : selectedEntities
+      }
       setSelectedEntities={setSelectedEntities}
       selectedEntityType={selectedEntityType}
       setSelectedEntityType={setSelectedEntityType}

--- a/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
@@ -10,6 +10,7 @@ import SelectionPanel from "@/features/set-operations/SelectionPanel";
 import { useRouter } from "next/router";
 import { useCoreSelector, selectMultipleCohortsById } from "@gff/core";
 import { LoadingOverlay } from "@mantine/core";
+import { useDeepCompareEffect } from "use-deep-compare";
 
 const SetOperationsSelection = (): JSX.Element => {
   const [selectedEntities, setSelectedEntities] = useState<SelectedEntities>(
@@ -50,7 +51,7 @@ const SetOperationsSelection = (): JSX.Element => {
   const isCohortComparisonDemo =
     cohort1Id === "demoCohort1Id" && cohort2Id === "demoCohort2Id";
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (cohorts.length > 0 || isCohortComparisonDemo) {
       setSelectedEntityType("cohort");
 


### PR DESCRIPTION
## Description
\+ Cohort Comparison Demo - Clicking "View Venn Diagram in Set Operations" takes user to Set Operations selection screen instead 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
