### PR TITLE
fix the package-lock tracking of pp-client 2.94.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6299,6 +6299,15 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@sjcrh/proteinpaint-client": {
+      "version": "2.94.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.94.1.tgz",
+      "integrity": "sha512-lXcBKASGv5r1VZ9/HpdrRLKhw4yTDotSYo2HThdzOZuxKkn0vIaJf5uVs6XQQiHJmFlYxJPGL30sAfUt6sjh+w==",
+      "peerDependencies": {
+        "postcss": "^8.4.41",
+        "postcss-import": "^14.1.0"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -28100,7 +28109,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "2.94.1",
+        "@sjcrh/proteinpaint-client": "^2.94.1",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",
@@ -28213,15 +28222,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.92.1-0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.92.1-0.tgz",
-      "integrity": "sha512-CNUQToEWxBbAGxdjibsa7XSa+++EGQroWGkvzoVPCQY1uFMhQicO9nH6bMU3hBlmmpeBxHiviqw+QuiW7owz5w==",
-      "peerDependencies": {
-        "postcss": "^8.4.41",
-        "postcss-import": "^14.1.0"
       }
     },
     "packages/portal-proto/node_modules/@types/jest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28109,7 +28109,7 @@
         "@mantine/notifications": "^7.8.1",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^1.8.5",
-        "@sjcrh/proteinpaint-client": "^2.94.1",
+        "@sjcrh/proteinpaint-client": "2.94.1",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/next.config.js
+++ b/packages/portal-proto/next.config.js
@@ -4,6 +4,18 @@
  * means that the application will be available at "https://<host>/v2"
  */
 const basePath = process.env.NEXT_PUBLIC_BASEPATH;
+const PROTEINPAINT_API =
+  process.env.PROTEINPAINT_API || process.env.NEXT_PUBLIC_PROTEINPAINT_API;
+const connectSrc = [
+  "https://portal.gdc.cancer.gov",
+  "https://browser-intake-datadoghq.com",
+  "https://api.gdc.cancer.gov",
+  "https://www.google-analytics.com",
+];
+const PROTEINPAINT_HOST = PROTEINPAINT_API.split("://")[1]?.split("/")[0] || "";
+// in SJ dev environment, this would point to a local PP server instance
+if (!connectSrc.includes(`https://${PROTEINPAINT_HOST}`))
+  connectSrc.push(`https://${PROTEINPAINT_HOST}`);
 
 // Fallback if Docker is not run: This calls git directly
 const buildHash = () => {
@@ -22,7 +34,7 @@ const cspHeader = `
     default-src 'self';
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://assets.adobedtm.com https://dap.digitalgov.gov https://www.googletagmanager.com;
     style-src 'self' 'unsafe-inline';
-    connect-src 'self' https://portal.gdc.cancer.gov https://browser-intake-datadoghq.com https://api.gdc.cancer.gov https://www.google-analytics.com;
+    connect-src 'self' ${connectSrc.join(" ")};
     frame-src https://portal.gdc.cancer.gov;
     form-action https://portal.gdc.cancer.gov;
     img-src 'self' blob: data:;


### PR DESCRIPTION
This fixes the package-lock that incorrectly tracked a local dev version of the proteinpaint-client, instead of the published version this morning.

This update also adds the local PP dev server host to the connect-src directive, for SJ dev environments that use local PP server instance.

## Description

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
