### PR TITLE
PEAR-2013 - Cohort Builder Search - Odd results and ordering of results can appear

### DIFF
--- a/packages/portal-proto/src/components/SearchInput.tsx
+++ b/packages/portal-proto/src/components/SearchInput.tsx
@@ -338,10 +338,10 @@ export const SearchInput: React.FC = () => {
                   .slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
                   .map((result, index) => {
                     const matchingEnums = result?.enum
-                      .slice(0, MAX_MATCHED_VALUES)
                       .filter((e) =>
                         result.terms.some((t) => e.toLowerCase().includes(t)),
-                      );
+                      )
+                      .slice(0, MAX_MATCHED_VALUES);
                     const showTooltip =
                       result.description !== "" || matchingEnums.length > 0;
                     const extraAttributes =

--- a/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
@@ -59,6 +59,11 @@ export interface FacetSearchDocument {
 export const miniSearch = new MiniSearch<FacetSearchDocument>({
   fields: ["name", "description", "enum"], // fields to index for full-text search
   storeFields: ["name", "category", "categoryKey", "description", "enum", "id"], // fields to return with search results
+  searchOptions: {
+    boost: {
+      name: 1.5,
+    },
+  },
 });
 
 export const useFacetSearch = (): MiniSearch<FacetSearchDocument> => {


### PR DESCRIPTION
## Description
- Fixed a bug where matches sometimes weren't showing up if there were 30+ terms
- Boosted the name a bit above description/terms so those matches will tend to be on top

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
