### PR TITLE
Sjpp client 2.76.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26304,7 +26304,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.73.0",
+        "@sjcrh/proteinpaint-client": "^2.76.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -26449,9 +26449,9 @@
       }
     },
     "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.73.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.73.0.tgz",
-      "integrity": "sha512-ZZl5CKthaxNI7OaQyCdS3dOCptTILYq7CbtNgiOSKOkuDrbohSV8In21douckqAjMEYENC6RS2MKww/QjoNN+g==",
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.76.0.tgz",
+      "integrity": "sha512-zX8r5MuPRgwlpffAUuWHl3Ha7GL0E4GdPqNKgtzBR/DQj5WKq61sQqZ+IvuQt44cF/rY/C7jvCa2j0sHd3z6yg==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.73.0",
+    "@sjcrh/proteinpaint-client": "^2.76.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/apps/scRNAseq.tsx
+++ b/packages/portal-proto/src/features/apps/scRNAseq.tsx
@@ -1,0 +1,8 @@
+import { FC } from "react";
+import { ScRNAseqWrapper } from "../proteinpaint/ScRNAseqWrapper";
+
+const ScRNAseqApp: FC = () => {
+  return <ScRNAseqWrapper />;
+};
+
+export default ScRNAseqApp;

--- a/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.tsx
@@ -1,6 +1,7 @@
-import { useRef, FC } from "react";
+import { useRef, FC, useState } from "react";
 import { useDeepCompareEffect } from "use-deep-compare";
 import { runproteinpaint } from "@sjcrh/proteinpaint-client";
+import { LoadingOverlay } from "@mantine/core";
 import {
   useCoreSelector,
   selectCurrentCohortFilters,
@@ -8,7 +9,8 @@ import {
   useFetchUserDetailsQuery,
   buildCohortGqlOperator,
 } from "@gff/core";
-import { isEqual, cloneDeep } from "lodash";
+
+import { RxComponentCallbacks } from "./sjpp-types";
 
 const basepath = PROTEINPAINT_API;
 
@@ -23,6 +25,18 @@ export const ScRNAseqWrapper: FC<PpProps> = (props: PpProps) => {
   const currentCohort = useCoreSelector(selectCurrentCohortFilters);
   const filter0 = buildCohortGqlOperator(currentCohort);
   const userDetails = useFetchUserDetailsQuery();
+  const [isLoading, setIsLoading] = useState(false);
+  const showLoadingOverlay = () => setIsLoading(true);
+  const hideLoadingOverlay = () => setIsLoading(false);
+  const matrixCallbacks: RxComponentCallbacks = {
+    "postRender.gdcScRNAseq": hideLoadingOverlay,
+    "error.gdcScRNAseq": hideLoadingOverlay,
+  };
+  const appCallbacks: RxComponentCallbacks = {
+    "preDispatch.gdcPlotApp": showLoadingOverlay,
+    "error.gdcPlotApp": hideLoadingOverlay,
+    "postRender.gdcPlotApp": hideLoadingOverlay,
+  };
 
   useDeepCompareEffect(
     () => {
@@ -65,6 +79,11 @@ export const ScRNAseqWrapper: FC<PpProps> = (props: PpProps) => {
         style={{ margin: "2em" }}
         className="sjpp-wrapper-root-div"
         //userDetails={userDetails}
+      />
+      <LoadingOverlay
+        data-testid="loading-spinner"
+        visible={isLoading}
+        zIndex={0}
       />
     </div>
   );

--- a/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.tsx
@@ -1,0 +1,101 @@
+import { useRef, FC } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
+import { runproteinpaint } from "@sjcrh/proteinpaint-client";
+import {
+  useCoreSelector,
+  selectCurrentCohortFilters,
+  PROTEINPAINT_API,
+  useFetchUserDetailsQuery,
+  buildCohortGqlOperator,
+} from "@gff/core";
+import { isEqual, cloneDeep } from "lodash";
+
+const basepath = PROTEINPAINT_API;
+
+interface PpProps {
+  basepath?: string;
+}
+
+export const ScRNAseqWrapper: FC<PpProps> = (props: PpProps) => {
+  // to track reusable instance for mds3 skewer track
+  const ppRef = useRef<PpApi>();
+  const prevArg = useRef<any>({});
+  const currentCohort = useCoreSelector(selectCurrentCohortFilters);
+  const filter0 = buildCohortGqlOperator(currentCohort);
+  const userDetails = useFetchUserDetailsQuery();
+
+  useDeepCompareEffect(
+    () => {
+      const rootElem = divRef.current as HTMLElement;
+      const holder = rootElem.querySelector(".sja_root_holder");
+      const arg = getScRNAseqArg(props, filter0, rootElem);
+      if (!arg) return;
+      // compare the argument to runpp to avoid unnecessary render
+      //   if ((data || prevArg.current) && isEqual(prevArg.current, data)) return;
+      //   prevArg.current = data;
+
+      const toolContainer = rootElem.parentNode.parentNode
+        .parentNode as HTMLElement;
+      toolContainer.style.backgroundColor = "#fff";
+
+      //   const arg = Object.assign(
+      //     { holder: rootElem, noheader: true, nobox: true, hide_dsHandles: true },
+      //     cloneDeep(data),
+      //   );
+
+      if (ppRef.current) {
+        ppRef.current.update(arg);
+      } else {
+        const pp_holder = rootElem.querySelector(".sja_root_holder");
+        if (pp_holder) pp_holder.remove();
+        runproteinpaint(arg).then((pp) => {
+          ppRef.current = pp;
+        });
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filter0, userDetails],
+  );
+
+  const divRef = useRef();
+  return (
+    <div>
+      <div
+        ref={divRef}
+        style={{ margin: "2em" }}
+        className="sjpp-wrapper-root-div"
+        //userDetails={userDetails}
+      />
+    </div>
+  );
+};
+
+interface ScRNAseqArg {
+  holder?: Element;
+  host: string;
+  launchGdcScRNAseq: true;
+  genome?: string;
+  filter0: any;
+  noheader: true;
+  nobox: true;
+  hide_dsHandles: true;
+}
+
+interface PpApi {
+  update(arg: any): null;
+}
+
+function getScRNAseqArg(props: PpProps, filter0: any, holder: Element) {
+  const arg: ScRNAseqArg = {
+    // host in gdc is just a relative url path,
+    // using the same domain as the GDC portal where PP is embedded
+    host: props.basepath || (basepath as string),
+    filter0: filter0 || null,
+    launchGdcScRNAseq: true,
+    holder,
+    noheader: true,
+    nobox: true,
+    hide_dsHandles: true,
+  };
+  return arg;
+}

--- a/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.unit.test.tsx
@@ -1,0 +1,57 @@
+import { render } from "@testing-library/react";
+import { ScRNAseqWrapper } from "./ScRNAseqWrapper";
+import { MantineProvider } from "@mantine/core";
+
+const filter = {};
+let runpparg,
+  userDetails,
+  isDemoMode = false;
+
+const nullFunction = () => null;
+
+jest.mock("@gff/core", () => ({
+  useCoreSelector: jest.fn().mockReturnValue({}),
+  buildCohortGqlOperator: jest.fn(() => filter),
+  useFetchUserDetailsQuery: jest.fn(() => userDetails),
+  useCoreDispatch: jest.fn(() => nullFunction()),
+  setActiveCohort: jest.fn(() => null),
+  PROTEINPAINT_API: "host:port/basepath",
+}));
+
+jest.mock("@/hooks/useIsDemoApp", () => ({
+  useIsDemoApp: jest.fn(() => isDemoMode),
+}));
+
+jest.mock("@sjcrh/proteinpaint-client", () => ({
+  __esModule: true,
+  runproteinpaint: jest.fn(async (arg) => {
+    runpparg = arg;
+    return {};
+  }),
+}));
+
+test("single cell RNAseq arguments", () => {
+  userDetails = { data: { username: "test" } };
+  const { unmount, rerender } = render(
+    <MantineProvider
+      theme={{
+        colors: {
+          primary: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+          base: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+        },
+      }}
+    >
+      <ScRNAseqWrapper />
+    </MantineProvider>,
+  );
+  expect(typeof runpparg).toBe("object");
+  expect(runpparg.holder instanceof HTMLElement).toBe(true);
+  expect(typeof runpparg.host).toBe("string");
+  expect(runpparg.launchGdcScRNAseq).toEqual(true);
+  expect(runpparg.filter0).toEqual(filter);
+  expect(runpparg.noheader).toEqual(true);
+  expect(runpparg.nobox).toEqual(true);
+  expect(runpparg.hide_dsHandles).toEqual(true);
+
+  unmount();
+});

--- a/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.unit.test.tsx
@@ -3,9 +3,8 @@ import { ScRNAseqWrapper } from "./ScRNAseqWrapper";
 import { MantineProvider } from "@mantine/core";
 
 const filter = {};
-let runpparg,
-  userDetails,
-  isDemoMode = false;
+let runpparg, userDetails;
+const isDemoMode = false;
 
 const nullFunction = () => null;
 
@@ -32,7 +31,7 @@ jest.mock("@sjcrh/proteinpaint-client", () => ({
 
 test("single cell RNAseq arguments", () => {
   userDetails = { data: { username: "test" } };
-  const { unmount, rerender } = render(
+  const { unmount } = render(
     <MantineProvider
       theme={{
         colors: {

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -209,6 +209,26 @@ export const REGISTERED_APPS = [
       "Current cohort does not have SSM or CNV data available for visualization.",
   },
   {
+    name: "Single Cell RNA-seq",
+    // icon: (
+    //   <OncoMatrixIcon
+    //     className="m-auto"
+    //     height={48}
+    //     width={80}
+    //     aria-hidden="true"
+    //   />
+    // ),
+    tags: ["variantAnalysis", "cnv", "ssm"],
+    //hasDemo: true,
+    description: "scRNAseq Visualization tool",
+    id: "scRNAseq",
+    countsField: "caseCount",
+    caseCounts: 0.25,
+    optimizeRules: ["available data = ssm or cnv"],
+    noDataTooltip:
+      "Current cohort does not have scRNAseq data available for visualization.",
+  },
+  {
     name: "Gene Expression Clustering",
     icon: (
       <GeneExpressionIcon


### PR DESCRIPTION
## Description

NOTE: The scRNAseq ATF card will need an icon and case counts.

Features:
- Support scRNAseq analysis tool
- hierCluster: click left dendrogram to highlight selected cluster, and show options to list items (add link to GDC gene page for genes) and perform ORA

Fixes:
- improve text color contrast in PP SSM lollipop view
- matrix groups should be sorted based on order defined in divideby term
- allow empty categorical term.values
- At gdc bam slicing ui, replace outdated sample_type with new terms
- always show Processing data... when a divideby term is selected for oncoMatrix and hierCluster
- At GDC lollipop subtrack, disable survival term when building the filter
- fix matrix divideby when using gene exp

## Checklist

- [x] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
