### PR TITLE
update the proteinpaint-client version to 2.106.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6315,6 +6315,15 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@sjcrh/proteinpaint-client": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.106.0.tgz",
+      "integrity": "sha512-F3/zo11lq6SQFVs51g025tmuGIknm+HEpl2jhwZ3cyWTgF20rYLtC1vImdAWsHEklFjg+GUTVHweAwBKQZk4VA==",
+      "peerDependencies": {
+        "postcss": "^8.4.41",
+        "postcss-import": "^14.1.0"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -28110,7 +28119,7 @@
         "@mantine/notifications": "^7.14.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.105.0",
+        "@sjcrh/proteinpaint-client": "^2.106.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",
@@ -28244,15 +28253,6 @@
       "integrity": "sha512-8ZVRr6D/8GEu2VmUVU447w4H+hl9dwefl//GpSGI2vKxXBqlud5X9PJQkSwi5J7I5FAxvlG5dr/zCxC3r3nsIQ==",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
-      }
-    },
-    "packages/portal-proto/node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.105.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.105.0.tgz",
-      "integrity": "sha512-ID6yvM8Ik9bQFoEGSBxZkwSh5AcYxuJiJHakws8c9ol1uLxJ7d9e3BPPMMPBpcL9zWmTv9rKIAZajSjJSAXF5Q==",
-      "peerDependencies": {
-        "postcss": "^8.4.41",
-        "postcss-import": "^14.1.0"
       }
     },
     "packages/portal-proto/node_modules/@types/jest": {

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.14.3",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.105.0",
+    "@sjcrh/proteinpaint-client": "^2.106.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/src/features/proteinpaint/dev.sh
+++ b/packages/portal-proto/src/features/proteinpaint/dev.sh
@@ -6,7 +6,7 @@
 if [[ "$1" == "unlink" ]]; then
 	# to test the published client package before submitting a PR with an updated pp-client version
 	npm unlink ../proteinpaint/client
-	npm uninstall @sjcrh/proteinpaint-client --save --workspace=packages/portal-proto 
+	npm uninstall @sjcrh/proteinpaint-client --save --workspace=packages/portal-proto
 	npm install @sjcrh/proteinpaint-client --save --workspace=packages/portal-proto
 
 else

--- a/packages/portal-proto/src/features/proteinpaint/dev.sh
+++ b/packages/portal-proto/src/features/proteinpaint/dev.sh
@@ -6,6 +6,9 @@
 if [[ "$1" == "unlink" ]]; then
 	# to test the published client package before submitting a PR with an updated pp-client version
 	npm unlink ../proteinpaint/client
+	npm uninstall @sjcrh/proteinpaint-client --save --workspace=packages/portal-proto 
+	npm install @sjcrh/proteinpaint-client --save --workspace=packages/portal-proto
+
 else
 	# to test the local PP client code
 	npm link ../proteinpaint/client


### PR DESCRIPTION
## Description

Known Issue:
-  SC plot: switching browser tab/changing browser window visibility will reset the scRNAseq plot to not have a selected sample, will be fixed in the next PR

Features:
- On the SC plot:
- SC plot: Showed control settings only in Plots and Gene Expression. Showed Sample column after Case. Added download icon in the DE table. The downloaded plots now
- Table: Added download table option
- In the SC plot added tabs Differentially Expressed Genes and Gene Set Enrichment Analysis under Differential Expression

Fixes:
- at querying GDC cnv file, remove use of sample_type and adapt to new file format
- hide cases with 0 bam files in gdc bam ui bam table;
- mds3 tk bug fix for expanded skewers to be clickable


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
