### PR TITLE
PEAR-2182 add tooltip to disabled button

### DIFF
--- a/packages/portal-proto/src/features/facets/FilterPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FilterPanel.tsx
@@ -98,10 +98,7 @@ const FilterPanel = ({
           {customConfig !== undefined && (
             <>
               <div className="flex min-h-[36px] mt-3.5 w-48 md:w-64 lg:w-80 2xl:w-96">
-                <Tooltip
-                  label="Reset custom filters"
-                  disabled={isEqual(customConfig.defaultFilters, facetFields)}
-                >
+                <Tooltip label="Reset custom filters">
                   <button
                     className="flex justify-center items-center w-12 border-1 rounded-l-md border-primary-darker text-primary disabled:opacity-50 disabled:bg-base-max disabled:text-primary disabled:cursor-not-allowed"
                     onClick={() => customConfig.handleResetCustomFilters()}


### PR DESCRIPTION
## Description
- adds "Reset custom filters" tooltip to the disabled Reset Custom Filters button in the Repository

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="420" alt="Screenshot 2024-09-16 at 11 21 03 PM" src="https://github.com/user-attachments/assets/edc0b21d-0857-47eb-96ec-f5c4316e2400">
