### PR TITLE
PEAR-2355 - Investigate repeated network calls for font requests with certain image downloads 

### DIFF
--- a/packages/portal-proto/src/features/charts/utils.ts
+++ b/packages/portal-proto/src/features/charts/utils.ts
@@ -60,12 +60,14 @@ const createSVG = async (ref: MutableRefObject<HTMLElement>): Promise<Blob> => {
             .split("(")[1]
             .split(")")[0]
             .replace(/"|'/g, "");
-          const fontFile = await fetch(fontUrl);
-          const blob = await fontFile.blob();
-          const base64 = await blobToBase64(blob);
-          styles.push(
-            rule.cssText.replace(/src: url\(.*?\)/, `src: url(${base64})`),
-          );
+          if (fontUrl.includes("latin")) {
+            const fontFile = await fetch(fontUrl);
+            const blob = await fontFile.blob();
+            const base64 = await blobToBase64(blob);
+            styles.push(
+              rule.cssText.replace(/src: url\(.*?\)/, `src: url(${base64})`),
+            );
+          }
         } else {
           styles.push(rule.cssText);
         }

--- a/packages/portal-proto/src/features/charts/utils.ts
+++ b/packages/portal-proto/src/features/charts/utils.ts
@@ -59,12 +59,14 @@ const createSVG = async (ref: MutableRefObject<HTMLElement>): Promise<Blob> => {
           .split("(")[1]
           .split(")")[0]
           .replace(/"|'/g, "");
-        const fontFile = await fetch(fontUrl);
-        const blob = await fontFile.blob();
-        const base64 = await blobToBase64(blob);
-        styles.push(
-          rule.cssText.replace(/src: url\(.*?\)/, `src: url(${base64})`),
-        );
+        if (fontUrl.includes("latin")) {
+          const fontFile = await fetch(fontUrl);
+          const blob = await fontFile.blob();
+          const base64 = await blobToBase64(blob);
+          styles.push(
+            rule.cssText.replace(/src: url\(.*?\)/, `src: url(${base64})`),
+          );
+        }
       } else {
         styles.push(rule.cssText);
       }


### PR DESCRIPTION
## Description
Disclaimer: I don't really know what was causing the change in behavior (and I'm not sure I can even recreate the behavior where there was less network calls on subsequent downloads). This PR changes the downloads to only include the font files we actually need, reducing the amount of network calls in general. Reduction from ~60 calls to ~20 calls per download. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
