### PR TITLE
PEAR-2261 - Handle domain being removed from cookie returned in API responses

### DIFF
--- a/packages/core/src/listeners.ts
+++ b/packages/core/src/listeners.ts
@@ -141,7 +141,7 @@ startCoreListening({
     if (!Cookies.get("gdc_context_id")) {
       const contextId = localStorage.getItem("gdc_context_id");
       if (contextId) {
-        Cookies.set("gdc_context_id", contextId, { domain: ".gdc.cancer.gov" });
+        Cookies.set("gdc_context_id", contextId);
       }
     }
   },

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -42,10 +42,8 @@ const persistConfig = {
         // Retrieve context id from local storage when rehydrating the store
         const contextId = localStorage.getItem("gdc_context_id");
         if (contextId) {
-          Cookies.remove("gdc_context_id");
-          Cookies.set("gdc_context_id", contextId, {
-            domain: ".gdc.cancer.gov",
-          });
+          Cookies.remove("gdc_context_id", { domain: ".gdc.cancer.gov" });
+          Cookies.set("gdc_context_id", contextId);
         }
         return outboundState;
       },


### PR DESCRIPTION
## Description
- Remove domain from context id cookie, delete cookies with previous domain
- This doesn't quite work on dev sites (there are still duplicate cookies) but I think it will work on qa/prod

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
