### PR TITLE
PEAR-2141 - Error modals instead of notifications for saving set problems

### DIFF
--- a/packages/core/src/features/modals/modalsSlice.ts
+++ b/packages/core/src/features/modals/modalsSlice.ts
@@ -20,6 +20,7 @@ export enum Modals {
   "LocalMutationSetModal" = "LocalMutationSetModal",
   "ImportCohortModal" = "ImportCohortModal",
   "SaveCohortErrorModal" = "SaveCohortErrorModal",
+  "SaveSetErrorModal" = "SaveSetErrorModal",
 }
 
 export interface ModalState {

--- a/packages/portal-proto/src/components/Modals/SetModals/AddToSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/AddToSetModal.tsx
@@ -10,6 +10,8 @@ import {
   useGeneSetCountQuery,
   useGeneSetCountsQuery,
   useAppendToGeneSetMutation,
+  showModal,
+  Modals,
 } from "@gff/core";
 import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
@@ -152,10 +154,7 @@ const AddToSetModal: React.FC<AddToSetModalProps> = ({
               .then((response) => {
                 const newSetId = response;
                 if (newSetId === undefined) {
-                  showNotification({
-                    message: "Problem modifiying set.",
-                    color: "red",
-                  });
+                  dispatch(showModal({ modal: Modals.SaveSetErrorModal }));
                 } else {
                   dispatch(
                     addSet({
@@ -173,11 +172,7 @@ const AddToSetModal: React.FC<AddToSetModalProps> = ({
                 }
               })
               .catch(() => {
-                showNotification({
-                  message: "Problem modifiying set.",
-                  color: "red",
-                  closeButtonProps: { "aria-label": "Close notification" },
-                });
+                dispatch(showModal({ modal: Modals.SaveSetErrorModal }));
               });
           }}
         >

--- a/packages/portal-proto/src/components/Modals/SetModals/RemoveFromSetModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/RemoveFromSetModal.tsx
@@ -9,6 +9,8 @@ import {
   addSet,
   useGeneSetCountsQuery,
   useRemoveFromGeneSetMutation,
+  showModal,
+  Modals,
 } from "@gff/core";
 import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
@@ -86,11 +88,7 @@ const RemoveFromSetModal: React.FC<RemoveFromSetModalProps> = ({
               .then((response) => {
                 const newSetId = response;
                 if (newSetId === undefined) {
-                  showNotification({
-                    message: "Problem modifiying set.",
-                    color: "red",
-                    closeButtonProps: { "aria-label": "Close notification" },
-                  });
+                  dispatch(showModal({ modal: Modals.SaveSetErrorModal }));
                 } else {
                   dispatch(
                     addSet({
@@ -107,11 +105,7 @@ const RemoveFromSetModal: React.FC<RemoveFromSetModalProps> = ({
                 }
               })
               .catch(() => {
-                showNotification({
-                  message: "Problem modifiying set.",
-                  color: "red",
-                  closeButtonProps: { "aria-label": "Close notification" },
-                });
+                dispatch(showModal({ modal: Modals.SaveSetErrorModal }));
               })
           }
           disabled={selectedSets.length === 0}

--- a/packages/portal-proto/src/components/Modals/SetModals/SaveSelectionModal.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/SaveSelectionModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { TextInput, NumberInput, Modal, Loader } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { showNotification } from "@mantine/notifications";
@@ -12,6 +12,8 @@ import {
   buildCohortGqlOperator,
   useCreateTopNGeneSetFromFiltersMutation,
   useCreateGeneSetFromFiltersMutation,
+  showModal,
+  Modals,
 } from "@gff/core";
 import FunctionButton from "@/components/FunctionButton";
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
@@ -51,7 +53,6 @@ const SaveSelectionAsSetModal: React.FC<SaveSelectionAsSetModalProps> = ({
   const dispatch = useCoreDispatch();
   const sets = useCoreSelector((state) => selectSetsByType(state, setType));
   const [createSet, response] = createSetHook();
-  const [showErrorModal, setShowErrorModal] = useState(false);
 
   const max = saveCount > SET_COUNT_LIMIT ? SET_COUNT_LIMIT : saveCount;
   const form = useForm({
@@ -164,7 +165,7 @@ const SaveSelectionAsSetModal: React.FC<SaveSelectionAsSetModalProps> = ({
                 form.reset();
               })
               .catch(() => {
-                setShowErrorModal(true);
+                dispatch(showModal({ modal: Modals.SaveSetErrorModal }));
               });
           }}
           disabled={!form.isValid()}
@@ -175,18 +176,6 @@ const SaveSelectionAsSetModal: React.FC<SaveSelectionAsSetModalProps> = ({
           Save
         </DarkFunctionButton>
       </ModalButtonContainer>
-      <Modal
-        opened={showErrorModal}
-        onClose={() => setShowErrorModal(false)}
-        title="Save Set Error"
-      >
-        <p className="py-2 px-4">There was a problem saving the set.</p>
-        <ModalButtonContainer data-testid="modal-button-container">
-          <DarkFunctionButton onClick={() => setShowErrorModal(false)}>
-            OK
-          </DarkFunctionButton>
-        </ModalButtonContainer>
-      </Modal>
     </Modal>
   );
 };

--- a/packages/portal-proto/src/components/Modals/SetModals/SetTable.tsx
+++ b/packages/portal-proto/src/components/Modals/SetModals/SetTable.tsx
@@ -11,6 +11,7 @@ import useStandardPagination from "@/hooks/useStandardPagination";
 import { createColumnHelper } from "@tanstack/react-table";
 import { HandleChangeInput } from "@/components/Table/types";
 import VerticalTable from "@/components/Table/VerticalTable";
+import { statusBooleansToDataStatus } from "src/utils";
 
 interface SelectCellProps {
   readonly count: number;
@@ -91,7 +92,12 @@ const SetTable: React.FC<SetTableProps> = ({
 }: SetTableProps) => {
   const componentId = useId();
   const sets = useCoreSelector((state) => selectSetsByType(state, setType));
-  const { data: counts, isSuccess } = countHook({
+  const {
+    data: counts,
+    isSuccess,
+    isFetching,
+    isError,
+  } = countHook({
     setIds: Object.keys(sets),
   });
 
@@ -174,7 +180,7 @@ const SetTable: React.FC<SetTableProps> = ({
       data={displayedData}
       columns={setTableColumns}
       handleChange={handleTableChange}
-      status={isSuccess ? "fulfilled" : "pending"}
+      status={statusBooleansToDataStatus(isFetching, isSuccess, isError)}
       pagination={{ ...paginationProps, label: `${setTypeLabel} set` }}
     />
   );

--- a/packages/portal-proto/src/components/SaveSetButton.tsx
+++ b/packages/portal-proto/src/components/SaveSetButton.tsx
@@ -9,6 +9,8 @@ import {
   SetTypes,
   hideModal,
   CreateSetValueArgs,
+  showModal,
+  Modals,
 } from "@gff/core";
 import { showNotification } from "@mantine/notifications";
 import { SaveOrCreateEntityModal } from "@/components/Modals/SaveOrCreateEntityModal";
@@ -53,11 +55,7 @@ const SaveSetButton: React.FC<SaveSetButttonProps> = ({
       }
       setSetName(null);
     } else if (response.isError) {
-      showNotification({
-        message: "Problem saving set.",
-        color: "red",
-        closeButtonProps: { "aria-label": "Close notification" },
-      });
+      dispatch(showModal({ modal: Modals.SaveSetErrorModal }));
     }
   }, [
     response.isSuccess,

--- a/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
+++ b/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
@@ -9,9 +9,12 @@ import {
   selectCohortMessage,
   clearCohortMessage,
   useGetBannerNotificationsQuery,
+  selectCurrentModal,
+  Modals,
+  hideModal,
 } from "@gff/core";
 import Banner from "@/components/Banner";
-import { Button } from "@mantine/core";
+import { Button, Modal } from "@mantine/core";
 import {
   DeleteCohortNotification,
   DiscardChangesCohortNotification,
@@ -26,6 +29,8 @@ import { Header } from "./Header";
 import { Footer } from "./Footer";
 import { useElementSize } from "@mantine/hooks";
 import ClearStoreErrorBoundary from "@/components/ClearStoreErrorBoundary";
+import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
+import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
 
 interface UserFlowVariedPagesProps {
   readonly headerElements: ReadonlyArray<ReactNode>;
@@ -44,6 +49,7 @@ export const UserFlowVariedPages = ({
   isContextBarSticky = false,
 }: PropsWithChildren<UserFlowVariedPagesProps>) => {
   const dispatch = useCoreDispatch();
+  const modal = useCoreSelector((state) => selectCurrentModal(state));
 
   useGetBannerNotificationsQuery();
   const banners = useCoreSelector((state) => selectBanners(state));
@@ -202,6 +208,19 @@ export const UserFlowVariedPages = ({
           >
             {children}
           </main>
+          <Modal
+            opened={modal === Modals.SaveSetErrorModal}
+            onClose={() => dispatch(hideModal())}
+            title="Save Set Error"
+            zIndex={500}
+          >
+            <p className="py-2 px-4">There was a problem saving the set.</p>
+            <ModalButtonContainer data-testid="modal-button-container">
+              <DarkFunctionButton onClick={() => dispatch(hideModal())}>
+                OK
+              </DarkFunctionButton>
+            </ModalButtonContainer>
+          </Modal>
         </>
       </ClearStoreErrorBoundary>
       <Footer />


### PR DESCRIPTION
## Description
Adds the remaining error modals instead of notifications. Created a global modal for save set errors since it is now used in quite a few places. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
