### PR TITLE
(PEAR-2099): Warning Modal dismiss text change

### DIFF
--- a/packages/portal-proto/src/components/Modals/UserProfileModal.tsx
+++ b/packages/portal-proto/src/components/Modals/UserProfileModal.tsx
@@ -72,7 +72,7 @@ export const UserProfileModal = ({
       }
       openModal={openModal}
       size="60%"
-      buttons={[{ title: "Done", dataTestId: "button-user-profile-done" }]}
+      buttons={[{ title: "Close", dataTestId: "button-user-profile-done" }]}
     >
       <div className={`${!data ? "py-4" : "py-2"}`}>
         {data?.length > 0 ? (


### PR DESCRIPTION
## Description
- Warning Modal that appears when user has no controlled access the dismiss button should say "Close"  

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
