### PR TITLE
PEAR-2161 adds ocpl shutdown banner

### DIFF
--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -281,11 +281,9 @@ const PortalApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
           <Head>
             <script
               src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js"
-              async 
-              />
+              async
+            />
           </Head>
-
-          <script>{`_satellite.pageBottom()`}</script>
         </div>
       </MantineProvider>
     </CoreProvider>

--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -281,8 +281,8 @@ const PortalApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
           <Head>
             <script
               src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js"
-              async
-            ></script>
+              async 
+              />
           </Head>
 
           <script>{`_satellite.pageBottom()`}</script>

--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -279,7 +279,10 @@ const PortalApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
             </SummaryModalContext.Provider>
           </URLContext.Provider>
           <Head>
-            <script src="https://assets.adobedtm.com/6a4249cd0a2c/073fd0859f8f/launch-39d47c17b228.min.js" />
+            <script
+              src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js"
+              async
+            ></script>
           </Head>
 
           <script>{`_satellite.pageBottom()`}</script>


### PR DESCRIPTION
## Description
- replaces current Adobe script with new one that includes the government shutdown banner
- see https://experienceleague.adobe.com/en/docs/experience-platform/tags/client-side/asynchronous-deployment for why `_satellite.pageBottom` was removed.

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1607" alt="Screenshot 2024-10-02 at 10 33 14 AM" src="https://github.com/user-attachments/assets/6c53a4d7-cac9-4717-9ac4-f21448a24ddd">
