### PR TITLE
PEAR-2206 - Removed annotations do not have result when searched for 

### DIFF
--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -44,6 +44,7 @@ export const QuickSearch = (): JSX.Element => {
     data: fileHistory,
     isSuccess: isHistorySuccess,
     isUninitialized: isHistoryUninit,
+    isError: isHistoryError,
   } = useGetHistoryQuery(searchText.trim(), {
     skip:
       searchText === "" ||
@@ -80,6 +81,7 @@ export const QuickSearch = (): JSX.Element => {
         // We checked history and there isn't a superseded file
         if (
           isHistoryUninit ||
+          isHistoryError ||
           (isHistorySuccess &&
             (fileHistory === undefined || fileHistory.length < 2))
         ) {

--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -102,6 +102,7 @@ export const QuickSearch = (): JSX.Element => {
     fileHistory,
     isHistorySuccess,
     isHistoryUninit,
+    isHistoryError,
   ]);
 
   useDeepCompareEffect(() => {


### PR DESCRIPTION
## Description
<img width="1006" alt="Screenshot 2024-10-02 at 3 49 56 PM" src="https://github.com/user-attachments/assets/22fcac82-ce27-46f2-9c76-402a1a58717c">

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
