### PR TITLE
PEAR-2211 - Change the focus behavior for the "Add a custom filter" modal window

### DIFF
--- a/packages/portal-proto/src/components/FacetSelection.tsx
+++ b/packages/portal-proto/src/components/FacetSelection.tsx
@@ -120,6 +120,7 @@ const FacetSelectionPanel = ({
   return (
     <div className="flex flex-col" data-testid="section-file-filter-search">
       <TextInput
+        data-autofocus
         label="Search for a property"
         data-testid="textbox-search-for-a-property"
         placeholder="search"


### PR DESCRIPTION
## Description
https://mantine.dev/core/modal/#initial-focus

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
