### PR TITLE
update the proteinpaint-client version to 2.78.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26304,7 +26304,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.76.0",
+        "@sjcrh/proteinpaint-client": "^2.78.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -26449,9 +26449,9 @@
       }
     },
     "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.76.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.76.0.tgz",
-      "integrity": "sha512-zX8r5MuPRgwlpffAUuWHl3Ha7GL0E4GdPqNKgtzBR/DQj5WKq61sQqZ+IvuQt44cF/rY/C7jvCa2j0sHd3z6yg==",
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.78.0.tgz",
+      "integrity": "sha512-6oZtdmiP7ZpsaV+G+5rXdTZ2TtK0rCJgueguObydy2jHWOK5KoIqkvP2ZTRM2E8f4XXSPFaLUzn57Cj1fjG2LA==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.76.0",
+    "@sjcrh/proteinpaint-client": "^2.78.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -15,6 +15,7 @@ import CohortLevelMAFIcon from "public/user-flow/icons/apps/CohortLevelMAF.svg";
 import ProteinPaintIcon from "public/user-flow/icons/apps/ProteinPaint.svg";
 import OncoMatrixIcon from "public/user-flow/icons/apps/OncoMatrix.svg";
 import GeneExpressionIcon from "public/user-flow/icons/apps/GeneExpression.svg";
+import ScRNASeqIcon from "public/user-flow/icons/apps/scRNASeq.svg";
 
 export const COHORTS = [
   { name: "New Custom Cohort", facets: [] },
@@ -210,14 +211,14 @@ export const REGISTERED_APPS = [
   },
   {
     name: "Single Cell RNA-seq",
-    // icon: (
-    //   <OncoMatrixIcon
-    //     className="m-auto"
-    //     height={48}
-    //     width={80}
-    //     aria-hidden="true"
-    //   />
-    // ),
+    icon: (
+      <ScRNASeqIcon
+        className="m-auto"
+        height={48}
+        width={80}
+        aria-hidden="true"
+      />
+    ),
     tags: ["variantAnalysis", "cnv", "ssm"],
     //hasDemo: true,
     description: "scRNAseq Visualization tool",


### PR DESCRIPTION
## Description
Features:
- May change the shape of lollipop skewers when the track is filtered or a subtrack.

Fixes:
- initialize optional matrix tw props in TwBase constructor
- genome browser plot now saves mds3 subtracks in state and recover from session
- Address section 508 issues in OncoMatrix and Gene Expression Clustering tools
- allow q.mode=continuous for q.type=custom-bin to fix numeric edit UI toggling

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
