### PR TITLE
PEAR-2149 - Reverse Tabnabbing

### DIFF
--- a/packages/portal-proto/src/components/AnchorLink.tsx
+++ b/packages/portal-proto/src/components/AnchorLink.tsx
@@ -22,6 +22,7 @@ export const AnchorLink = ({
       <Link
         href={href}
         target="_blank"
+        rel="noreferrer"
         className="flex gap-1 underline font-content"
         data-testid={customDataTestID}
       >

--- a/packages/portal-proto/src/components/Modals/DownloadAccessAgreement.tsx
+++ b/packages/portal-proto/src/components/Modals/DownloadAccessAgreement.tsx
@@ -40,6 +40,7 @@ const DownloadAccessAgreement: React.FC<DownloadAccessAgreementProps> = ({
               size="sm"
               href="https://gdc.cancer.gov/about-data/data-analysis-policies"
               target="_blank"
+              rel="noreferrer"
               className="underline"
             >
               GDC Data Use Agreement
@@ -49,6 +50,7 @@ const DownloadAccessAgreement: React.FC<DownloadAccessAgreementProps> = ({
               size="sm"
               href={dbGapLink}
               target="_blank"
+              rel="noreferrer"
               className="underline"
             >
               dbGaP

--- a/packages/portal-proto/src/components/Summary/SummaryCount.tsx
+++ b/packages/portal-proto/src/components/Summary/SummaryCount.tsx
@@ -26,6 +26,7 @@ const SummaryCount = ({
           href={href}
           className="text-utility-link underline"
           target={shouldOpenInNewTab && "_blank"}
+          rel="noreferrer"
         >
           {count}
         </Link>

--- a/packages/portal-proto/src/features/charts/utils.ts
+++ b/packages/portal-proto/src/features/charts/utils.ts
@@ -13,6 +13,7 @@ const handleDownload = (href: string, filename: string) => {
   aElement.setAttribute("download", filename);
   aElement.href = href;
   aElement.setAttribute("target", "_blank");
+  aElement.setAttribute("rel", "noreferrer");
   aElement.click();
   URL.revokeObjectURL(href);
 };

--- a/packages/portal-proto/src/features/projects/utils.tsx
+++ b/packages/portal-proto/src/features/projects/utils.tsx
@@ -46,6 +46,7 @@ export const formatDataForSummary = (
         href={`https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=${dbGaP_study_accession}`}
         className="underline text-utility-link"
         target="_blank"
+        rel="noreferrer"
       >
         {dbGaP_study_accession}
       </Link>


### PR DESCRIPTION
## Description
I choose to use "noreferrer" since we're using that most places in the portal and "Using rel="noreferrer" implies also rel="noopener", so if you have chosen to use rel="noreferrer", the use of rel="noopener" isn’t required." (per this: https://owasp.org/www-community/attacks/Reverse_Tabnabbing) 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
