### PR TITLE
PEAR-1968 restores case ID column to annotations table

### DIFF
--- a/packages/portal-proto/src/features/files/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/files/AnnotationsTable.tsx
@@ -30,7 +30,6 @@ import { useDeepCompareMemo } from "use-deep-compare";
 interface AnnotationsTableProps {
   readonly annotations: ReadonlyArray<FileAnnotationsType>;
 }
-// TODO when DEV-2653 is fixed, re-add case ID col, hide case UUID col by default
 type AnnotationTableData = Pick<
   FileAnnotationsType,
   | "annotation_id"
@@ -99,8 +98,7 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
   const [sortBy, setSortBy] = useState<SortBy[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    // TODO when DEV-2653 is fixed, re-add case ID col, hide case UUID col by default
-    // case_id: false,
+    case_id: false,
     entity_id: false,
     status: false,
     notes: false,
@@ -181,8 +179,11 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
         id: "case_id",
         header: "Case UUID",
         enableSorting: false,
-        // TODO when DEV-2653 is fixed, re-add case ID col, hide case UUID col by default
-        // cell: ({ getValue }) => getValue() ?? "--",
+        cell: ({ getValue }) => getValue() ?? "--",
+      }),
+      annotationsTableColumnHelper.accessor("case_submitter_id", {
+        id: "case_submitter_id",
+        header: "Case ID",
         cell: ({ getValue, row }) =>
           getValue() ? (
             <Link
@@ -195,22 +196,6 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
             "--"
           ),
       }),
-      // TODO when DEV-2653 is fixed, re-add case ID col, hide case UUID col by default
-      // annotationsTableColumnHelper.accessor("case_submitter_id", {
-      //   id: "case_submitter_id",
-      //   header: "Case ID",
-      //   cell: ({ getValue, row }) =>
-      //     getValue() ? (
-      //       <Link
-      //         href={`/cases/${row.original.case_id}`}
-      //         className="text-utility-link underline font-content"
-      //       >
-      //         {getValue()}
-      //       </Link>
-      //     ) : (
-      //       "--"
-      //     ),
-      // }),
       annotationsTableColumnHelper.accessor("entity_type", {
         id: "entity_type",
         header: "Entity Type",


### PR DESCRIPTION
## Description
Reverts the changes made in PEAR-1899 (previously done as workaround due to BE bug, which has now been fixed). 

File summary page > Annotations table:
- restore the Case ID column with link
- return case UUID column to being hidden by default

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1410" alt="Screenshot 2024-09-03 at 3 49 11 PM" src="https://github.com/user-attachments/assets/c1efdf02-428c-48d9-a74d-ac34d80ca3cc">

<img width="266" alt="Screenshot 2024-09-03 at 3 49 22 PM" src="https://github.com/user-attachments/assets/315d1c63-eec4-4b2c-8da3-8b03a62b48f1">
