### PR TITLE
fix MAF UI handling of multipart respoonse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6316,9 +6316,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.108.4-0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.108.4-0.tgz",
-      "integrity": "sha512-sap6S9CGkYoZbNXjF7DbS2KXAvYuBPJLtLw3HOxqeKy0zh1wvmwvvIjzjjJ/Rf2/yYDdHNbW9h6FvzQ3SKtlrA==",
+      "version": "2.108.5-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.108.5-0.tgz",
+      "integrity": "sha512-hlMzOrfN7yKtwHB2HxoxiI67m4pVcVyUk6CpS8ly57GlCc8NSThoe052sQq4lZLrZrArmKatkhtZbiIm71LgAA==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"
@@ -28119,7 +28119,7 @@
         "@mantine/notifications": "^7.14.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.108.4-0",
+        "@sjcrh/proteinpaint-client": "^2.108.5-0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6316,9 +6316,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.108.3-0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.108.3-0.tgz",
-      "integrity": "sha512-aCzaPsZbycOkPVdDJyoUugyL8cGM0QVy9GVD8Q5gw2iEBLDsltjDaZDe4L544KJ7m4mvSFNkBUdBaPE2Ef9rEA==",
+      "version": "2.108.4-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.108.4-0.tgz",
+      "integrity": "sha512-sap6S9CGkYoZbNXjF7DbS2KXAvYuBPJLtLw3HOxqeKy0zh1wvmwvvIjzjjJ/Rf2/yYDdHNbW9h6FvzQ3SKtlrA==",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"
@@ -27966,7 +27966,7 @@
       "version": "2.16.3",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.15.4",
+        "@gff/portal-components": "^2.16.3",
         "@mantine/core": "^7.14.3",
         "next": "^14.2.5",
         "typescript": "^5.6.3"
@@ -28110,8 +28110,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.15.0",
-        "@gff/portal-components": "^2.15.5",
+        "@gff/core": "^2.16.3",
+        "@gff/portal-components": "^2.16.3",
         "@mantine/core": "^7.14.3",
         "@mantine/dates": "^7.14.3",
         "@mantine/form": "^7.14.3",
@@ -28119,7 +28119,7 @@
         "@mantine/notifications": "^7.14.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.108.3-0",
+        "@sjcrh/proteinpaint-client": "^2.108.4-0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.14.3",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.108.3-0",
+    "@sjcrh/proteinpaint-client": "^2.108.4-0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.14.3",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.108.4-0",
+    "@sjcrh/proteinpaint-client": "^2.108.5-0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

SJ PRs:
- [fix: correctly detect the boundary text between binary and json text in the same octet chunjk](https://github.com/stjude/proteinpaint/pull/2950)
- [protect against missing error payload or empty data when handling maf response](https://github.com/stjude/proteinpaint/pull/2948)

This fixes this error as seen in qa-yellow
- We added more error checks to have more meaningful messages for end users when there is a problem with processing MAF response.
- We were able to replicate the issue that was present in qa-yellow but not dev, where the smaller stream chunks sizes caused the multipart/mixed boundary detection to not work, by using Chrome's Network tab -> Throttling -> Fast/Slow 4G/3G

Details
![Screenshot 2025-03-12 at 1 08 20 PM](https://github.com/user-attachments/assets/dfbb4f76-117a-4c05-b2ff-409fbf670195)

The problematic bundled code below has `g.body`, which should be `g?.body`
```js
 !g?.body?.ok && (Array.isArray(g.body?.errors) && function(e) {
``` 
However, everything works as expected in local dev. The preceding [published 2.108.3-0 ] (https://www.npmjs.com/package/@sjcrh/proteinpaint-client/v/2.108.3-0?activeTab=code) in line 395 has  
```js
if (!runStatus?.body?.ok) { 
  ...
} 
```
would indicate that the only way this could happen is if the response data did not exist, but the Network tab shows that the multipart response body is being received by the browser. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
