### PR TITLE
PEAR-2219 - Replace cohort modal not showing up for Mutation Frequency

### DIFF
--- a/packages/portal-proto/src/features/GenomicTables/GenesTable/utils.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/GenesTable/utils.tsx
@@ -1,7 +1,8 @@
 // This table can be found at /analysis_page?app=MutationFrequencyApp
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { Gene, GeneToggledHandler, columnFilterType } from "./types";
-import { Dispatch, SetStateAction, useMemo, useId } from "react";
+import { Dispatch, SetStateAction, useId } from "react";
+import { useDeepCompareMemo } from "use-deep-compare";
 import { Checkbox, Tooltip } from "@mantine/core";
 import {
   IoIosArrowDropdownCircle as DownIcon,
@@ -18,6 +19,8 @@ import NumeratorDenominator from "@/components/NumeratorDenominator";
 import AnnotationsIcon from "./AnnotationsIcon";
 import RatioWithSpring from "@/components/RatioWithSpring";
 import { ComparativeSurvival } from "@/features/genomic/types";
+
+const genesTableColumnHelper = createColumnHelper<Gene>();
 
 export const useGenerateGenesTableColumns = ({
   handleSurvivalPlotToggled,
@@ -49,9 +52,8 @@ export const useGenerateGenesTableColumns = ({
   totalPages: number;
 }): ColumnDef<Gene>[] => {
   const componentId = useId();
-  const genesTableColumnHelper = useMemo(() => createColumnHelper<Gene>(), []);
 
-  const genesTableDefaultColumns = useMemo<ColumnDef<Gene>[]>(
+  const genesTableDefaultColumns = useDeepCompareMemo<ColumnDef<Gene>[]>(
     () => [
       genesTableColumnHelper.display({
         id: "select",

--- a/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/utils.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/utils.tsx
@@ -3,7 +3,8 @@ import { humanify } from "@/utils/index";
 import { SSMSData, FilterSet } from "@gff/core";
 import { SomaticMutation, SsmToggledHandler } from "./types";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { Dispatch, SetStateAction, useMemo, useId } from "react";
+import { Dispatch, SetStateAction, useId } from "react";
+import { useDeepCompareMemo } from "use-deep-compare";
 import { Checkbox } from "@mantine/core";
 import { HeaderTooltip } from "@/components/Table/HeaderTooltip";
 import {
@@ -37,6 +38,8 @@ export const filterMutationType = (mutationSubType: string): string => {
   return operation.charAt(0).toUpperCase() + operation.slice(1);
 };
 
+const SMTableColumnHelper = createColumnHelper<SomaticMutation>();
+
 export const useGenerateSMTableColumns = ({
   toggledSsms,
   isDemoMode,
@@ -69,12 +72,10 @@ export const useGenerateSMTableColumns = ({
   cohortFilters: FilterSet;
 }): ColumnDef<SomaticMutation>[] => {
   const componentId = useId();
-  const SMTableColumnHelper = useMemo(
-    () => createColumnHelper<SomaticMutation>(),
-    [],
-  );
 
-  const SMTableDefaultColumns = useMemo<ColumnDef<SomaticMutation>[]>(
+  const SMTableDefaultColumns = useDeepCompareMemo<
+    ColumnDef<SomaticMutation>[]
+  >(
     () => [
       SMTableColumnHelper.display({
         id: "select",


### PR DESCRIPTION
## Description
React table strikes again, memoize columns correctly so that rerender doesn't "close" modal

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

https://github.com/user-attachments/assets/fbd56e53-73b8-46c0-a9cd-dcc4e2e4c9a8

