### PR TITLE
removes deprecated default tumor code card from cohort builder

### DIFF
--- a/packages/core/src/features/cohort/data/cohort_builder.json
+++ b/packages/core/src/features/cohort/data/cohort_builder.json
@@ -112,7 +112,6 @@
         "cases.samples.biospecimen_anatomic_site",
         "cases.samples.specimen_type",
         "cases.samples.preservation_method",
-        "cases.samples.tumor_code",
         "cases.samples.tumor_descriptor",
         "cases.samples.portions.analytes.aliquots.analyte_type"
       ],

--- a/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/cohortBuilderConfigSlice.unit.test.ts
@@ -202,7 +202,6 @@ describe("cohortConfig reducer", () => {
       "cases.samples.biospecimen_anatomic_site",
       "cases.samples.specimen_type",
       "cases.samples.preservation_method",
-      "cases.samples.tumor_code",
       "cases.samples.tumor_descriptor",
       "cases.samples.portions.analytes.aliquots.analyte_type",
       "genes.upload.gene_id",


### PR DESCRIPTION
## Description
Removes the Tumor Code card as a default card from the Cohort Builder since it's a deprecated property.

## Checklist

- [/] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1470" alt="Screenshot 2025-02-12 at 5 22 30 PM" src="https://github.com/user-attachments/assets/31bff8aa-c02c-43ac-a57a-129037266dc8" />
