### PR TITLE
Qa 2378 test automation update 2.16.0 continued

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
@@ -326,12 +326,22 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |d342f285-b9ba-4737-b668-09bfc761e74f |
     |93d6d769-17fe-4bc9-bf94-bc9f92f1c747 |
     |TCGA-BG-A0M0-10A, TCGA-BG-A0M0-01A   |
+    |Normal, Tumor                        |
+    |Tumor, Normal                        |
+    |Primary, Not Applicable              |
+    |Metastatic                           |
+    |3D Organoid, Buffy Coat              |
+    |Solid Tissue, Unknown                |
+    |Unknown, OCT                         |
+    |Frozen, Frozen                       |
+
 * Verify that "Sample Sheet from Page" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |
     |TCGA-LUAD                            |
     |APOLLO                               |
+    |Sample Type                          |
 
 ## Metadata
 * Download "Metadata" from "Page"

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/categories_facet_card_presence.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/categories_facet_card_presence.spec
@@ -56,6 +56,8 @@ tags: gdc-data-portal-v2, cohort-builder, facet-cards, regression
   |Synchronous Malignancy     |
   |Progression or Recurrence  |
   |Residual Disease           |
+  |Child Pugh Classification  |
+  |Ishak Fibrosis Score       |
 
 * Validate presence of facet cards on the "Disease Specific Classifications" tab on the Cohort Builder page
   |facet_name                 |
@@ -75,6 +77,7 @@ tags: gdc-data-portal-v2, cohort-builder, facet-cards, regression
   |International Prognostic Index |
   |Eln Risk Classification        |
   |Wilms Tumor Histologic Subtype |
+  |Weiss Assessment Score     |
 
 * Validate presence of facet cards on the "Treatment" tab on the Cohort Builder page
   |facet_name                 |

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/categories_facet_card_presence.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/categories_facet_card_presence.spec
@@ -105,7 +105,6 @@ tags: gdc-data-portal-v2, cohort-builder, facet-cards, regression
   |Biospecimen Anatomic Site  |
   |Specimen Type              |
   |Preservation Method        |
-  |Tumor Code                 |
   |Tumor Descriptor           |
   |Analyte Type               |
 

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec
@@ -361,6 +361,12 @@ tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecime
     |BEATAML1.0-COHORT                    |
     |ORGANOID-PANCREATIC                  |
     |S181                                 |
+    |Normal                               |
+    |Not Applicable                       |
+    |3D Organoid                          |
+    |Peripheral Blood NOS                 |
+    |Fresh                                |
+
 * Verify that "Sample Sheet from Cohort Case View Files" does not contain specified information
     |required_info                        |
     |-------------------------------------|
@@ -368,6 +374,7 @@ tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecime
     |TCGA                                 |
     |gliomas                              |
     |FM-AD                                |
+    |Sample Type                          |
 
 ## Flip Filters
 * Perform the following actions on a filter card in Cohort Summary View

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/is_cancer_gene_census.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/is_cancer_gene_census.spec
@@ -95,6 +95,8 @@ tags: gdc-data-portal-v2, regression, mutation-frequency, is-cancer-census-off
   |FAT4                               |
   |ABCB                               |
   |ABCC                               |
+  |num_cohort_cnv_loss_cases          |
+  |cohort_cnv_loss_cases_percentage   |
 
 ## Gene Table - Select Mutations Filter Button
 * Search the table for ""

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/table_tsv_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/table_tsv_download.spec
@@ -65,6 +65,8 @@ but it usually requires a wait. So I've put 5 seconds.
   |MUC16                                  |
   |FAT3                                   |
   |MUC16                                  |
+  |num_cohort_cnv_loss_cases              |
+  |cohort_cnv_loss_cases_percentage       |
 * Perform the following actions on a filter card
   |filter_name          |action               |
   |---------------------|---------------------|


### PR DESCRIPTION
## Description
- Update sample sheet download expected data
- Test for new facet cards in cohort builder
- Mutation Frequency gene table update test data

Test: 
qa-int, vpn2
`gauge run specs/gdc_data_portal_v2/cart/download_associated_data.spec specs/gdc_data_portal_v2/cohort_builder/categories_facet_card_presence.spec specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec specs/gdc_data_portal_v2/mutation_frequency/is_cancer_gene_census.spec specs/gdc_data_portal_v2/mutation_frequency/table_tsv_download.spec`