### PR TITLE
PEAR-748: Add spinners when loading or redrawing can be slow or confusing [PART2]

### DIFF
--- a/packages/portal-proto/src/features/cohortComparison/CohortCard.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/CohortCard.tsx
@@ -20,9 +20,9 @@ interface CohortCardProps {
 }
 
 const DEFAULT_CHART_DATA = [
-  { key: "S1_minus_S2", value: 0, highlighted: false },
-  { key: "S2_minus_S1", value: 0, highlighted: false },
-  { key: "S1_intersect_S2", value: 0, highlighted: false },
+  { key: "S1_minus_S2", value: "...", highlighted: false },
+  { key: "S2_minus_S1", value: "...", highlighted: false },
+  { key: "S1_intersect_S2", value: "...", highlighted: false },
 ];
 
 const LABELS = ["S₁", "S₂"];

--- a/packages/portal-proto/src/features/cohortComparison/CohortCard.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/CohortCard.tsx
@@ -1,12 +1,8 @@
-import dynamic from "next/dynamic";
-import { LoadingOverlay, Paper } from "@mantine/core";
+import { Paper } from "@mantine/core";
 import { FIELD_LABELS } from "src/fields";
 import CohortVennDiagram from "./CohortVennDiagram";
 import Link from "next/link";
 import { CohortComparisonType } from "./CohortComparison";
-const VennDiagram = dynamic(() => import("@/features/charts/VennDiagram"), {
-  ssr: false,
-});
 
 interface CohortCardProps {
   readonly selectedCards: Record<string, boolean>;
@@ -18,14 +14,6 @@ interface CohortCardProps {
   readonly caseSetIds: string[];
   readonly casesFetching: boolean;
 }
-
-const DEFAULT_CHART_DATA = [
-  { key: "S1_minus_S2", value: "...", highlighted: false },
-  { key: "S2_minus_S1", value: "...", highlighted: false },
-  { key: "S1_intersect_S2", value: "...", highlighted: false },
-];
-
-const LABELS = ["S₁", "S₂"];
 
 const CohortCard: React.FC<CohortCardProps> = ({
   selectedCards,
@@ -89,22 +77,11 @@ const CohortCard: React.FC<CohortCardProps> = ({
       </div>
       <hr />
 
-      <div className="relative">
-        <LoadingOverlay
-          visible={casesFetching || counts.length === 0}
-          zIndex={1}
-        />
-        {caseSetIds.length > 0 && !(casesFetching || counts.length === 0) ? (
-          <CohortVennDiagram caseSetIds={caseSetIds} cohorts={cohorts} />
-        ) : (
-          <VennDiagram
-            chartData={DEFAULT_CHART_DATA}
-            labels={LABELS}
-            ariaLabel="The Venn diagram displays the number of cases shared between the cohorts."
-            interactable={false}
-          />
-        )}
-      </div>
+      <CohortVennDiagram
+        caseSetIds={caseSetIds}
+        cohorts={cohorts}
+        isLoading={casesFetching || counts.length === 0}
+      />
 
       <div className="-mt-8 mb-2 z-10 flex justify-center relative">
         <Link

--- a/packages/portal-proto/src/features/cohortComparison/CohortVennDiagram.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/CohortVennDiagram.tsx
@@ -4,8 +4,10 @@ import {
   useVennDiagramQuery,
   FilterSet,
 } from "@gff/core";
-
 import makeIntersectionFilters from "./makeIntersectionFilters";
+import { LoadingOverlay } from "@mantine/core";
+import { useDeepCompareMemo } from "use-deep-compare";
+
 const VennDiagram = dynamic(() => import("@/features/charts/VennDiagram"), {
   ssr: false,
 });
@@ -22,47 +24,72 @@ interface CohortVennDiagramProps {
     };
   };
   readonly caseSetIds: string[];
+  readonly isLoading: boolean;
 }
+
+const DEFAULT_CHART_DATA = [
+  { key: "S1_minus_S2", value: "...", highlighted: false },
+  { key: "S2_minus_S1", value: "...", highlighted: false },
+  { key: "S1_intersect_S2", value: "...", highlighted: false },
+];
+
+const LABELS = ["S₁", "S₂"];
 
 const CohortVennDiagram: React.FC<CohortVennDiagramProps> = ({
   cohorts,
   caseSetIds,
+  isLoading: externalLoading,
 }: CohortVennDiagramProps) => {
-  const filters = makeIntersectionFilters(
-    buildCohortGqlOperator(cohorts?.primary_cohort.filter),
-    buildCohortGqlOperator(cohorts?.comparison_cohort.filter),
-    caseSetIds,
+  const filters = useDeepCompareMemo(
+    () =>
+      makeIntersectionFilters(
+        buildCohortGqlOperator(cohorts?.primary_cohort.filter),
+        buildCohortGqlOperator(cohorts?.comparison_cohort.filter),
+        caseSetIds,
+      ),
+    [cohorts, caseSetIds],
   );
 
-  const { data } = useVennDiagramQuery({
+  const { data, isLoading: dataLoading } = useVennDiagramQuery({
     set1Filters: filters.cohort1,
     set2Filters: filters.cohort2,
     intersectionFilters: filters.intersection,
   });
 
+  const isLoading = externalLoading || dataLoading;
+
+  const chartData = useDeepCompareMemo(() => {
+    if (isLoading || !data) return DEFAULT_CHART_DATA;
+
+    return [
+      {
+        key: "S1_minus_S2",
+        value: data.set1?.hits?.total || 0,
+        highlighted: false,
+      },
+      {
+        key: "S2_minus_S1",
+        value: data.set2?.hits?.total || 0,
+        highlighted: false,
+      },
+      {
+        key: "S1_intersect_S2",
+        value: data.intersection?.hits?.total || 0,
+        highlighted: false,
+      },
+    ];
+  }, [isLoading, data]);
+
   return (
-    <VennDiagram
-      chartData={[
-        {
-          key: "S1_minus_S2",
-          value: data?.set1?.hits?.total || "...",
-          highlighted: false,
-        },
-        {
-          key: "S2_minus_S1",
-          value: data?.set2?.hits?.total || "...",
-          highlighted: false,
-        },
-        {
-          key: "S1_intersect_S2",
-          value: data?.intersection?.hits?.total || "...",
-          highlighted: false,
-        },
-      ]}
-      labels={["S₁", "S₂"]}
-      ariaLabel="The Venn diagram displays the number of cases shared between the cohorts."
-      interactable={false}
-    />
+    <div className="relative">
+      <LoadingOverlay visible={isLoading} zIndex={1} />
+      <VennDiagram
+        chartData={chartData}
+        labels={LABELS}
+        ariaLabel="The Venn diagram displays the number of cases shared between the cohorts."
+        interactable={false}
+      />
+    </div>
   );
 };
 

--- a/packages/portal-proto/src/features/cohortComparison/CohortVennDiagram.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/CohortVennDiagram.tsx
@@ -45,17 +45,17 @@ const CohortVennDiagram: React.FC<CohortVennDiagramProps> = ({
       chartData={[
         {
           key: "S1_minus_S2",
-          value: data?.set1?.hits?.total || 0,
+          value: data?.set1?.hits?.total || "...",
           highlighted: false,
         },
         {
           key: "S2_minus_S1",
-          value: data?.set2?.hits?.total || 0,
+          value: data?.set2?.hits?.total || "...",
           highlighted: false,
         },
         {
           key: "S1_intersect_S2",
-          value: data?.intersection?.hits?.total || 0,
+          value: data?.intersection?.hits?.total || "...",
           highlighted: false,
         },
       ]}

--- a/packages/portal-proto/src/features/facets/NumericRangeFacet/FromTo.tsx
+++ b/packages/portal-proto/src/features/facets/NumericRangeFacet/FromTo.tsx
@@ -212,7 +212,7 @@ const FromTo: React.FC<FromToProps> = ({
           (fromValueInDays !== undefined && fromValueInDays >= WARNING_DAYS),
       );
     }
-  }, [field, form.values.toValue, form.values.fromValue, units]);
+  }, [field, form.values.toValue, form.values.fromValue, units, queryInYears]);
 
   /**
    * Handle Apply button which will add/update/remove a range filter to the field.


### PR DESCRIPTION
## Description
Default value as "..." when the venn diagram is loading in cohort comparison app.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
