### PR TITLE
update the proteinpaint-client version to 2.79.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26561,7 +26561,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.78.0",
+        "@sjcrh/proteinpaint-client": "^2.79.3",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -26706,9 +26706,9 @@
       }
     },
     "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.78.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.78.0.tgz",
-      "integrity": "sha512-6oZtdmiP7ZpsaV+G+5rXdTZ2TtK0rCJgueguObydy2jHWOK5KoIqkvP2ZTRM2E8f4XXSPFaLUzn57Cj1fjG2LA==",
+      "version": "2.79.3",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.79.3.tgz",
+      "integrity": "sha512-RMhJox2gIl0cqhEXa5p20Soc5isRHjYs86iEvPZ9O6/Uh2gqbbg+DXwGKR4gns59RVJUvPFmgWphU0WkSJqfkQ==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.78.0",
+    "@sjcrh/proteinpaint-client": "^2.79.3",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Devops:
- replace `rollup` with `esbuild` to create prod bundle for client code (NOTE TO UC/GDC: we've been using `esbuild` since June for PP client development work as hooked to the GFF dev bundling, so we feel that we've tested this change thoroughly. The estimated PP client bundle size as part of the GFF bundle seems to not have changed at around 11.8MB.)
- create separate workspaces for shared code ([types](https://www.npmjs.com/package/@sjcrh/proteinpaint-types) and [utils](https://www.npmjs.com/package/@sjcrh/proteinpaint-shared)): this fixes an issue with the previous symlink setup, where the `client` package is not guaranteed to be updated when shared code is updated from the `server` workspace

Fixes:
- section 508 issues in singleCellPlot controls: aria-label should be on element with roles
- support new GDC /status api return in stale cache check

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
