### PR TITLE
update the proteinpaint-client version to 2.88.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdc-frontend-framework",
-  "version": "2.14.0",
+  "version": "2.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdc-frontend-framework",
-      "version": "2.14.0",
+      "version": "2.15.5",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -28057,7 +28057,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "2.81.2",
+        "@sjcrh/proteinpaint-client": "2.88.0",
         "@tanstack/react-table": "^8.9.3",
         "filesize": "^8.0.7",
         "minisearch": "^3.0.4",
@@ -28171,10 +28171,9 @@
       }
     },
     "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.81.2",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.81.2.tgz",
-      "integrity": "sha512-6zOW8cSHwYIDISBFh9j5GdthadL2DfgKfoGQST5wJ6vTOWVuuIN6qqW0FNEARwXCUy7o7h6rybV1eA1zAle7fA==",
-      "license": "SEE LICENSE IN ./LICENSE",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.88.0.tgz",
+      "integrity": "sha512-X/AVwkltkUs57gJLabhPhhtLxLQqiUZKiDAUO9s2RPGfWlxZ7IAd+RrA6cECCB0lvz/KGtbBoZgiXV5rVwEzqw==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.8.1",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^1.8.5",
-    "@sjcrh/proteinpaint-client": "2.81.2",
+    "@sjcrh/proteinpaint-client": "2.88.0",
     "@tanstack/react-table": "^8.9.3",
     "filesize": "^8.0.7",
     "minisearch": "^3.0.4",


### PR DESCRIPTION
## Description
Features:
- hiercluster: make zscore transformation a checkbox option in Clustering menu

Fixes:
- matrix/hiercluster: show value when it equals to 0 in hover over tooltip and click menu
- Track proteinpaint-types as a prod dependency in server package.json so that it's installed in container.
- improve isNumeric() helper to not allow truncated alphanumeric parseFloat(), and create strictNumeric() helper
- detect and set the gdc version first before caching
- prototype cnv filter prompt to change cnvMaxLength
- handle genes that has no expression data for any sample in the gene exp clustering tool
- if a small number of radios, show in a single line by default
- do not allow <3 genes in the termdb/cluster request and instruct the user to do a page refresh to clear the error
- use string concat to preserve the apiHost.geneExp path that was being stripped by url.resolve()

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
