### PR TITLE
update the proteinpaint-client version to 2.73.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5832,11 +5832,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.69.1-0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.69.1-0.tgz",
-      "integrity": "sha512-cuGDxBlOFxue7AI7ajDIj7IJ02S7JJJtn3/XNvQ4RjQh9/EFpf+1knK117ZYJlS4Vq8smDRuJN2eRzs9fe92gw=="
-    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "dev": true,
@@ -20437,8 +20432,9 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "license": "ISC"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -20587,7 +20583,6 @@
     },
     "node_modules/postcss-import": {
       "version": "14.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -21421,7 +21416,6 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -21429,7 +21423,6 @@
     },
     "node_modules/read-cache/node_modules/pify": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26242,7 +26235,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.69.1-0",
+        "@sjcrh/proteinpaint-client": "^2.73.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -26386,6 +26379,15 @@
         "react-dom": "^18.2.0"
       }
     },
+    "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.73.0.tgz",
+      "integrity": "sha512-ZZl5CKthaxNI7OaQyCdS3dOCptTILYq7CbtNgiOSKOkuDrbohSV8In21douckqAjMEYENC6RS2MKww/QjoNN+g==",
+      "peerDependencies": {
+        "postcss": "^8.4.41",
+        "postcss-import": "^14.1.0"
+      }
+    },
     "packages/portal-proto/node_modules/clsx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
@@ -26395,10 +26397,9 @@
       }
     },
     "packages/portal-proto/node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
-      "dev": true,
+      "version": "8.4.41",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -26415,7 +26416,7 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "source-map-js": "^1.2.0"
       },
       "engines": {

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -29,7 +29,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.69.1-0",
+    "@sjcrh/proteinpaint-client": "^2.73.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/proteinpaint/dev.sh
+++ b/packages/portal-proto/src/features/proteinpaint/dev.sh
@@ -9,16 +9,15 @@ if [[ "$1" == "unlink" ]]; then
 else
 	# to test the local PP client code
 	npm link ../proteinpaint/client
+	# An issue with npm link and workspaces: the non-linked @sjcrh/proteinpaint-client package
+	# may be moved to portal-proto/node_modules, creating 2 separate modules of the same package,
+	# must ensure only the linked module is used for bundling so delete
+	rm -rf packages/portal-proto/node_modules/@sjcrh
+	# also not able to do a simpler
+	# `cd packages/portal-proto && npm link path/to/proteinpaint/client`,
+	# where the linked module would be in portal-proto/node_modules instead of the
+	# other way around
 fi
-
-# An issue with npm link and workspaces: the non-linked @sjcrh/proteinpaint-client package
-# may be moved to portal-proto/node_modules, creating 2 separate modules of the same package,
-# must ensure only the linked module is used for bundling so delete
-rm -rf packages/portal-proto/node_modules/@sjcrh
-# also not able to do a simpler
-# `cd packages/portal-proto && npm link path/to/proteinpaint/client`,
-# where the linked module would be in portal-proto/node_modules instead of the
-# other way around
 
 # sometimes the nextjs bundle cache are stale after npm link
 rm -rf packages/portal-proto/.next


### PR DESCRIPTION
## Description

Features:
- In the gene set edit UI: If available in the dataset, more controls are available to edit gene lists for top variably expressed genes.

Fixes:
- fix the error that when hiercluster is using divideBy, the tw will not show in Cases menu for gdc"
- from matrix term group edit menu, term group name submit button will close the term group edit menu.
- fix the error: from matrix term group edit menu, delete group name and submit still show the old name.
- Assign alive/dead labels to GDC survival exit codes


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
