### PR TITLE
pluralize gene in mutation frequency

### DIFF
--- a/packages/portal-proto/src/features/genomic/filters.json
+++ b/packages/portal-proto/src/features/genomic/filters.json
@@ -1,7 +1,7 @@
 [
   {
     "full": "genes.gene_id",
-    "title": "Mutated Gene",
+    "title": "Mutated Genes",
     "name": "Genes",
     "facet_type": "set",
     "doc_type": "genes",


### PR DESCRIPTION
## Description
- pluralize "gene" in Mutation Frequency's filter card

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="419" alt="Screenshot 2024-11-18 at 3 17 29 PM" src="https://github.com/user-attachments/assets/fdd3476f-8294-4c92-bb2b-f3f3c9eadd0c">
