### PR TITLE
Update proteinpaint-client version to 2.118.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5865,9 +5865,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.116.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.116.0.tgz",
-      "integrity": "sha512-A+0sHpE//yieqKIa+z3bhPX/G6YOc8tAdm8xDcyZuohCzsXK4qbRrE/4iapWYMzhOy/jBvAurBEglXYDeQCJCQ==",
+      "version": "2.118.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.118.1.tgz",
+      "integrity": "sha512-UdzyEJyLJHU4dDSeiE+aJJodOZq+J9NiZFBAeR13HDXJNFf8fPqPJ1ZEpGJ2lR1L36DHMzKze+6QXCqBS0adfg==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -27759,7 +27759,6 @@
       "version": "2.16.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@napi-rs/magic-string-linux-x64-gnu": "*",
         "blueimp-md5": "^2.19.0",
         "queue": "^6.0.2",
         "uuid": "^8.3.2"
@@ -28048,7 +28047,7 @@
         "@mantine/notifications": "^7.17.2",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.108.6-0",
+        "@sjcrh/proteinpaint-client": "^2.118.1",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "^7.17.2",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.108.6-0",
+    "@sjcrh/proteinpaint-client": "2.118.1",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Non-urgent, proactive early release of ProteinPaint-related tool updates. 

Cohort Level MAF
- Close the MAF download stream on the server side if the browser request/connection gets closed. This is a permanent fix to prevent the accumulation of orphaned gdcmaf processes in the server

Hierarchical Clustering
- Option to uncluster genes
- Add a geneset edit ui in Clustering btn menu. This is a separate control from the geneset edit ui in "Genes" btn menu, which is only applicable to non-clustering row groups and could not edit clustering row group.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
