### PR TITLE
PEAR-935: add featureFlag support

### DIFF
--- a/packages/portal-proto/src/features/featureFlags.ts
+++ b/packages/portal-proto/src/features/featureFlags.ts
@@ -12,8 +12,8 @@ if (typeof window !== "undefined") localStorage = window.localStorage;
  * Feature flag for Single Cell RNA-seq
  */
 export const DISPLAY_SC_RNA_SEQ_APP =
-  localStorage.GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP ||
-  process.env.NEXT_PUBLIC_GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP ||
+  localStorage?.GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP ||
+  process?.env?.NEXT_PUBLIC_GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP ||
   false;
 
 /**

--- a/packages/portal-proto/src/features/featureFlags.ts
+++ b/packages/portal-proto/src/features/featureFlags.ts
@@ -1,0 +1,37 @@
+/**
+ *  Feature flags for GDC Portal.
+ *  Define a flag in either local storage or  environment variable
+ *  Note that in a production build NextJS will compile in the value of the ENV
+ *  variable when it is built
+ *
+ */
+let localStorage: Storage = {} as Storage;
+if (typeof window !== "undefined") localStorage = window.localStorage;
+
+/**
+ * Feature flag for Single Cell RNA-seq
+ */
+export const DISPLAY_SC_RNA_SEQ_APP =
+  localStorage.GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP ||
+  process.env.NEXT_PUBLIC_GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP ||
+  false;
+
+/**
+ * Determines whether a feature is enabled based on the provided value.
+ *
+ * The function evaluates the input based on its type to return a boolean indicating
+ * the enabled status. If the input is undefined, it returns false. If the input is a
+ * boolean, it returns the value directly. If the input is a string, it checks if the
+ * string value is "true" (case insensitive) to return true; otherwise, returns false.
+ *
+ * @param {string | boolean | undefined} value - The input value to evaluate.
+ * @returns {boolean} - True if the feature is enabled, false otherwise.
+ */
+export const isFeatureEnabled = (
+  value: string | boolean | undefined,
+): boolean => {
+  if (value === undefined) return false;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return String(value).toLowerCase() == "true";
+  return false;
+};

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -20,13 +20,6 @@ import {
   isFeatureEnabled,
 } from "@/features/featureFlags";
 
-console.log(
-  "RA: DISPLAY_SC_RNA_SEQ_APP",
-  DISPLAY_SC_RNA_SEQ_APP,
-  DISPLAY_SC_RNA_SEQ_APP == true,
-  DISPLAY_SC_RNA_SEQ_APP == "true",
-);
-
 export const COHORTS = [
   { name: "New Custom Cohort", facets: [] },
   {

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -15,6 +15,17 @@ import CohortLevelMAFIcon from "public/user-flow/icons/apps/CohortLevelMAF.svg";
 import ProteinPaintIcon from "public/user-flow/icons/apps/ProteinPaint.svg";
 import OncoMatrixIcon from "public/user-flow/icons/apps/OncoMatrix.svg";
 import GeneExpressionIcon from "public/user-flow/icons/apps/GeneExpression.svg";
+import {
+  DISPLAY_SC_RNA_SEQ_APP,
+  isFeatureEnabled,
+} from "@/features/featureFlags";
+
+console.log(
+  "RA: DISPLAY_SC_RNA_SEQ_APP",
+  DISPLAY_SC_RNA_SEQ_APP,
+  DISPLAY_SC_RNA_SEQ_APP == true,
+  DISPLAY_SC_RNA_SEQ_APP == "true",
+);
 
 export const COHORTS = [
   { name: "New Custom Cohort", facets: [] },
@@ -208,26 +219,31 @@ export const REGISTERED_APPS = [
     noDataTooltip:
       "Current cohort does not have SSM or CNV data available for visualization.",
   },
-  {
-    name: "Single Cell RNA-seq",
-    // icon: (
-    //   <OncoMatrixIcon
-    //     className="m-auto"
-    //     height={48}
-    //     width={80}
-    //     aria-hidden="true"
-    //   />
-    // ),
-    tags: ["variantAnalysis", "cnv", "ssm"],
-    //hasDemo: true,
-    description: "scRNAseq Visualization tool",
-    id: "scRNAseq",
-    countsField: "caseCount",
-    caseCounts: 0.25,
-    optimizeRules: ["available data = ssm or cnv"],
-    noDataTooltip:
-      "Current cohort does not have scRNAseq data available for visualization.",
-  },
+
+  ...(isFeatureEnabled(DISPLAY_SC_RNA_SEQ_APP)
+    ? [
+        {
+          name: "Single Cell RNA-seq",
+          // icon: (
+          //   <OncoMatrixIcon
+          //     className="m-auto"
+          //     height={48}
+          //     width={80}
+          //     aria-hidden="true"
+          //   />
+          // ),
+          tags: ["variantAnalysis", "cnv", "ssm"],
+          //hasDemo: true,
+          description: "scRNAseq Visualization tool",
+          id: "scRNAseq",
+          countsField: "caseCount",
+          optimizeRules: ["available data = ssm or cnv"],
+          noDataTooltip:
+            "Current cohort does not have scRNAseq data available for visualization.",
+        },
+      ]
+    : []),
+
   {
     name: "Gene Expression Clustering",
     icon: (


### PR DESCRIPTION
## Description

This adds a feature flag file to support feature flags and defines a feature flag for Single-Cell RNA-seq.

 The feature flag can be turned on by defining it in localStorage or via an environment variable.
Note that the value of the env variable will be evaluated at build time and will not be changeable after the build.

To turn on  Single-Cell RNA-seq: either add: `GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP: true` to local storage or:
```
export NEXT_PUBLIC_GDC_PORTAL_DISPLAY_SC_RNA_SEQ_APP=true
npm run dev
```

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
