### PR TITLE
update proteinpaint-client to v2.79.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26561,7 +26561,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.79.3",
+        "@sjcrh/proteinpaint-client": "^2.79.6",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -26706,9 +26706,9 @@
       }
     },
     "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.79.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.79.3.tgz",
-      "integrity": "sha512-RMhJox2gIl0cqhEXa5p20Soc5isRHjYs86iEvPZ9O6/Uh2gqbbg+DXwGKR4gns59RVJUvPFmgWphU0WkSJqfkQ==",
+      "version": "2.79.6",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.79.6.tgz",
+      "integrity": "sha512-r1y7cgCzLyRVm+IGMp+h214l1ubn55cytV+JWCe11Ai5MI4yZwstNRtVffLrSMnRHeHlOmGJyjZLTM3/6chuAg==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.79.3",
+    "@sjcrh/proteinpaint-client": "^2.79.6",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Fixes:
- ProteinPaint SSM: fix geneSearchBox errors
- BAM Slicing Download and Sequence Reads: Disable Submit button when 1. case/file is loading, 2. Under Variants tab, variant not selected, 3. Under Gene or position tab, no valid result from search box.
- Disco Plot: pass unfrozen filter to launch ProteinPaint track from Disco Plot
- Gene Expression Clustering: reset highlighted top/left dendrogram to black when data changed

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
