### PR TITLE
PEAR-2180 - Repository - custom filters are not including additional info in their titles

### DIFF
--- a/packages/portal-proto/src/features/facets/FilterPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FilterPanel.tsx
@@ -150,7 +150,8 @@ const FilterPanel = ({
               customConfig?.defaultFilters !== undefined
                 ? customConfig.defaultFilters.includes(facet.full)
                 : true;
-            const facetName = facet.title || fieldNameToTitle(facet.full);
+            const facetName =
+              facet.title || fieldNameToTitle(facet.full, isDefault ? 1 : 2);
             return createFacetCard({
               facet,
               valueLabel:


### PR DESCRIPTION
## Description
Fix merge goof where extra field for custom filters got dropped

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
