### PR TITLE
Documented parallel test execution QA-2275

### DIFF
--- a/holmes-py/README.md
+++ b/holmes-py/README.md
@@ -141,6 +141,23 @@ gauge run [args] [flags]
 ````bash
 PWDEBUG=1 gauge run specs
 ````
+
+### Execute Tests in Parallel
+Let gauge choose number of execution streams (depends on the number of CPU cores available):
+````bash
+gauge run --parallel specs
+````
+OR, choose number of streams:
+````bash
+gauge run --parallel -n=number_here specs
+````
+I found there was no difference in test success rate if you let gauge choose the number of
+execution streams, or if you specified a smaller amount. So, the best course of action is to let
+gauge choose the number of streams and finish the regression tests faster.
+
+If a test does fail, rerun them individually before reporting results.
+
+### Gauge Execution Documentation
 See [Run Gauge Specifications](https://docs.gauge.org/execution.html?os=macos&language=python&ide=vscode)
 
 This will also compile all the supporting code implementations.

--- a/holmes-py/env/default/default.properties
+++ b/holmes-py/env/default/default.properties
@@ -17,7 +17,8 @@ screenshot_on_failure = true
 logs_directory = logs
 
 # Parallel Execution using threads
-enable_multithreading = true
+# As of 08/19/2024, only the Java and .NET language runners supports parallel execution of specs by using threads.
+enable_multithreading = false
 
 # use for testing single apps purpose in a repo
 APP_ENDPOINT_PROD = https://portal.gdc.cancer.gov


### PR DESCRIPTION
## Description
- Documented how to run automated tests in parallel. 
- Using parallel execution, regression tests take about 10 minutes down from approximately 55 minutes. 
