### PR TITLE
PEAR-2325 - Cohort Builder Search - After navigating, the portal may erroneously search for the title of the facet card into the facet card

### DIFF
--- a/packages/portal-proto/src/components/SearchInput.tsx
+++ b/packages/portal-proto/src/components/SearchInput.tsx
@@ -116,9 +116,7 @@ export const SearchInput: React.FC = () => {
     });
 
     const matches = Object.values(result?.match || {});
-    const enumSearchResult =
-      matches.some((m) => m.includes("enum")) &&
-      !matches.some((m) => m.includes("name"));
+    const enumSearchResult = matches.some((m) => m.includes("enum"));
 
     const additionalQuery = enumSearchResult
       ? { tab: result.categoryKey, searchTerm }

--- a/packages/portal-proto/src/components/SearchInput.tsx
+++ b/packages/portal-proto/src/components/SearchInput.tsx
@@ -115,9 +115,10 @@ export const SearchInput: React.FC = () => {
       hash: undefined,
     });
 
-    const enumSearchResult = Object.values(result?.match || {}).some((m) =>
-      m.includes("enum"),
-    );
+    const matches = Object.values(result?.match || {});
+    const enumSearchResult =
+      matches.some((m) => m.includes("enum")) &&
+      !matches.some((m) => m.includes("name"));
 
     const additionalQuery = enumSearchResult
       ? { tab: result.categoryKey, searchTerm }
@@ -393,7 +394,7 @@ export const SearchInput: React.FC = () => {
                           label={
                             <>
                               <Highlight
-                                highlight={searchTerm}
+                                highlight={result.terms}
                                 highlightStyles={{ fontStyle: "italic" }}
                               >
                                 {result.description}
@@ -407,7 +408,7 @@ export const SearchInput: React.FC = () => {
                                     {MAX_MATCHED_VALUES}):
                                   </b>
                                   <Highlight
-                                    highlight={searchTerm}
+                                    highlight={result.terms}
                                     highlightStyles={{ fontStyle: "italic" }}
                                   >
                                     {matchingEnums.join(" • ")}

--- a/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
@@ -49,6 +49,8 @@ export const get_facets = (
     });
 };
 
+export const STOP_WORDS = new Set(["of", "or"]);
+
 export interface FacetSearchDocument {
   name: string;
   category: string;
@@ -60,6 +62,7 @@ export interface FacetSearchDocument {
 export const miniSearch = new MiniSearch<FacetSearchDocument>({
   fields: ["name", "description", "enum"], // fields to index for full-text search
   storeFields: ["name", "category", "categoryKey", "description", "enum", "id"], // fields to return with search results
+  processTerm: (term) => (STOP_WORDS.has(term) ? null : term.toLowerCase()), // index term processing
   searchOptions: {
     boost: {
       name: 1.5,

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -15,6 +15,21 @@ import FacetControlsHeader from "./FacetControlsHeader";
 import { BAD_DATA_MESSAGE } from "./constants";
 import { CloseIcon } from "@/utils/icons";
 import { calculateStickyHeaderHeight } from "src/utils/";
+import MiniSearch, { SearchResult } from "minisearch";
+import { STOP_WORDS } from "../cohortBuilder/dictionary";
+
+interface FacetResultDoc {
+  enum: string;
+  count: number;
+}
+
+type FullResults = FacetResultDoc & SearchResult;
+
+export const miniSearch = new MiniSearch<FacetResultDoc>({
+  fields: ["enum"],
+  storeFields: ["enum", "count"],
+  processTerm: (term) => (STOP_WORDS.has(term) ? null : term.toLowerCase()), // index term processing
+});
 
 /**
  *  Enumeration facet filters handle display and selection of
@@ -188,14 +203,32 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
           }, [] as Array<[string, number]>)
         : [];
 
-      const filteredData = [
-        ...tempFilteredData,
-        ...selectedEnumNotInData,
-      ].filter((entry) =>
-        searchTerm === ""
-          ? entry
-          : entry[0].toLowerCase().includes(searchTerm.toLowerCase().trim()),
-      );
+      const enumData = [...tempFilteredData, ...selectedEnumNotInData];
+
+      let filteredData = enumData;
+
+      if (searchTerm) {
+        miniSearch.removeAll();
+
+        const searchDocuments = enumData.map((entry) => ({
+          id: entry[0],
+          enum: entry[0],
+          count: entry[1],
+        }));
+
+        miniSearch.addAll(searchDocuments);
+
+        const results = miniSearch.search(searchTerm, {
+          prefix: true,
+          combineWith: "OR",
+        });
+
+        const searchResults: [string, number][] = (
+          results as FullResults[]
+        ).map((result) => [result.enum, result.count]);
+
+        filteredData = searchResults;
+      }
 
       const remainingValues = filteredData.length - maxValuesToDisplay;
       const cardStyle = calcCardStyle(remainingValues);


### PR DESCRIPTION
## Description
- Doesn't add search term if there is a match in the name of the field
- Facet cards use minisearch to look for results as well, so the results on the card line up with the values in the Search Bar
- Fix highlighting of values in search bar

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
