### PR TITLE
PEAR-2335 - In Data Portal, NCI OCPL Government Shutdown Banner does not appear

### DIFF
--- a/packages/portal-proto/next.config.js
+++ b/packages/portal-proto/next.config.js
@@ -39,13 +39,13 @@ const buildHash = () => {
 
 const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://assets.adobedtm.com https://dap.digitalgov.gov https://www.googletagmanager.com;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://assets.adobedtm.com https://dap.digitalgov.gov https://www.googletagmanager.com https://static-dev.cancer.gov;
     style-src 'self' 'unsafe-inline';
     connect-src 'self' ${connectSrc.join(" ")};
     frame-src https://portal.gdc.cancer.gov;
     form-action https://portal.gdc.cancer.gov;
-    img-src 'self' 'unsafe-inline' blob: data:;
-    font-src 'self';
+    img-src 'self' 'unsafe-inline' blob: data: https://metrics.cancer.gov;
+    font-src 'self' https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
     frame-ancestors 'none';


### PR DESCRIPTION
## Description
Fix gov shutdown banner being blocked by CSP header

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
It's back, baby
<img width="1432" alt="Screenshot 2025-02-17 at 11 31 30 AM" src="https://github.com/user-attachments/assets/fd1a5890-e6aa-4416-8a33-ba0e853fa2a3" />

