### PR TITLE
PEAR-2220 - Creating a cohort from Set Operations can be slow

### DIFF
--- a/packages/portal-proto/src/components/CohortCreationButton.tsx
+++ b/packages/portal-proto/src/components/CohortCreationButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useState } from "react";
-import { Tooltip, ButtonProps } from "@mantine/core";
+import { Tooltip, ButtonProps, Loader } from "@mantine/core";
 import { FaPlus as PlusIcon } from "react-icons/fa";
 import tw from "tailwind-styled-components";
 import { FilterSet, useCoreDispatch, Modals, showModal } from "@gff/core";
@@ -141,7 +141,11 @@ const CohortCreationButton: React.FC<CohortCreationButtonProps> = ({
           aria-label={tooltipText}
         >
           <IconWrapperTW $disabled={disabled} aria-hidden="true">
-            <PlusIcon color="white" size={12} />
+            {loading ? (
+              <Loader size={12} color="white" />
+            ) : (
+              <PlusIcon color="white" size={12} />
+            )}
           </IconWrapperTW>
           <span className="pr-2 self-center">{label ?? "--"}</span>
         </CohortCreationStyledButton>

--- a/packages/portal-proto/src/features/set-operations/CountButtonWrapperForSetsAndCases.tsx
+++ b/packages/portal-proto/src/features/set-operations/CountButtonWrapperForSetsAndCases.tsx
@@ -138,8 +138,8 @@ const CountButtonWrapperForSetsAndCases: React.FC<
   const createCohort = async () => {
     return await createSet({
       filters: filters,
-      intent: entityType == "cohort" ? "portal" : "user",
-      set_type: entityType == "cohort" ? "frozen" : "mutable",
+      intent: "portal",
+      set_type: "frozen",
     })
       .unwrap()
       .then((setId) => {


### PR DESCRIPTION
## Description
Adds loading state on button back. Thew slowness is from having to create a set before opening modal. The set operations sets are complicated/special and we can't create them in the same way so they need the pre modal opening load state.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

https://github.com/user-attachments/assets/f413512e-4ead-4d86-a33c-55bda76441e5
