### PR TITLE
PEAR-2253 Make somatic mutations card title consistent

### DIFF
--- a/packages/portal-proto/src/features/genomic/filters.json
+++ b/packages/portal-proto/src/features/genomic/filters.json
@@ -9,7 +9,7 @@
   },
   {
     "full": "ssms.ssm_id",
-    "title": "Somatic Mutations",
+    "title": "Somatic Mutation",
     "name": "Somatic Mutations",
     "facet_type": "set",
     "doc_type": "ssms",


### PR DESCRIPTION
## Description
- made the "Somatic Mutations" card title singular in Mutation Frequency for consistency

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="402" alt="Screenshot 2024-11-19 at 12 08 23 PM" src="https://github.com/user-attachments/assets/807118d1-b8de-4e0f-a695-fdcbb3d31887">
