### PR TITLE
create an scRNAseq file count hook for the corresponding ATF card

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/scRNAseqCaseCount.ts
+++ b/packages/portal-proto/src/features/proteinpaint/scRNAseqCaseCount.ts
@@ -1,12 +1,12 @@
 import { graphqlAPISlice, buildCohortGqlOperator, FilterSet } from "@gff/core";
 
 const graphQLQuery = `
-  query scRNAseqFileCountQuery($cohortFilters: FiltersArgument,
-  $scRNAseqFileFilter: FiltersArgument) {
+  query scRNAseqCaseCountQuery($cohortFilters: FiltersArgument,
+  $scRNAseqCaseFilter: FiltersArgument) {
   viewer {
     explore {
-      scRNAseqFileCount : cases {
-        hits(case_filters: $cohortFilters, filters: $scRNAseqFileFilter, first: 0) {
+      scRNAseqCaseCount : cases {
+        hits(case_filters: $cohortFilters, filters: $scRNAseqCaseFilter, first: 0) {
           total
         }
       }
@@ -17,13 +17,13 @@ const graphQLQuery = `
 /**
  * Injects endpoints for case counts for sequenceReads
  */
-const scRNAseqFileCountSlice = graphqlAPISlice.injectEndpoints({
+const scRNAseqCaseCountSlice = graphqlAPISlice.injectEndpoints({
   endpoints: (builder) => ({
-    scRNAseqFileCount: builder.query<number, FilterSet>({
+    scRNAseqCaseCount: builder.query<number, FilterSet>({
       query: (cohortFilters) => {
         const graphQLFilters = {
           cohortFilters: buildCohortGqlOperator(cohortFilters),
-          scRNAseqFileFilter: {
+          scRNAseqCaseFilter: {
             op: "and",
             content: [
               {
@@ -56,9 +56,9 @@ const scRNAseqFileCountSlice = graphqlAPISlice.injectEndpoints({
         };
       },
       transformResponse: (response) =>
-        response?.data?.viewer?.explore?.scRNAseqFileCount?.hits?.total ?? 0,
+        response?.data?.viewer?.explore?.scRNAseqCaseCount?.hits?.total ?? 0,
     }),
   }),
 });
 
-export const { useLazyScRNAseqFileCountQuery } = scRNAseqFileCountSlice;
+export const { useLazyScRNAseqCaseCountQuery } = scRNAseqCaseCountSlice;

--- a/packages/portal-proto/src/features/proteinpaint/scRNAseqCounts.ts
+++ b/packages/portal-proto/src/features/proteinpaint/scRNAseqCounts.ts
@@ -1,0 +1,64 @@
+import { graphqlAPISlice, buildCohortGqlOperator, FilterSet } from "@gff/core";
+
+const graphQLQuery = `
+  query scRNAseqFileCountQuery($cohortFilters: FiltersArgument,
+  $scRNAseqFileFilter: FiltersArgument) {
+  viewer {
+    explore {
+      scRNAseqFileCount : cases {
+        hits(case_filters: $cohortFilters, filters: $scRNAseqFileFilter, first: 0) {
+          total
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * Injects endpoints for case counts for sequenceReads
+ */
+const scRNAseqFileCountSlice = graphqlAPISlice.injectEndpoints({
+  endpoints: (builder) => ({
+    scRNAseqFileCount: builder.query<number, FilterSet>({
+      query: (cohortFilters) => {
+        const graphQLFilters = {
+          cohortFilters: buildCohortGqlOperator(cohortFilters),
+          scRNAseqFileFilter: {
+            op: "and",
+            content: [
+              {
+                op: "in",
+                content: {
+                  field: "files.data_format",
+                  value: "tsv",
+                },
+              },
+              {
+                op: "in",
+                content: {
+                  field: "files.data_type",
+                  value: "Single Cell Analysis",
+                },
+              },
+              {
+                op: "in",
+                content: {
+                  field: "files.experimental_strategy",
+                  value: ["scRNA-Seq"],
+                },
+              },
+            ],
+          },
+        };
+        return {
+          graphQLFilters,
+          graphQLQuery,
+        };
+      },
+      transformResponse: (response) =>
+        response?.data?.viewer?.explore?.scRNAseqFileCount?.hits?.total ?? 0,
+    }),
+  }),
+});
+
+export const { useLazyScRNAseqFileCountQuery } = scRNAseqFileCountSlice;

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -16,7 +16,7 @@ import ProteinPaintIcon from "public/user-flow/icons/apps/ProteinPaint.svg";
 import OncoMatrixIcon from "public/user-flow/icons/apps/OncoMatrix.svg";
 import GeneExpressionIcon from "public/user-flow/icons/apps/GeneExpression.svg";
 import ScRNASeqIcon from "public/user-flow/icons/apps/scRNASeq.svg";
-import { useLazyScRNAseqFileCountQuery } from "../../proteinpaint/scRNAseqCounts";
+import { useLazyScRNAseqCaseCountQuery } from "../../proteinpaint/scRNAseqCaseCount";
 import { CountHookRegistry } from "@gff/core";
 import {
   DISPLAY_SC_RNA_SEQ_APP,
@@ -24,8 +24,8 @@ import {
 } from "@/features/featureFlags";
 
 CountHookRegistry.getInstance().registerHook(
-  "scRNAseqFileCount",
-  useLazyScRNAseqFileCountQuery,
+  "scRNAseqCaseCount",
+  useLazyScRNAseqCaseCountQuery,
 );
 
 export const COHORTS = [
@@ -237,7 +237,7 @@ export const REGISTERED_APPS = [
           //hasDemo: true,
           description: "scRNAseq Visualization tool",
           id: "scRNAseq",
-          countsField: "scRNAseqFileCount",
+          countsField: "scRNAseqCaseCount",
           optimizeRules: ["available data = ssm or cnv"],
           noDataTooltip:
             "Current cohort does not have scRNAseq data available for visualization.",

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -16,10 +16,17 @@ import ProteinPaintIcon from "public/user-flow/icons/apps/ProteinPaint.svg";
 import OncoMatrixIcon from "public/user-flow/icons/apps/OncoMatrix.svg";
 import GeneExpressionIcon from "public/user-flow/icons/apps/GeneExpression.svg";
 import ScRNASeqIcon from "public/user-flow/icons/apps/scRNASeq.svg";
+import { useLazyScRNAseqFileCountQuery } from "../../proteinpaint/scRNAseqCounts";
+import { CountHookRegistry } from "@gff/core";
 import {
   DISPLAY_SC_RNA_SEQ_APP,
   isFeatureEnabled,
 } from "@/features/featureFlags";
+
+CountHookRegistry.getInstance().registerHook(
+  "scRNAseqFileCount",
+  useLazyScRNAseqFileCountQuery,
+);
 
 export const COHORTS = [
   { name: "New Custom Cohort", facets: [] },
@@ -230,7 +237,7 @@ export const REGISTERED_APPS = [
           //hasDemo: true,
           description: "scRNAseq Visualization tool",
           id: "scRNAseq",
-          countsField: "caseCount",
+          countsField: "scRNAseqFileCount",
           optimizeRules: ["available data = ssm or cnv"],
           noDataTooltip:
             "Current cohort does not have scRNAseq data available for visualization.",


### PR DESCRIPTION
## Description

This branch creates an scRNAseq case count for the corresponding ATF card.

@craigrbarnes I followed the [card count doc](https://docs.gdc.cancer.gov/Data_Portal/Users_Guide/Developers_Guide/#application-card-counts) and used `counts/hooks/mafFileCount.ts` in gff-core as a template. I'm not able to find unit test examples to use as a guide/template for writing scRNAseqCaseCount.ts tests, please advise as needed. If the resulting case count is fully dependent on the request filter + API response, then maybe a unit test is not needed?

Tested manually
1. without cohort filter: 36 unique cases (1 seurat file each) + 8 extra seurat files for a few cases = 44 files as shown in the table above the rendered scRNAseq plot

![Screenshot 2025-01-30 at 8 20 55 PM](https://github.com/user-attachments/assets/d7164e50-1698-454e-8ec8-4d4583fa6e67)

![Screenshot 2025-01-30 at 8 22 34 PM](https://github.com/user-attachments/assets/c8cd31d5-1ca2-4902-a29b-6f5e2b214d2a)

2. with CPTAC progam as filter: 28 cases + 8 extra files (not unique to a case) = 36 table rows above rendered plot

![Screenshot 2025-01-31 at 9 19 36 AM](https://github.com/user-attachments/assets/ee9a2efa-e7ca-4b2e-8ded-eae88b769fd9)

![Screenshot 2025-01-31 at 9 23 14 AM](https://github.com/user-attachments/assets/259e2f55-25cd-4025-b1b2-3a034ba002aa)


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
