### PR TITLE
PEAR-2203 fixes metadata download from cohort bar.

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -107,7 +107,7 @@ const ContextBar = ({
       method: "POST",
       dispatch: coreDispatch,
       params: {
-        filters: downloadFilter,
+        case_filters: downloadFilter,
         fields: METADATA_FIELDS.join(","),
         format: "JSON",
         pretty: "True",


### PR DESCRIPTION
## Description
- have the metadata download from cohort bar use `case_filters` instead of `filters`
## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

Example metadata download using a eye cohort from home page and TP53 in filters. With `filters` and genomic filters, the download would be empty.

<img width="781" alt="Screenshot 2024-09-30 at 2 47 17 PM" src="https://github.com/user-attachments/assets/53d559eb-79e2-4828-a56e-daddf58582c1">

