### PR TITLE
update proteinpaint-client version to 2.108.6-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6316,9 +6316,10 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.108.5-0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.108.5-0.tgz",
-      "integrity": "sha512-hlMzOrfN7yKtwHB2HxoxiI67m4pVcVyUk6CpS8ly57GlCc8NSThoe052sQq4lZLrZrArmKatkhtZbiIm71LgAA==",
+      "version": "2.108.6-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.108.6-0.tgz",
+      "integrity": "sha512-6xxqbc+QGkZ4qscApeHB2a81IKuYXNPPp6epfA6wPQGwVl0TjLfnq0R0VDeoYyLhyDBjdZulKKDojO2JKsN+JQ==",
+      "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
         "postcss-import": "^14.1.0"
@@ -28119,7 +28120,7 @@
         "@mantine/notifications": "^7.14.3",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "^2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.108.5-0",
+        "@sjcrh/proteinpaint-client": "^2.108.6-0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.14.3",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "^2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.108.5-0",
+    "@sjcrh/proteinpaint-client": "^2.108.6-0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

This uses patch to release-2.108, to be able to display an error bar in the MAF UI if the related server data processing is terminated. The small change to proteinpaint repo [client/gdc/maf.js ](https://github.com/stjude/proteinpaint/pull/2967/files#diff-c242c4d458ce69508ca7be68521ce196d20b3316a33e11b3e434291d0ee2a94f)is the only new, applicable code to frontend. We expect a user would see this error very rarely, backend data processing termination should be a rare event, after the updates to the rust code.

![Screenshot 2025-03-17 at 11 43 05 PM](https://github.com/user-attachments/assets/394dbd28-926e-4a67-866e-77a8d1d416d6)


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
