### PR TITLE
PEAR-2338: Run detect secret pre-commit hook on commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
-
 pre-commit run --all-files

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
 pre-commit run --all-files
+npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 pre-commit run --all-files
-npx lint-staged
+npx lint-staged --allow-empty

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+
+pre-commit run --all-files


### PR DESCRIPTION
## Description
Tested fail scenario for `fix end of files`.

### Note
Husky’s pre-commit hook `(.husky/pre-commit`) was only running `lint-staged`, so the hooks defined in .`pre-commit-config.yaml` (including `detect-secrets`) were not being executed on every commit. I updated the hook to also run `pre-commit run` .

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1406" alt="Screenshot 2025-02-18 at 8 40 19 PM" src="https://github.com/user-attachments/assets/c6b57f6a-ae31-43db-8110-d8a0c90684cb" />
