### PR TITLE
PEAR-1546: add axe-core for accessibility testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,25 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@axe-core/react": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.10.0.tgz",
+      "integrity": "sha512-gpFj1+G0zabbd0ZDum1N5FPJtUOfPIfslXNH58WuR7opSK0WTwPJ49ZlYr/Wg2fA4VGI5lfkG5fAZSG9p8ecKw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.0",
+        "requestidlecallback": "^0.3.0"
+      }
+    },
+    "node_modules/@axe-core/react/node_modules/axe-core": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/cli": {
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.24.1.tgz",
@@ -21980,6 +21999,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "dev": true,
@@ -26220,6 +26245,7 @@
       "version": "2.14.4",
       "license": "Apache-2",
       "dependencies": {
+        "@axe-core/react": "^4.10.0",
         "@datadog/browser-rum": "^5.23.3",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -14,6 +14,7 @@
     "test:all": "jest"
   },
   "dependencies": {
+    "@axe-core/react": "^4.10.0",
     "@datadog/browser-rum": "^5.23.3",
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/modifiers": "^6.0.1",

--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -20,7 +20,7 @@ import "@nci-gdc/sapien/dist/bodyplot.css";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 // ReactModal needs the app element set for a11y reasons.
 // It hides the main application from screen readers while modals are open.
 import ReactModal from "react-modal";
@@ -35,6 +35,15 @@ import { Notifications } from "@mantine/notifications";
 import "@mantine/notifications/styles.css";
 
 if (process.env.NODE_ENV !== "test") ReactModal.setAppElement("#__next");
+
+// Adds axe accessibility plugin in development/testing environments
+if (typeof window !== "undefined" && process.env.NODE_ENV !== "production") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ReactDOM = require("react-dom");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const axe = require("@axe-core/react");
+  axe(React, ReactDOM, 1000);
+}
 
 if (process.env.NEXT_PUBLIC_DD_ENABLED) {
   datadogRum.init({


### PR DESCRIPTION
## Description

This package adds axe-core/react support for non-production environments. See [@axe-core/react] (https://www.npmjs.com/package/@axe-core/react) for more details. The package also adds accessibility issues to the development console messages (in the screenshot below).
You can expand the list, and it will highlight which element has the issues. Each issue has a link to the relevant deque university page.

A configuration object can be passed to configure the messages; however, for this PR, the default config is being used. If needed, a configuration can be added later.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![image](https://github.com/user-attachments/assets/41236a17-b749-4561-a50d-c4fd9d2c99e2)

