### PR TITLE
PEAR-2224 - Mutation Frequency - Removing a gene/mutation filter can cause other filters to reset 

### DIFF
--- a/packages/portal-proto/src/features/genomic/appApi.ts
+++ b/packages/portal-proto/src/features/genomic/appApi.ts
@@ -12,7 +12,7 @@ const persistConfig = {
   whitelist: ["filters", "filtersExpanded"],
 };
 
-const reducers = combineReducers({
+export const reducers = combineReducers({
   filters: geneFrequencyFiltersReducer,
   filtersExpanded: geneFrequencyExpandedReducer,
 });

--- a/packages/portal-proto/src/features/genomic/hooks.ts
+++ b/packages/portal-proto/src/features/genomic/hooks.ts
@@ -44,7 +44,6 @@ import {
   removeGeneAndSSMFilter,
   selectGeneAndSSMFiltersByNames,
   clearGeneAndSSMFilters,
-  removeAllNonSetFilters,
 } from "@/features/genomic/geneAndSSMFiltersSlice";
 import {
   toggleFilter,
@@ -60,7 +59,6 @@ import { humanify } from "@/utils/index";
 import { useDeepCompareMemo } from "use-deep-compare";
 import { appendSearchTermFilters } from "@/features/GenomicTables/utils";
 import FilterFacets from "@/features/genomic/filters.json";
-import { GENE_AND_MUTATION_FIELDS } from "./constants";
 
 /**
  * Update Genomic Enum Facets filters. These are app local updates and are not added
@@ -72,9 +70,6 @@ export const useUpdateGenomicEnumFacetFilter =
     // update the filter for this facet
     return (field: string, operation: Operation) => {
       dispatch(updateGeneAndSSMFilter({ field: field, operation: operation }));
-      if (GENE_AND_MUTATION_FIELDS.includes(field)) {
-        dispatch(removeAllNonSetFilters());
-      }
     };
   };
 

--- a/packages/portal-proto/src/features/genomic/tests/geneAndSSMFiltersSlice.unit.test.ts
+++ b/packages/portal-proto/src/features/genomic/tests/geneAndSSMFiltersSlice.unit.test.ts
@@ -1,0 +1,144 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { reducers } from "../appApi";
+import { updateGeneAndSSMFilter } from "../geneAndSSMFiltersSlice";
+
+describe("updateGeneAndSSMFilter", () => {
+  it("update fields normally", () => {
+    const store = configureStore({ reducer: reducers });
+    store.dispatch(
+      updateGeneAndSSMFilter({
+        field: "genes.is_cancer_gene_census",
+        operation: {
+          operator: "includes",
+          field: "genes.is_cancer_gene_census",
+          operands: ["true"],
+        },
+      }),
+    );
+    expect(store.getState().filters).toEqual({
+      mode: "and",
+      root: {
+        "genes.is_cancer_gene_census": {
+          operator: "includes",
+          field: "genes.is_cancer_gene_census",
+          operands: ["true"],
+        },
+      },
+    });
+
+    store.dispatch(
+      updateGeneAndSSMFilter({
+        field: "ssms.consequence.transcript.annotation.vep_impact",
+        operation: {
+          operator: "includes",
+          field: "ssms.consequence.transcript.annotation.vep_impact",
+          operands: ["high"],
+        },
+      }),
+    );
+
+    expect(store.getState().filters).toEqual({
+      mode: "and",
+      root: {
+        "genes.is_cancer_gene_census": {
+          operator: "includes",
+          field: "genes.is_cancer_gene_census",
+          operands: ["true"],
+        },
+        "ssms.consequence.transcript.annotation.vep_impact": {
+          operator: "includes",
+          field: "ssms.consequence.transcript.annotation.vep_impact",
+          operands: ["high"],
+        },
+      },
+    });
+  });
+
+  it("update gene/ssm set filter clears other filters", () => {
+    const store = configureStore({ reducer: reducers });
+    store.dispatch(
+      updateGeneAndSSMFilter({
+        field: "genes.is_cancer_gene_census",
+        operation: {
+          operator: "includes",
+          field: "genes.is_cancer_gene_census",
+          operands: ["true"],
+        },
+      }),
+    );
+
+    store.dispatch(
+      updateGeneAndSSMFilter({
+        field: "genes.gene_id",
+        operation: {
+          field: "genes.gene_id",
+          operator: "includes",
+          operands: ["ENSG00000141510"],
+        },
+      }),
+    );
+
+    expect(store.getState().filters).toEqual({
+      mode: "and",
+      root: {
+        "genes.gene_id": {
+          operator: "includes",
+          field: "genes.gene_id",
+          operands: ["ENSG00000141510"],
+        },
+      },
+    });
+  });
+
+  it("removing ssm/gene set filter does not clear filters", () => {
+    const store = configureStore({ reducer: reducers });
+    store.dispatch(
+      updateGeneAndSSMFilter({
+        field: "genes.gene_id",
+        operation: {
+          field: "genes.gene_id",
+          operator: "includes",
+          operands: ["ENSG00000141510", "ENSG00000120332"],
+        },
+      }),
+    );
+
+    store.dispatch(
+      updateGeneAndSSMFilter({
+        field: "genes.is_cancer_gene_census",
+        operation: {
+          operator: "includes",
+          field: "genes.is_cancer_gene_census",
+          operands: ["true"],
+        },
+      }),
+    );
+
+    store.dispatch(
+      updateGeneAndSSMFilter({
+        field: "genes.gene_id",
+        operation: {
+          field: "genes.gene_id",
+          operator: "includes",
+          operands: ["ENSG00000141510"],
+        },
+      }),
+    );
+
+    expect(store.getState().filters).toEqual({
+      mode: "and",
+      root: {
+        "genes.is_cancer_gene_census": {
+          operator: "includes",
+          field: "genes.is_cancer_gene_census",
+          operands: ["true"],
+        },
+        "genes.gene_id": {
+          operator: "includes",
+          field: "genes.gene_id",
+          operands: ["ENSG00000141510"],
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Description

## Checklist

- [x] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
