### PR TITLE
PEAR-1284: Make gene strand look same across the app.

### DIFF
--- a/packages/portal-proto/src/features/mutationSummary/ConsequenceTable.tsx
+++ b/packages/portal-proto/src/features/mutationSummary/ConsequenceTable.tsx
@@ -204,9 +204,7 @@ export const ConsequenceTable = ({
         id: "gene_strand",
         header: "Gene Strand",
         cell: ({ row }) => (
-          <span className="text-lg font-bold">
-            {row.original.gene_strand > 0 ? <HiPlus /> : <HiMinus />}
-          </span>
+          <span>{row.original.gene_strand > 0 ? <HiPlus /> : <HiMinus />}</span>
         ),
       }),
       consequenceTableColumnHelper.display({

--- a/packages/portal-proto/src/features/mutationSummary/ConsequenceTable.tsx
+++ b/packages/portal-proto/src/features/mutationSummary/ConsequenceTable.tsx
@@ -29,6 +29,7 @@ import { convertDateToString } from "@/utils/date";
 import { downloadTSV } from "@/components/Table/utils";
 import ImpactHeaderWithTooltip from "../GenomicTables/SharedComponent/ImpactHeaderWithTooltip";
 import TotalItems from "@/components/Table/TotalItem";
+import { HiPlus, HiMinus } from "react-icons/hi";
 
 const consequenceTableColumnHelper = createColumnHelper<ConsequenceTableData>();
 
@@ -132,7 +133,7 @@ export const ConsequenceTable = ({
             consequences: consequence_type,
             transcript: transcript_id,
             is_canonical: is_canonical,
-            gene_strand: gene_strand > 0 ? "+" : "-",
+            gene_strand: gene_strand,
             impact: {
               polyphen_impact: polyphen_impact,
               polyphen_score: polyphen_score,
@@ -203,7 +204,9 @@ export const ConsequenceTable = ({
         id: "gene_strand",
         header: "Gene Strand",
         cell: ({ row }) => (
-          <span className="text-lg font-bold">{row.original.gene_strand}</span>
+          <span className="text-lg font-bold">
+            {row.original.gene_strand > 0 ? <HiPlus /> : <HiMinus />}
+          </span>
         ),
       }),
       consequenceTableColumnHelper.display({
@@ -282,6 +285,11 @@ export const ConsequenceTable = ({
                 .filter(({ length }) => length)
                 .join(", ")}`;
               return impactString;
+            },
+          },
+          gene_strand: {
+            composer: (consequenceData) => {
+              return consequenceData.gene_strand > 0 ? "+" : "-";
             },
           },
           transcript: {

--- a/packages/portal-proto/src/features/mutationSummary/types.ts
+++ b/packages/portal-proto/src/features/mutationSummary/types.ts
@@ -6,7 +6,7 @@ export interface ConsequenceTableData {
   consequences: string;
   transcript: string;
   is_canonical: boolean;
-  gene_strand: string;
+  gene_strand: number;
   impact: {
     polyphen_impact: string;
     polyphen_score: number;


### PR DESCRIPTION
## Description

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1298" alt="gene_strand" src="https://github.com/user-attachments/assets/231615a2-9c7d-459b-b02b-4ed91d66ff90">
<img width="1318" alt="gene_strand_1" src="https://github.com/user-attachments/assets/c4b93234-5815-445d-85f1-bf9f3109f689">
