### PR TITLE
PEAR-2184 - Cart Page is missing icons on download buttons

### DIFF
--- a/packages/portal-proto/src/features/cart/CartHeader.tsx
+++ b/packages/portal-proto/src/features/cart/CartHeader.tsx
@@ -135,6 +135,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
               classNames={{
                 root: `${buttonStyle} ml-4 ${focusStyles}`,
               }}
+              leftSection={<DownloadIcon aria-hidden="true" />}
               rightSection={
                 <DropdownIcon
                   size={20}
@@ -190,6 +191,7 @@ const CartHeader: React.FC<CartHeaderProps> = ({
               classNames={{
                 root: `${buttonStyle} ${focusStyles}`,
               }}
+              leftSection={<DownloadIcon aria-hidden="true" />}
               rightSection={
                 <DropdownIcon
                   size={20}


### PR DESCRIPTION
## Description

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1425" alt="Screenshot 2024-09-19 at 4 19 02 PM" src="https://github.com/user-attachments/assets/9802b4bc-3062-4d5d-a90b-7d8c59ba60e3">
