### PR TITLE
update proteinpaint-client version to 2.81.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26561,7 +26561,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.79.6",
+        "@sjcrh/proteinpaint-client": "^2.81.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -26706,9 +26706,9 @@
       }
     },
     "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.79.6",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.79.6.tgz",
-      "integrity": "sha512-r1y7cgCzLyRVm+IGMp+h214l1ubn55cytV+JWCe11Ai5MI4yZwstNRtVffLrSMnRHeHlOmGJyjZLTM3/6chuAg==",
+      "version": "2.81.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.81.1.tgz",
+      "integrity": "sha512-T4a6HRs3HKiWb0xfabNOxN64wDD+AonoIpGJPRym2u3H1SIJkt8LxEvkX9HhCfhRWkjIBOcbu/4yUq9LiU5geQ==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "^2.79.6",
+    "@sjcrh/proteinpaint-client": "^2.81.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description

Fixes:
- ProteinPaint: wait for the gene lookup request to return before detecting and displaying gene search errors

NOTE: The previously released gene search fix below did not fully work in qa-int/qa-yellow, due to a slightly slower server response time compared to local dev. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
