### PR TITLE
Update pp version to 2.108.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6316,9 +6316,10 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.106.0.tgz",
-      "integrity": "sha512-F3/zo11lq6SQFVs51g025tmuGIknm+HEpl2jhwZ3cyWTgF20rYLtC1vImdAWsHEklFjg+GUTVHweAwBKQZk4VA==",
+      "version": "2.108.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.108.0.tgz",
+      "integrity": "sha512-DzqN0ncYcU7F8WmezmQBsrA9nbKvrZmlqyZnsAQ5VPqc8Awa7+CNiWIwL/bTg2m5kqqoo84y3MqC+jXWZfe0ng==",
+      "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"
@@ -28119,7 +28120,7 @@
         "@mantine/notifications": "^7.14.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.106.0",
+        "@sjcrh/proteinpaint-client": "^2.108.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.14.3",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.106.0",
+    "@sjcrh/proteinpaint-client": "^2.108.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Features:
- Added ability to visualize log2FC and NES scores as barplots within table columns
- Refactored showDownload/downloadFilename into a single function. Fixed bug with 0 values not being included in downloads

Fixes:
- HierCluster: should only cluster overlapping tested samples shared across all the selected genes/metabilites/terms
- Update termsetting pill for gene expression terms
- mds3 tk sample summary can account for cnv-only mode and cnv filters

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
