### PR TITLE
update proteinpaint-client version to 2.104.1-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6315,6 +6315,15 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@sjcrh/proteinpaint-client": {
+      "version": "2.104.1-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.104.1-0.tgz",
+      "integrity": "sha512-9tBd1KMTJdoxGQ/vCs3haeGJ5VQxRb7sdVxQt8DpUcgAjQdRaLQe1vo9rWZiGQ66N1M+PWKaNnrQTY2LtopPPg==",
+      "peerDependencies": {
+        "postcss": "^8.4.41",
+        "postcss-import": "^14.1.0"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -28110,7 +28119,7 @@
         "@mantine/notifications": "^7.14.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^2.5.0",
-        "@sjcrh/proteinpaint-client": "2.98.0",
+        "@sjcrh/proteinpaint-client": "^2.104.1-0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",
@@ -28244,15 +28253,6 @@
       "integrity": "sha512-8ZVRr6D/8GEu2VmUVU447w4H+hl9dwefl//GpSGI2vKxXBqlud5X9PJQkSwi5J7I5FAxvlG5dr/zCxC3r3nsIQ==",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
-      }
-    },
-    "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.98.0.tgz",
-      "integrity": "sha512-38hSoAviGinMXlqbXyBfRPOjnNH9mOvptnNgf3MIy8lXGTqTyg0yC+SKmNCeuBgn7BaeHQJTxVoRRWOJs8ADXw==",
-      "peerDependencies": {
-        "postcss": "^8.4.41",
-        "postcss-import": "^14.1.0"
       }
     },
     "packages/portal-proto/node_modules/@types/jest": {

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.14.3",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^2.5.0",
-    "@sjcrh/proteinpaint-client": "2.98.0",
+    "@sjcrh/proteinpaint-client": "^2.104.1-0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

ScRNAseq:
Features:
- added legend menu upon click
- showed active sample on tab instead of moving samples table above
- show extra properties in sample tab

Fixes:
- address section 508 issues in single cell plot, mostly to label control inputs

OncoMatrix:
Features:
- show white border for snvIndel cell in oncoPrint mode when CNV also presents
- exclude splice region consequence by default

ProteinPaint:
Fixes:
- address section 508 issues in single cell plot, mostly to label control inputs

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
