### PR TITLE
add the ProteinPaint host to the connect-src directive only in dev

### DIFF
--- a/packages/portal-proto/next.config.js
+++ b/packages/portal-proto/next.config.js
@@ -4,18 +4,24 @@
  * means that the application will be available at "https://<host>/v2"
  */
 const basePath = process.env.NEXT_PUBLIC_BASEPATH;
-const PROTEINPAINT_API =
-  process.env.PROTEINPAINT_API || process.env.NEXT_PUBLIC_PROTEINPAINT_API;
 const connectSrc = [
   "https://portal.gdc.cancer.gov",
   "https://browser-intake-datadoghq.com",
   "https://api.gdc.cancer.gov",
   "https://www.google-analytics.com",
 ];
-const PROTEINPAINT_HOST = PROTEINPAINT_API.split("://")[1]?.split("/")[0] || "";
-// in SJ dev environment, this would point to a local PP server instance
-if (!connectSrc.includes(`https://${PROTEINPAINT_HOST}`))
-  connectSrc.push(`https://${PROTEINPAINT_HOST}`);
+
+if (process.env.NODE_ENV == "development") {
+  // in SJ dev environment, this would point to a local PP server instance
+  const PROTEINPAINT_API =
+    process.env.PROTEINPAINT_API ||
+    process.env.NEXT_PUBLIC_PROTEINPAINT_API ||
+    "";
+  const PROTEINPAINT_HOST =
+    PROTEINPAINT_API.split("://")[1]?.split("/")[0] || "";
+  if (PROTEINPAINT_HOST && !connectSrc.includes(`https://${PROTEINPAINT_HOST}`))
+    connectSrc.push(`https://${PROTEINPAINT_HOST}`);
+}
 
 // Fallback if Docker is not run: This calls git directly
 const buildHash = () => {


### PR DESCRIPTION
## Description

This update prevents unintentionally adding a PP API host to the connect-src directive in prod environment.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
