### PR TITLE
Qa 2365 update test automation 2.16.0 release

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
@@ -28,10 +28,10 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
 
 ## Clinical TSV
 * Navigate to "Cart" from "Header" "section"
-* Select "Download Associated Data" on the Cart page
-* Download "Clinical: TSV" from "Cart Header Dropdown"
-* Read file content from compressed "Clinical: TSV from Cart Header Dropdown"
-* Verify that "Clinical: TSV from Cart Header Dropdown" has expected information
+* Select "Clinical"
+* Download "TSV" from "Cart Header Dropdown"
+* Read file content from compressed "TSV from Cart Header Dropdown"
+* Verify that "TSV from Cart Header Dropdown" has expected information
     |required_info                        |
     |-------------------------------------|
     |follow_ups.barretts_esophagus_goblet_cells_present     |
@@ -85,7 +85,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |HCM-CSHL-0182-C25_other_clinical_attribute|
     |Initial Diagnosis                    |
 
-* Verify that "Clinical: TSV from Cart Header Dropdown" does not contain specified information
+* Verify that "TSV from Cart Header Dropdown" does not contain specified information
     |required_info                          |
     |---------------------------------------|
     |FM-AD                                  |
@@ -125,10 +125,10 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |exposures.weight                       |
 
 ## Clinical JSON
-* Select "Download Associated Data" on the Cart page
-* Download "Clinical: JSON" from "Cart Header Dropdown"
-* Read from "Clinical: JSON from Cart Header Dropdown"
-* Verify that "Clinical: JSON from Cart Header Dropdown" has expected information
+* Select "Clinical"
+* Download "JSON" from "Cart Header Dropdown"
+* Read from "JSON from Cart Header Dropdown"
+* Verify that "JSON from Cart Header Dropdown" has expected information
     |required_info                        |
     |-------------------------------------|
     |Current Reformed Smoker, Duration Not Specified |
@@ -171,7 +171,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |a242040c-f78a-4fa8-8960-8e2f1020f0d5 |
     |HCM-CSHL-0182-C25_other_clinical_attribute|
 
-* Verify that "Clinical: JSON from Cart Header Dropdown" does not contain specified information
+* Verify that "JSON from Cart Header Dropdown" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |
@@ -179,10 +179,10 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |APOLLO                               |
 
 ## Biospecimen TSV
-* Select "Download Associated Data" on the Cart page
-* Download "Biospecimen: TSV" from "Cart Header Dropdown"
-* Read file content from compressed "Biospecimen: TSV from Cart Header Dropdown"
-* Verify that "Biospecimen: TSV from Cart Header Dropdown" has expected information
+* Select "Biospecimen"
+* Download "TSV" from "Cart Header Dropdown"
+* Read file content from compressed "TSV from Cart Header Dropdown"
+* Verify that "TSV from Cart Header Dropdown" has expected information
     |required_info                        |
     |-------------------------------------|
     |portion_id                           |
@@ -235,7 +235,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |TCGA-BG-A0M0-01Z-00-DX1              |
     |98.0                                 |
     |BOTTOM                               |
-* Verify that "Biospecimen: TSV from Cart Header Dropdown" does not contain specified information
+* Verify that "TSV from Cart Header Dropdown" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |
@@ -243,10 +243,10 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |APOLLO                               |
 
 ## Biospecimen JSON
-* Select "Download Associated Data" on the Cart page
-* Download "Biospecimen: JSON" from "Cart Header Dropdown"
-* Read from "Biospecimen: JSON from Cart Header Dropdown"
-* Verify that "Biospecimen: JSON from Cart Header Dropdown" has expected information
+* Select "Biospecimen"
+* Download "JSON" from "Cart Header Dropdown"
+* Read from "JSON from Cart Header Dropdown"
+* Verify that "JSON from Cart Header Dropdown" has expected information
     |required_info                        |
     |-------------------------------------|
     |1ae8657f-477f-4e1a-aef2-dd1c1ab5f26a |
@@ -291,7 +291,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |5341a8a5-acac-5a24-a963-d27dbecc5db2 |
     |3df88b48-da53-4014-9507-de070223d1dd |
     |91e73c21-abd7-4c20-ac1e-81f4dabc7511 |
-* Verify that "Biospecimen: JSON from Cart Header Dropdown" does not contain specified information
+* Verify that "JSON from Cart Header Dropdown" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |
@@ -299,10 +299,9 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |APOLLO                               |
 
 ## Sample Sheet
-* Select "Download Associated Data" on the Cart page
-* Download "Sample Sheet" from "Cart Header Dropdown"
-* Read from "Sample Sheet from Cart Header Dropdown"
-* Verify that "Sample Sheet from Cart Header Dropdown" has expected information
+* Download "Sample Sheet" from "Page"
+* Read from "Sample Sheet from Page"
+* Verify that "Sample Sheet from Page" has expected information
     |required_info                        |
     |-------------------------------------|
     |File ID                              |
@@ -325,7 +324,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |d342f285-b9ba-4737-b668-09bfc761e74f |
     |93d6d769-17fe-4bc9-bf94-bc9f92f1c747 |
     |TCGA-BG-A0M0-10A, TCGA-BG-A0M0-01A   |
-* Verify that "Sample Sheet from Cart Header Dropdown" does not contain specified information
+* Verify that "Sample Sheet from Page" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |
@@ -333,10 +332,9 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |APOLLO                               |
 
 ## Metadata
-* Select "Download Associated Data" on the Cart page
-* Download "Metadata" from "Cart Header Dropdown"
-* Read from "Metadata from Cart Header Dropdown"
-* Verify that "Metadata from Cart Header Dropdown" has expected information
+* Download "Metadata" from "Page"
+* Read from "Metadata from Page"
+* Verify that "Metadata from Page" has expected information
     |required_info                        |
     |-------------------------------------|
     |data_format	                      |
@@ -392,7 +390,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |0.00013948633598826976               |
     |0.022844                             |
     |8cd9cd506d600cbeb4abbe6470babf6f     |
-* Verify that "Metadata from Cart Header Dropdown" does not contain specified information
+* Verify that "Metadata from Page" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/cohort_builder_search_bar.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/cohort_builder_search_bar.spec
@@ -42,7 +42,7 @@ tags: gdc-data-portal-v2, cohort-builder, search-bar, regression
   |Project                |Project                |
 
 * Enter "age at index" in the text box "Cohort Builder Search Bar"
-
+* Pause "1" seconds
 * Expected result "cohort-builder-search-no-results" in the search bar on the Cohort Builder page
 
 * Add a custom filter from "Custom Filters" tab on the Cohort Builder page
@@ -55,9 +55,10 @@ and come back so it loads in and becomes searchable. This is only
 with automation, performing it manually works as expected.
 * Navigate to "Analysis" from "Header" "section"
 * Navigate to "Cohort" from "Header" "section"
+* Pause "2" seconds
 
 * Enter "age at index" in the text box "Cohort Builder Search Bar"
-
+* Pause "1" seconds
 * Expected result "age at index" in the search bar on the Cohort Builder page
 
 * Select search bar result and validate the presence of correct facet card

--- a/holmes-py/specs/gdc_data_portal_v2/file_summary/validate_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/file_summary/validate_tables.spec
@@ -50,8 +50,11 @@ tags: gdc-data-portal-v2, regression, file-summary
     |text_to_validate                       |
     |---------------------------------------|
     |Workflow Type                          |
-    |Workflow Completion Date               |
     |Birdseed                               |
+* Verify the table "Analysis File Summary" is not displaying this information
+    |text_to_validate                       |
+    |---------------------------------------|
+    |Workflow Completion Date               |
     |2023-03-10                             |
 
 ## Verify Reference Genome Table is Not Present

--- a/holmes-py/specs/gdc_data_portal_v2/footer/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/footer/link_checking.spec
@@ -21,7 +21,7 @@ tags: gdc-data-portal-v2, regression, footer, navigation
   |Data Portal                                |A repository and computational platform for cancer researchers |
   |Website                                    |The NCI's Genomic Data Commons                                 |
   |API                                        |The GDC Application Programming Interface (API)                |
-  |Data Transfer Tool                         |The GDC Data Transfer Tool, a command-line driven application  |
+  |Data Transfer Tool                         |The GDC Data Transfer Tool provides an optimized method        |
   |Documentation                              |can find detailed information on GDC processes and tools       |
   |Data Submission Portal                     |The GDC Data Submission Portal is a web-based system           |
   |Publications                               |To request a publication page that meets the above criteria    |

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/filter_check.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/filter_check.spec
@@ -17,7 +17,7 @@ tags: gdc-data-portal-v2, mutation-frequency, regression
   |filter_name            |
   |-----------------------|
   |Mutated Gene           |
-  |Somatic Mutations      |
+  |Somatic Mutation       |
   |Biotype                |
   |VEP Impact             |
   |SIFT Impact            |
@@ -25,12 +25,12 @@ tags: gdc-data-portal-v2, mutation-frequency, regression
   |Consequence Type       |
   |Type                   |
 * Switch to "Mutations" tab in the Mutation Frequency app
-* Is text "somatic mutations" present on the page
+* Is text "Not Mutated Cases" present on the page
 * Verify presence of filter card
   |filter_name            |
   |-----------------------|
   |Mutated Gene           |
-  |Somatic Mutations      |
+  |Somatic Mutation       |
   |Biotype                |
   |VEP Impact             |
   |SIFT Impact            |

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -182,6 +182,7 @@ def download_file_at_file_table(file: str, source: str):
         "File Summary File Versions": APP.file_summary_page.click_file_version_download_option,
         "Manage Sets": APP.manage_sets_page.click_on_download_for_set,
         "Mutation Frequency": APP.mutation_frequency_page.click_table_download_button,
+        "Page": APP.shared.click_button_with_displayed_text_name,
         "Projects": APP.projects_page.click_button,
         "Project Summary": APP.project_summary_page.click_button,
         "Project Summary Biospecimen": APP.project_summary_page.click_biospecimen_download_button,


### PR DESCRIPTION
## Description
- Updated test automation to align with changes in 2.16.0 release

What files to test: 
vpn2, qa-int 
gauge run specs/gdc_data_portal_v2/cart/download_associated_data.spec
gauge run specs/gdc_data_portal_v2/cohort_builder/cohort_builder_search_bar.spec
gauge run specs/gdc_data_portal_v2/file_summary/validate_tables.spec
gauge run specs/gdc_data_portal_v2/footer/link_checking.spec
gauge run specs/gdc_data_portal_v2/mutation_frequency/filter_check.spec