### PR TITLE
PEAR-2328: Fix for Cohort Bar - Endless loading spinner can appear if user clicks "add new unsaved cohort" button too fast

### DIFF
--- a/packages/core/src/listeners.ts
+++ b/packages/core/src/listeners.ts
@@ -86,7 +86,7 @@ startCoreListening({
   effect: async (_, listenerApi) => {
     // the last cohort added is the one we want to get the case count for
     const cohorts = selectAvailableCohorts(listenerApi.getState()).sort(
-      (a, b) => (a.modified_datetime <= b.modified_datetime ? 1 : -1),
+      (a, b) => b.modified_datetime.localeCompare(a.modified_datetime),
     );
     const latestCohortId = cohorts[0]?.id;
     listenerApi.dispatch(fetchCohortCaseCounts(latestCohortId));

--- a/packages/core/src/listeners.ts
+++ b/packages/core/src/listeners.ts
@@ -86,7 +86,11 @@ startCoreListening({
   effect: async (_, listenerApi) => {
     // the last cohort added is the one we want to get the case count for
     const cohorts = selectAvailableCohorts(listenerApi.getState()).sort(
-      (a, b) => b.modified_datetime.localeCompare(a.modified_datetime),
+      (a, b) => {
+        const dateA = new Date(a.modified_datetime);
+        const dateB = new Date(b.modified_datetime);
+        return dateB.getTime() - dateA.getTime();
+      },
     );
     const latestCohortId = cohorts[0]?.id;
     listenerApi.dispatch(fetchCohortCaseCounts(latestCohortId));


### PR DESCRIPTION
## Description

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
