### PR TITLE
Add thousand comma separator for CDave y-axis

### DIFF
--- a/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
+++ b/packages/portal-proto/src/features/charts/VictoryBarChart.tsx
@@ -163,7 +163,7 @@ const VictoryBarChart: React.FC<VictoryBarChartProps> = ({
         }}
         tickFormat={
           yAxisFormatAsInteger
-            ? (t) => (Number.isInteger(t) ? t : null)
+            ? (t) => (Number.isInteger(t) ? t.toLocaleString() : null)
             : undefined
         }
       />


### PR DESCRIPTION
## Description
The formatting was lost when we worked on [PEAR-2087 ](https://gdc-ctds.atlassian.net/browse/PEAR-2087). Now we still check that the value is an integer and format it accordingly.
 
## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
![cdave](https://github.com/user-attachments/assets/818eab0c-819e-42be-8060-bde01eec4488)
