### PR TITLE
PEAR-2325 - Cohort Builder Search morphology fix

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
@@ -62,6 +62,7 @@ export interface FacetSearchDocument {
 export const miniSearch = new MiniSearch<FacetSearchDocument>({
   fields: ["name", "description", "enum"], // fields to index for full-text search
   storeFields: ["name", "category", "categoryKey", "description", "enum", "id"], // fields to return with search results
+  tokenize: (string) => string.split(/[\n\r\s,]+/u), // indexing tokenizer
   processTerm: (term) => (STOP_WORDS.has(term) ? null : term.toLowerCase()), // index term processing
   searchOptions: {
     boost: {

--- a/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
@@ -50,6 +50,7 @@ export const get_facets = (
 };
 
 export const STOP_WORDS = new Set(["of", "or"]);
+export const TOKENIZE_STRING = /[\n\r\s,\-_]+/u;
 
 export interface FacetSearchDocument {
   name: string;
@@ -62,7 +63,7 @@ export interface FacetSearchDocument {
 export const miniSearch = new MiniSearch<FacetSearchDocument>({
   fields: ["name", "description", "enum"], // fields to index for full-text search
   storeFields: ["name", "category", "categoryKey", "description", "enum", "id"], // fields to return with search results
-  tokenize: (string) => string.split(/[\n\r\s,]+/u), // indexing tokenizer
+  tokenize: (string) => string.split(TOKENIZE_STRING), // indexing tokenizer
   processTerm: (term) => (STOP_WORDS.has(term) ? null : term.toLowerCase()), // index term processing
   searchOptions: {
     boost: {

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -17,7 +17,7 @@ import { BAD_DATA_MESSAGE } from "./constants";
 import { CloseIcon } from "@/utils/icons";
 import { calculateStickyHeaderHeight } from "src/utils/";
 import MiniSearch from "minisearch";
-import { STOP_WORDS } from "../cohortBuilder/dictionary";
+import { STOP_WORDS, TOKENIZE_STRING } from "../cohortBuilder/dictionary";
 
 interface FacetResultDoc {
   enum: string;
@@ -27,7 +27,7 @@ interface FacetResultDoc {
 export const miniSearch = new MiniSearch<FacetResultDoc>({
   fields: ["enum"],
   storeFields: ["enum", "count"],
-  tokenize: (string) => string.split(/[\n\r\s,]+/u), // indexing tokenizer
+  tokenize: (string) => string.split(TOKENIZE_STRING), // indexing tokenizer
   processTerm: (term) => (STOP_WORDS.has(term) ? null : term.toLowerCase()), // index term processing
 });
 

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/router";
+import { flatten } from "lodash";
 import { fieldNameToTitle } from "@gff/core";
 import { DEFAULT_VISIBLE_ITEMS, updateFacetEnum } from "./utils";
 import { EnumFacetHooks, FacetCardProps } from "@/features/facets/types";
@@ -224,11 +225,10 @@ const EnumFacet: React.FC<FacetCardProps<EnumFacetHooks>> = ({
           combineWith: "OR",
         });
 
-        const searchResults: [string, number][] = (
-          results as FullResults[]
-        ).map((result) => [result.enum, result.count]);
-
-        filteredData = searchResults;
+        const terms = flatten(results.map((r) => r.terms));
+        filteredData = enumData.filter((d) =>
+          terms.some((t) => d[0].toLowerCase().includes(t)),
+        );
       }
 
       const remainingValues = filteredData.length - maxValuesToDisplay;

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -16,15 +16,13 @@ import FacetControlsHeader from "./FacetControlsHeader";
 import { BAD_DATA_MESSAGE } from "./constants";
 import { CloseIcon } from "@/utils/icons";
 import { calculateStickyHeaderHeight } from "src/utils/";
-import MiniSearch, { SearchResult } from "minisearch";
+import MiniSearch from "minisearch";
 import { STOP_WORDS } from "../cohortBuilder/dictionary";
 
 interface FacetResultDoc {
   enum: string;
   count: number;
 }
-
-type FullResults = FacetResultDoc & SearchResult;
 
 export const miniSearch = new MiniSearch<FacetResultDoc>({
   fields: ["enum"],

--- a/packages/portal-proto/src/features/facets/EnumFacet.tsx
+++ b/packages/portal-proto/src/features/facets/EnumFacet.tsx
@@ -28,6 +28,7 @@ type FullResults = FacetResultDoc & SearchResult;
 export const miniSearch = new MiniSearch<FacetResultDoc>({
   fields: ["enum"],
   storeFields: ["enum", "count"],
+  tokenize: (string) => string.split(/[\n\r\s,]+/u), // indexing tokenizer
   processTerm: (term) => (STOP_WORDS.has(term) ? null : term.toLowerCase()), // index term processing
 });
 


### PR DESCRIPTION
## Description
Changes the the way the search tokens are created by removing most punctuation as a place to split on so that "8010/3" is processed as "8010/3" instead of "8010", "3"

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="327" alt="Screenshot 2025-02-19 at 1 47 46 PM" src="https://github.com/user-attachments/assets/4708759f-60ac-4121-be7a-581e52f731bc" />
