### PR TITLE
Remove margin to save space for the pp based analysis tool content

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/CohortLevelMafWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CohortLevelMafWrapper.tsx
@@ -61,7 +61,6 @@ export const CohortLevelMafWrapper: FC<PpProps> = (props: PpProps) => {
     <div>
       <div
         ref={divRef}
-        style={{ margin: "2em" }}
         className="sjpp-wrapper-root-div"
         //userDetails={userDetails}
       />

--- a/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
@@ -234,7 +234,6 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
       {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
       <div
         ref={divRef}
-        style={{ margin: "2em" }}
         className="sjpp-wrapper-root-div"
         //userDetails={userDetails}
       />

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -139,7 +139,6 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
       )}
       <div
         ref={divRef}
-        style={{ margin: "2em" }}
         className="sjpp-wrapper-root-div"
         //userDetails={userDetails}
       />

--- a/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ScRNAseqWrapper.tsx
@@ -77,7 +77,6 @@ export const ScRNAseqWrapper: FC<PpProps> = (props: PpProps) => {
     <div>
       <div
         ref={divRef}
-        style={{ margin: "2em" }}
         className="sjpp-wrapper-root-div"
         //userDetails={userDetails}
       />

--- a/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/SequenceReadWrapper.tsx
@@ -77,7 +77,7 @@ export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
     <div>
       <div
         ref={alertRef}
-        style={{ margin: "2em", display: `${alertDisplay}` }}
+        style={{ display: `${alertDisplay}` }}
         className="sjpp-wrapper-alert-div"
       >
         <b>Access alert</b>
@@ -92,7 +92,7 @@ export const SequenceReadWrapper: FC<PpProps> = (props: PpProps) => {
       </div>
       <div
         ref={divRef}
-        style={{ margin: "2em", display: `${rootDisplay}` }}
+        style={{ display: `${rootDisplay}` }}
         className="sjpp-wrapper-root-div"
       ></div>
     </div>


### PR DESCRIPTION
## Description

This allows to save space for the pp analysis tools

## Checklist

- [] Added proper unit tests
- [] Left proper TODO messages for any remaining tasks
- [] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
