### PR TITLE
bugfix: node-gyp not picking up proxy vars

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,8 @@ image: docker.osdc.io/ncigdc/nodejs20:3.0.6
 variables:
   DEPLOY_SERVICE_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
   NODE_VER: v20.15.1
-  npm_config_https_proxy: http://cloud-proxy:3128
-  npm_config_proxy: http://cloud-proxy:3128
+  npm_config_https_proxy: http://cloud-proxy-gdc:3128
+  npm_config_proxy: http://cloud-proxy-gdc:3128
   npm_config_registry: https://nexus.osdc.io/repository/npm-all/
 
 .default_rules: &default_rules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@ Prettier Checks:
     NODE_ENV: test
   before_script:
     - npm ci --cache .npm
+    - npm config set proxy ${npm_config_https_proxy}
   script:
     - npm run format:check
   <<: *default_rules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ Linting:
     NODE_ENV: test
     npm_config_tarball: /tmp/node-headers.tgz
   before_script:
-    - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
+    - curl -sSL https://nexus.osdc.io/repository/misc/nodejs/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - dnf install gcc-c++ make -y
     - npm ci
   script:
@@ -56,7 +56,7 @@ Prettier Checks:
     NODE_ENV: test
     npm_config_tarball: /tmp/node-headers.tgz
   before_script:
-    - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
+    - curl -sSL https://nexus.osdc.io/repository/misc/nodejs/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - dnf install gcc-c++ make -y
     - npm ci
   script:
@@ -69,7 +69,7 @@ Build and test core and portal:
     NODE_ENV: test
     npm_config_tarball: /tmp/node-headers.tgz
   before_script:
-    - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
+    - curl -sSL https://nexus.osdc.io/repository/misc/nodejs/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - dnf install gcc-c++ make -y
     - npm ci
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ Linting:
     npm_config_tarball: /tmp/node-headers.tgz
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
+    - dnf install gcc-c++ make -y
     - npm ci --cache .npm
   script:
     - npm run lint
@@ -57,6 +58,7 @@ Prettier Checks:
     npm_config_tarball: /tmp/node-headers.tgz
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
+    - dnf install gcc-c++ make -y
     - npm ci --cache .npm
   script:
     - npm run format:check
@@ -69,6 +71,7 @@ Build and test core and portal:
     npm_config_tarball: /tmp/node-headers.tgz
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
+    - dnf install gcc-c++ make -y
     - npm ci --cache .npm
   script:
     - cd ${CI_PROJECT_DIR}/packages/core

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,6 @@ image: docker.osdc.io/ncigdc/nodejs20:3.0.6
 
 variables:
   npm_config_registry: https://nexus.osdc.io/repository/npm-all/
-  npm_config_cache: .npm
   npm_config_proxy: http://cloud-proxy:3128
   npm_config_https_proxy: http://cloud-proxy:3128
   DEPLOY_SERVICE_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
@@ -45,7 +44,7 @@ Linting:
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - dnf install gcc-c++ make -y
-    - npm ci --cache .npm
+    - npm ci
   script:
     - npm run lint
   <<: *default_rules
@@ -59,7 +58,7 @@ Prettier Checks:
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - dnf install gcc-c++ make -y
-    - npm ci --cache .npm
+    - npm ci
   script:
     - npm run format:check
   <<: *default_rules
@@ -72,7 +71,7 @@ Build and test core and portal:
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - dnf install gcc-c++ make -y
-    - npm ci --cache .npm
+    - npm ci
   script:
     - cd ${CI_PROJECT_DIR}/packages/core
     - npm run build:clean

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,9 @@ Linting:
   stage: test
   variables:
     NODE_ENV: test
+    npm_config_tarball: /tmp/node-headers.tgz
   before_script:
+    - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - npm ci --cache .npm
   script:
     - npm run lint
@@ -64,7 +66,9 @@ Build and test core and portal:
   stage: test
   variables:
     NODE_ENV: test
+    npm_config_tarball: /tmp/node-headers.tgz
   before_script:
+    - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - npm ci --cache .npm
   script:
     - cd ${CI_PROJECT_DIR}/packages/core

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,9 +51,11 @@ Prettier Checks:
   stage: test
   variables:
     NODE_ENV: test
+    NODE_VER: v20.15.1
   before_script:
     - npm ci --cache .npm
-    - npm config set proxy ${npm_config_https_proxy}
+    - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
+    - npm config set tarball /tmp/node-headers.tgz
   script:
     - npm run format:check
   <<: *default_rules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,9 +52,9 @@ Prettier Checks:
   variables:
     NODE_ENV: test
     NODE_VER: v20.15.1
+    npm_config_tarball: /tmp/node-headers.tgz
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
-    - npm config set tarball /tmp/node-headers.tgz
     - npm ci --cache .npm
   script:
     - npm run format:check

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,10 +27,11 @@ stages:
 image: docker.osdc.io/ncigdc/nodejs20:3.0.6
 
 variables:
-  npm_config_registry: https://nexus.osdc.io/repository/npm-all/
-  npm_config_proxy: http://cloud-proxy:3128
-  npm_config_https_proxy: http://cloud-proxy:3128
   DEPLOY_SERVICE_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
+  NODE_VER: v20.15.1
+  npm_config_https_proxy: http://cloud-proxy:3128
+  npm_config_proxy: http://cloud-proxy:3128
+  npm_config_registry: https://nexus.osdc.io/repository/npm-all/
 
 .default_rules: &default_rules
   rules:
@@ -53,7 +54,6 @@ Prettier Checks:
   stage: test
   variables:
     NODE_ENV: test
-    NODE_VER: v20.15.1
     npm_config_tarball: /tmp/node-headers.tgz
   before_script:
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,9 +53,9 @@ Prettier Checks:
     NODE_ENV: test
     NODE_VER: v20.15.1
   before_script:
-    - npm ci --cache .npm
     - curl -sSL https://nodejs.org/download/release/${NODE_VER}/node-${NODE_VER}-headers.tar.gz -o /tmp/node-headers.tgz
     - npm config set tarball /tmp/node-headers.tgz
+    - npm ci --cache .npm
   script:
     - npm run format:check
   <<: *default_rules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,8 @@ image: docker.osdc.io/ncigdc/nodejs20:3.0.6
 variables:
   DEPLOY_SERVICE_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
   NODE_VER: v20.15.1
-  npm_config_https_proxy: http://cloud-proxy-gdc:3128
-  npm_config_proxy: http://cloud-proxy-gdc:3128
+  npm_config_https_proxy: http://cloud-proxy:3128
+  npm_config_proxy: http://cloud-proxy:3128
   npm_config_registry: https://nexus.osdc.io/repository/npm-all/
 
 .default_rules: &default_rules


### PR DESCRIPTION
## Description
node-gyp does not work with proxy vars and always wants to download from nodejs.org. See node-gyp/issues/1133 and 1154

Value of `NODE_VER` is the one that node-gyp tries to pull by default.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
