### PR TITLE
PEAR-2388 - Unsaved_Cohort has been created notification no longer shows up

### DIFF
--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -871,14 +871,9 @@ export const discardActiveCohortChanges =
 
 export const setActiveCohortList =
   (cohorts: Cohort[]): ThunkAction<void, CoreState, undefined, UnknownAction> =>
-  async (dispatch: CoreDispatch, getState) => {
+  async (dispatch: CoreDispatch) => {
     // set the list of all cohorts
     dispatch(setCohortList(cohorts));
-
-    const availableCohorts = selectAllCohorts(getState());
-    if (Object.keys(availableCohorts).length === 0) {
-      dispatch(addNewDefaultUnsavedCohort());
-    }
 
     // have to request counts for all cohorts loaded from the backend
     cohorts.forEach((cohort) => {

--- a/packages/core/src/features/cohort/availableCohortsSlice.ts
+++ b/packages/core/src/features/cohort/availableCohortsSlice.ts
@@ -265,15 +265,10 @@ const slice = createSlice({
       );
 
       const selector = cohortsAdapter.getSelectors();
-      if (selector.selectAll(state).length === 0) {
-        cohortsAdapter.addOne(
-          state,
-          newCohort({ customName: UNSAVED_COHORT_NAME }),
-        );
-        const selector = cohortsAdapter.getSelectors();
-        const createdCohort = selector.selectAll(state)[0];
-        state.currentCohort = createdCohort.id;
-      } else if (action?.payload.id === undefined) {
+      if (
+        selector.selectAll(state).length > 0 &&
+        action?.payload.id === undefined
+      ) {
         state.currentCohort = selector.selectAll(state)[0].id;
       }
     },

--- a/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
@@ -741,40 +741,6 @@ describe("add, update, and remove cohort", () => {
     });
   });
 
-  test("should create new unsaved cohort when removing last cohort", () => {
-    const removeState = {
-      currentCohort: "000-000-000-1",
-      ids: ["000-000-000-1"],
-      entities: {
-        "000-000-000-1": {
-          name: "New Cohort",
-          filters: { mode: "and", root: {} },
-          id: "000-000-000-1",
-          caseSet: {
-            caseSetId: {
-              mode: "and",
-              root: {},
-            },
-            status: "uninitialized" as DataStatus,
-          },
-          counts: {
-            ...NullCountsData,
-          },
-          modified: false,
-          modified_datetime: new Date().toISOString(),
-        },
-      },
-    };
-
-    const availableCohorts = availableCohortsReducer(
-      removeState,
-      removeCohort({}),
-    );
-    expect(Object.values(availableCohorts.entities)[0]?.name).toEqual(
-      "Unsaved_Cohort",
-    );
-  });
-
   test("should removed prior unsaved cohort when adding new one", () => {
     const availableCohorts = availableCohortsReducer(
       {

--- a/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
+++ b/packages/core/src/features/cohort/tests/availableCohortSlice.unit.test.ts
@@ -21,7 +21,6 @@ import { EntityState } from "@reduxjs/toolkit";
 import { MOCK_COHORTS } from "./mockData";
 import { FilterSet } from "../filters";
 import { getInitialCoreState } from "src/store.unit.test";
-import { DataStatus } from "src/dataAccess";
 import { NullCountsData } from "../type";
 
 const state = getInitialCoreState();

--- a/packages/portal-components/src/cohort/CohortManager.tsx
+++ b/packages/portal-components/src/cohort/CohortManager.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import { useDeepCompareEffect } from "use-deep-compare";
 import { Tooltip, MantineProvider, Button } from "@mantine/core";
 import { AppContext } from "src/context";
 import { UndoIcon } from "src/commonIcons";
@@ -27,6 +28,7 @@ const CohortManager: React.FC<CohortManagerProps> = ({
   invalidCohortNames = [],
 }) => {
   const currentCohort = hooks.useSelectCurrentCohort();
+  const cohorts = hooks.useSelectAvailableCohorts();
 
   const handleDelete = hooks.useDeleteCohort();
   const handleDiscard = hooks.useDiscardChanges();
@@ -50,6 +52,19 @@ const CohortManager: React.FC<CohortManagerProps> = ({
   const setCohortMessage = useContext(CohortNotificationContext);
 
   useCreateCohortExternally(setCohortMessage);
+
+  useDeepCompareEffect(() => {
+    if (cohorts.length === 0) {
+      addNewDefaultUnsavedCohort();
+      setCohortMessage &&
+        setCohortMessage([{ cmd: "newCohort", param1: defaultCohortName }]);
+    }
+  }, [
+    cohorts,
+    addNewDefaultUnsavedCohort,
+    defaultCohortName,
+    setCohortMessage,
+  ]);
 
   return (
     <MantineProvider

--- a/packages/portal-components/src/cohort/CohortManager.tsx
+++ b/packages/portal-components/src/cohort/CohortManager.tsx
@@ -15,6 +15,7 @@ interface CohortManagerProps {
   readonly hooks: CohortHooks;
   readonly defaultCohortName: string;
   readonly invalidCohortNames?: string[];
+  readonly isFetchingCohorts?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ const CohortManager: React.FC<CohortManagerProps> = ({
   hooks,
   defaultCohortName,
   invalidCohortNames = [],
+  isFetchingCohorts = false,
 }) => {
   const currentCohort = hooks.useSelectCurrentCohort();
   const cohorts = hooks.useSelectAvailableCohorts();
@@ -54,7 +56,7 @@ const CohortManager: React.FC<CohortManagerProps> = ({
   useCreateCohortExternally(setCohortMessage);
 
   useDeepCompareEffect(() => {
-    if (cohorts.length === 0) {
+    if (cohorts.length === 0 && !isFetchingCohorts) {
       addNewDefaultUnsavedCohort();
       setCohortMessage &&
         setCohortMessage([{ cmd: "newCohort", param1: defaultCohortName }]);
@@ -64,6 +66,7 @@ const CohortManager: React.FC<CohortManagerProps> = ({
     addNewDefaultUnsavedCohort,
     defaultCohortName,
     setCohortMessage,
+    isFetchingCohorts,
   ]);
 
   return (

--- a/packages/portal-components/src/cohort/CohortNotificationProvider.tsx
+++ b/packages/portal-components/src/cohort/CohortNotificationProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useReducer,
 } from "react";
 import { useDeepCompareCallback, useDeepCompareEffect } from "use-deep-compare";
+import { isEqual } from "lodash";
 import { Button } from "@mantine/core";
 import { Notifications, showNotification } from "@mantine/notifications";
 import { ContextModalProps, ModalsProvider } from "@mantine/modals";
@@ -46,7 +47,7 @@ const cohortMessageReducer = (
     case "update":
       return [...state, ...action.payload];
     case "clear":
-      return [];
+      return state.filter((message) => !isEqual(message, action.payload));
     default:
       return state;
   }
@@ -84,6 +85,9 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
             },
             autoClose: 5000,
             closeButtonProps: { "aria-label": "Close notification" },
+            id: `new-cohort-${
+              (message as CohortNotificationCommandWithParam).param1
+            }`,
           });
           break;
         case "deleteCohort":
@@ -100,6 +104,9 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
             },
             autoClose: 5000,
             closeButtonProps: { "aria-label": "Close notification" },
+            id: `delete-cohort-${
+              (message as CohortNotificationCommandWithParam).param1
+            }`,
           });
           break;
         case "savedCohort":
@@ -116,6 +123,9 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
             },
             autoClose: 5000,
             closeButtonProps: { "aria-label": "Close notification" },
+            id: `saved-cohort-${
+              (message as CohortNotificationCommandWithParam).param1
+            }`,
           });
           break;
         case "savedCohortSetCurrent":
@@ -137,6 +147,9 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
             },
             autoClose: 5000,
             closeButtonProps: { "aria-label": "Close notification" },
+            id: `saved-cohort-set-current-${
+              (message as CohortNotificationCommandWithParam).param2
+            }`,
           });
           break;
         case "savedCurrentCohort":
@@ -147,6 +160,7 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
             },
             autoClose: 5000,
             closeButtonProps: { "aria-label": "Close notification" },
+            id: "saved-current-cohort",
           });
           break;
         case "discardChanges":
@@ -157,6 +171,7 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
             },
             autoClose: 5000,
             closeButtonProps: { "aria-label": "Close notification" },
+            id: "discard-changes",
           });
           break;
         case "error":
@@ -173,12 +188,14 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
             },
             autoClose: 5000,
             closeButtonProps: { "aria-label": "Close notification" },
+            id: `cohort-error-${
+              (message as CohortNotificationCommandWithParam).param1
+            }`,
           });
           break;
       }
+      dispatch({ type: "clear", payload: [message] });
     }
-
-    dispatch({ type: "clear", payload: [] });
   }, [cohortMessage, useSetActiveCohort]);
 
   const updateCohortMessage = useDeepCompareCallback(

--- a/packages/portal-components/src/cohort/CohortNotificationProvider.tsx
+++ b/packages/portal-components/src/cohort/CohortNotificationProvider.tsx
@@ -41,7 +41,9 @@ const SaveCohortErrorModal = ({ context, id }: ContextModalProps) => (
 
 const cohortMessageReducer = (
   state: CohortNotificationCommand[],
-  action: { type: "update" | "clear"; payload: CohortNotificationCommand[] },
+  action:
+    | { type: "update"; payload: CohortNotificationCommand[] }
+    | { type: "clear"; payload: CohortNotificationCommand },
 ) => {
   switch (action.type) {
     case "update":
@@ -194,7 +196,7 @@ const CohortNotificationProvider: React.FC<CohortNotificationWrapperProps> = ({
           });
           break;
       }
-      dispatch({ type: "clear", payload: [message] });
+      dispatch({ type: "clear", payload: message });
     }
   }, [cohortMessage, useSetActiveCohort]);
 

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager/CohortManager.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager/CohortManager.tsx
@@ -17,7 +17,11 @@ import ImportCohortModal from "../Modals/ImportCohortModal";
 import { cohortActionsHooks } from "./cohortActionHooks";
 import { INVALID_COHORT_NAMES, useCohortFacetFilters } from "../utils";
 
-const CohortManager: React.FC = () => {
+interface CohortManagerProps {
+  readonly isFetchingCohorts: boolean;
+}
+
+const CohortManager: React.FC<CohortManagerProps> = ({ isFetchingCohorts }) => {
   const modal = useCoreSelector(selectCurrentModal);
   const coreDispatch = useCoreDispatch();
 
@@ -34,6 +38,7 @@ const CohortManager: React.FC = () => {
         hooks={cohortActionsHooks}
         invalidCohortNames={INVALID_COHORT_NAMES}
         defaultCohortName={UNSAVED_COHORT_NAME}
+        isFetchingCohorts={isFetchingCohorts}
       />
       <ImportCohortModal opened={modal === Modals.ImportCohortModal} />
       <CaseSetModal

--- a/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/ContextBar.tsx
@@ -46,9 +46,11 @@ import { getFormattedTimestamp } from "@/utils/date";
 const ContextBar = ({
   handleIsSticky,
   isSticky,
+  isFetchingCohorts,
 }: {
   handleIsSticky: (isSticky: boolean) => void;
   isSticky: boolean;
+  isFetchingCohorts: boolean;
 }): JSX.Element => {
   const coreDispatch = useCoreDispatch();
   const cohorts = useCoreSelector((state) => selectAvailableCohorts(state));
@@ -235,7 +237,7 @@ const ContextBar = ({
 
   return (
     <CollapsibleContainer
-      Top={<CohortManager />}
+      Top={<CohortManager isFetchingCohorts={isFetchingCohorts} />}
       isCollapsed={isGroupCollapsed}
       toggle={() => setIsGroupCollapsed(!isGroupCollapsed)}
       onlyIcon={false}

--- a/packages/portal-proto/src/pages/analysis_page.tsx
+++ b/packages/portal-proto/src/pages/analysis_page.tsx
@@ -35,6 +35,7 @@ const SingleAppsPage: NextPage = () => {
           handleIsSticky={(isStickyParam: boolean) =>
             setIsSticky(isStickyParam)
           }
+          isFetchingCohorts={!initialCohortsFetched}
         />
       }
       isContextBarSticky={isSticky}


### PR DESCRIPTION
## Description
- Moves automatic creation of unsaved cohort to shared CohortManager component so we can alert on it
- Fixes some issues with simultaneous cohort notifications (i.e. deleting cohort and then creating unsaved cohort) 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

https://github.com/user-attachments/assets/79112c3e-71bf-40f1-8dd9-6735e99ac024

