### PR TITLE
PEAR-2185 - Error handling modal does not appear on summary page

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager/CohortModals.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager/CohortModals.tsx
@@ -1,12 +1,10 @@
-import { LoadingOverlay, Modal } from "@mantine/core";
+import { LoadingOverlay } from "@mantine/core";
 import SaveCohortModal from "@/components/Modals/SaveCohortModal";
 import { GenericCohortModal } from "../Modals/GenericCohortModal";
 import ImportCohortModal from "../Modals/ImportCohortModal";
 import CaseSetModal from "@/components/Modals/SetModals/CaseSetModal";
 import GeneSetModal from "@/components/Modals/SetModals/GeneSetModal";
 import MutationSetModal from "@/components/Modals/SetModals/MutationSetModal";
-import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
-import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
 import {
   addNewSavedCohort,
   buildCohortGqlOperator,
@@ -14,7 +12,6 @@ import {
   DataStatus,
   discardCohortChanges,
   FilterSet,
-  hideModal,
   Modals,
   Operation,
   removeCohort,

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager/CohortModals.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager/CohortModals.tsx
@@ -256,19 +256,6 @@ export const CohortModals: React.FC<CohortModalsProps> = ({
         saveAs
       />
 
-      <Modal
-        opened={modal === Modals.SaveCohortErrorModal}
-        onClose={() => coreDispatch(hideModal())}
-        title="Save Cohort Error"
-      >
-        <p className="py-2 px-4">There was a problem saving the cohort.</p>
-        <ModalButtonContainer data-testid="modal-button-container">
-          <DarkFunctionButton onClick={() => coreDispatch(hideModal())}>
-            OK
-          </DarkFunctionButton>
-        </ModalButtonContainer>
-      </Modal>
-
       <ImportCohortModal opened={modal === Modals.ImportCohortModal} />
 
       <CaseSetModal

--- a/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
+++ b/packages/portal-proto/src/features/layout/UserFlowVariedPages.tsx
@@ -222,6 +222,19 @@ export const UserFlowVariedPages = ({
               </DarkFunctionButton>
             </ModalButtonContainer>
           </Modal>
+
+          <Modal
+            opened={modal === Modals.SaveCohortErrorModal}
+            onClose={() => dispatch(hideModal())}
+            title="Save Cohort Error"
+          >
+            <p className="py-2 px-4">There was a problem saving the cohort.</p>
+            <ModalButtonContainer data-testid="modal-button-container">
+              <DarkFunctionButton onClick={() => dispatch(hideModal())}>
+                OK
+              </DarkFunctionButton>
+            </ModalButtonContainer>
+          </Modal>
         </>
       </ClearStoreErrorBoundary>
       <Footer />


### PR DESCRIPTION
## Description
Move cohort error modal up so it works on pages with cohort manager bar

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
