### PR TITLE
PEAR-2256 - Query Expressions, expand/collapse buttons no longer work

### DIFF
--- a/packages/portal-proto/src/components/CollapsibleContainer.tsx
+++ b/packages/portal-proto/src/components/CollapsibleContainer.tsx
@@ -86,7 +86,9 @@ export const CollapsibleContainer = (
       <div
         aria-hidden={isCollapsed}
         style={{ height: !isCollapsed ? descHeight : 0 }}
-        className="transition-[height] duration-300"
+        className={`transition-[height] duration-300 ${
+          isCollapsed ? "overflow-hidden" : ""
+        }`}
       >
         <div
           className={`${


### PR DESCRIPTION
## Description
This was caused by the fix for PEAR-2208 so it would be good to check that its still fixed.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
