### PR TITLE
PEAR-1513 Allows searching by ssm id in mutation tables

### DIFF
--- a/packages/core/src/features/genomic/ssmsTableSlice.ts
+++ b/packages/core/src/features/genomic/ssmsTableSlice.ts
@@ -154,6 +154,11 @@ export const buildSSMSTableSearchFilters = (
           field: "ssms.gene_aa_change",
           operands: [`*${term}*`],
         },
+        {
+          operator: "includes",
+          field: "ssms.ssm_id",
+          operands: [`*${term}*`],
+        },
       ],
     };
   }

--- a/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
@@ -545,7 +545,8 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
             search={{
               enabled: true,
               defaultSearchTerm: searchTerm,
-              tooltip: "e.g. TP53, ENSG00000141510, chr17:g.7675088C>T, R175H",
+              tooltip:
+                "e.g. TP53, ENSG00000141510, chr17:g.7675088C>T, R175H, 8e30604f-3a45-5533-bdd7-0a4353700318",
             }}
             tableTotalDetail={
               <TotalItems total={data?.ssmsTotal} itemName="somatic mutation" />


### PR DESCRIPTION
## Description
- allows user to search by an ssm's id in mutation tables (case & gene summary page; mutation frequency)

## Checklist
- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1697" alt="Screenshot 2025-04-11 at 11 02 58 PM" src="https://github.com/user-attachments/assets/ffdff9ce-c607-471b-b976-4128aa4f9223" />

<img width="1382" alt="Screenshot 2025-04-11 at 11 04 16 PM" src="https://github.com/user-attachments/assets/aeff82e2-31fe-4178-8f1d-e5a76137ac97" />
