### PR TITLE
PEAR-2294 - Quick Search - Randomly, search navigation will not work

### DIFF
--- a/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
+++ b/packages/portal-proto/src/components/QuickSearch/QuickSearch.tsx
@@ -205,9 +205,11 @@ export const QuickSearch = (): JSX.Element => {
     if (!id) {
       return;
     }
-    const selectedObj = fileHistory
+
+    const selectedObj = supersededFile
       ? fileHistory.find((h) => h.uuid === id)
       : matchedSearchList.find((obj) => obj.value == id).obj;
+
     const entityPath = extractEntityPath(selectedObj);
     router.push(entityPath);
     setSearchText("");
@@ -258,7 +260,9 @@ export const QuickSearch = (): JSX.Element => {
         ) : undefined
       }
       onSearchChange={(query) => {
-        setLoading(true);
+        if (query !== "") {
+          setLoading(true);
+        }
         setMatchedSearchList([]);
         setSearchText(query);
       }}


### PR DESCRIPTION
## Description
This was caused by some sort of race condition where the file history call was getting fetched/used when it shouldn't be. Wasn't able to pinpoint why that was happening but this at least prevents the error caused by the onclick event using file history data incorrectly in that case. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
