### PR TITLE
PEAR-2022 - Investigate further state-clearing improvements

### DIFF
--- a/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
+++ b/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
@@ -1,7 +1,9 @@
 import React, { Component, ReactNode } from "react";
 import { NextRouter, withRouter } from "next/router";
 import { Modal } from "@mantine/core";
-import { persistor } from "@gff/core";
+import { persistor as corePersistor, persistor } from "@gff/core";
+import { persistor as repositoryPersistor } from "@/features/repositoryApp/RepositoryApp";
+import { persistor as projectsPersistor } from "@/features/projectsCenter/ProjectsCenter";
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
 import ModalButtonContainer from "@/components/StyledComponents/ModalButtonContainer";
 // Done this way because There is currently no way to write an error boundary as a function component.
@@ -45,7 +47,14 @@ class ClearStoreErrorBoundary extends Component<
             <ModalButtonContainer data-testid="modal-button-container">
               <DarkFunctionButton
                 onClick={async () => {
-                  await persistor.purge();
+                  if (this.props.router?.query?.app === "Downloads") {
+                    await repositoryPersistor.purge();
+                  } else if (this.props.router?.query?.app === "Projects") {
+                    await projectsPersistor.purge();
+                  } else {
+                    await persistor.purge();
+                  }
+
                   this.props.router
                     .replace({
                       query: {

--- a/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
+++ b/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
@@ -51,9 +51,9 @@ class ClearStoreErrorBoundary extends Component<
                     await repositoryPersistor.purge();
                   } else if (this.props.router?.query?.app === "Projects") {
                     await projectsPersistor.purge();
-                  } else {
-                    await corePersistor.purge();
                   }
+
+                  await corePersistor.purge();
 
                   this.props.router
                     .replace({

--- a/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
+++ b/packages/portal-proto/src/components/ClearStoreErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ReactNode } from "react";
 import { NextRouter, withRouter } from "next/router";
 import { Modal } from "@mantine/core";
-import { persistor as corePersistor, persistor } from "@gff/core";
+import { persistor as corePersistor } from "@gff/core";
 import { persistor as repositoryPersistor } from "@/features/repositoryApp/RepositoryApp";
 import { persistor as projectsPersistor } from "@/features/projectsCenter/ProjectsCenter";
 import DarkFunctionButton from "@/components/StyledComponents/DarkFunctionButton";
@@ -52,7 +52,7 @@ class ClearStoreErrorBoundary extends Component<
                   } else if (this.props.router?.query?.app === "Projects") {
                     await projectsPersistor.purge();
                   } else {
-                    await persistor.purge();
+                    await corePersistor.purge();
                   }
 
                   this.props.router

--- a/packages/portal-proto/src/features/projectsCenter/ProjectsCenter.tsx
+++ b/packages/portal-proto/src/features/projectsCenter/ProjectsCenter.tsx
@@ -7,7 +7,7 @@ import { PersistGate } from "redux-persist/integration/react";
 import { persistStore } from "redux-persist";
 import { AppStore } from "./appApi";
 
-const persistor = persistStore(AppStore);
+export const persistor = persistStore(AppStore);
 
 export const ProjectsCenter = (): JSX.Element => {
   const clearAllFilters = useClearAllProjectFilters();

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -101,7 +101,6 @@ export const RepositoryApp = (): JSX.Element => {
         callback(cartFiles, currentCart, dispatch);
       });
   };
-
   const buildCohortGqlOperatorWithCart = (): GqlOperation => {
     // create filter with current cart file ids
     const cartFilterSet: FilterSet = {

--- a/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/RepositoryApp.tsx
@@ -40,7 +40,7 @@ import { PersistGate } from "redux-persist/integration/react";
 import { useRouter } from "next/router";
 import { IoMdArrowDropdown as Dropdown } from "react-icons/io";
 
-const persistor = persistStore(AppStore);
+export const persistor = persistStore(AppStore);
 
 const useCohortCentricFiles = () => {
   const repositoryFilters = useAppSelector((state) =>
@@ -101,6 +101,7 @@ export const RepositoryApp = (): JSX.Element => {
         callback(cartFiles, currentCart, dispatch);
       });
   };
+
   const buildCohortGqlOperatorWithCart = (): GqlOperation => {
     // create filter with current cart file ids
     const cartFilterSet: FilterSet = {


### PR DESCRIPTION
## Description
The "Unexpected Error” state-clearing escape hatch was only clearing the core persisted store and not local app persisted stores. This is a little hard to test, you can try changing the shape of the store from the slices and then refreshing. 

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
