### PR TITLE
PEAR-2087 - cDAVE: Investigate if analysis card's y-axis can display only integers 

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
@@ -187,6 +187,7 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
                   : undefined
               }
               truncateLabels
+              yAxisFormatAsInteger
             />
           </div>
           <OffscreenWrapper>
@@ -206,6 +207,7 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
                   : undefined
               }
               chartRef={downloadChartRef}
+              yAxisFormatAsInteger
             />
           </OffscreenWrapper>
         </>

--- a/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
+++ b/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
@@ -99,6 +99,7 @@ interface VictoryBarChartProps {
   };
   readonly hideYTicks?: boolean;
   readonly hideXTicks?: boolean;
+  readonly yAxisFormatAsInteger?: boolean;
   readonly chartRef?: React.MutableRefObject<HTMLElement>;
   readonly truncateLabels?: boolean;
 }
@@ -115,6 +116,7 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
   chartPadding,
   hideYTicks = false,
   hideXTicks = false,
+  yAxisFormatAsInteger = false,
   chartRef = undefined,
   truncateLabels = false,
 }: VictoryBarChartProps) => {
@@ -159,6 +161,11 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
           grid: { stroke: "#F5F5F5", strokeWidth: 1 },
           axisLabel: { fontSize: 25, fontFamily: "Noto Sans" },
         }}
+        tickFormat={
+          yAxisFormatAsInteger
+            ? (t) => (Number.isInteger(t) ? t : null)
+            : undefined
+        }
       />
       <VictoryAxis
         style={{


### PR DESCRIPTION
## Description
Add option to only display integers on axis in bar chart

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1203" alt="Screenshot 2024-10-03 at 3 26 47 PM" src="https://github.com/user-attachments/assets/1493408e-70d6-4575-9e7a-c33e413bc4fc">
