### PR TITLE
PEAR-2400 - Wrong cohort filters when using Replace in Mutation Frequency

### DIFF
--- a/packages/portal-components/src/cohort/types.ts
+++ b/packages/portal-components/src/cohort/types.ts
@@ -60,11 +60,15 @@ export interface CohortHooks {
   useReplaceCohort: () => ({
     newName,
     filters,
+    caseFilters,
+    createStaticCohort,
     cohortId,
     saveAs,
   }: {
     newName: string;
     filters: any;
+    caseFilters: any;
+    createStaticCohort: boolean;
     cohortId?: string;
     saveAs: boolean;
   }) => Promise<{ newCohortId: string }>;

--- a/packages/portal-components/src/modals/SaveCohortModal.tsx
+++ b/packages/portal-components/src/modals/SaveCohortModal.tsx
@@ -70,7 +70,14 @@ const SaveCohortModal: React.FC<SaveCohortModalProps> = ({
     setIsSaving(true);
 
     if (replace) {
-      replaceCohort({ newName, filters, cohortId, saveAs })
+      replaceCohort({
+        newName,
+        filters,
+        caseFilters,
+        createStaticCohort,
+        cohortId,
+        saveAs,
+      })
         .then(({ newCohortId }) => {
           setCohortMessage &&
             setCohortMessage([

--- a/packages/portal-proto/src/features/cohortBuilder/CohortManager/cohortActionHooks.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/CohortManager/cohortActionHooks.ts
@@ -305,10 +305,65 @@ const useUpdateCohortState = () => {
   return updateCohortState;
 };
 
+const useCreateCohortRequest = () => {
+  const [createSet] = useCreateCaseSetFromFiltersMutation();
+
+  const createCohortRequest = async ({
+    filters,
+    caseFilters,
+    newName,
+    createStaticCohort,
+  }: {
+    filters: FilterSet;
+    caseFilters: FilterSet;
+    newName: string;
+    createStaticCohort: boolean;
+  }) => {
+    let cohortFilters = filters;
+
+    if (createStaticCohort) {
+      await createSet({
+        filters: buildCohortGqlOperator(filters),
+        case_filters: buildCohortGqlOperator(caseFilters),
+        intent: "portal",
+        set_type: "frozen",
+      })
+        .unwrap()
+        .then((setId: string) => {
+          cohortFilters = {
+            mode: "and",
+            root: {
+              "cases.case_id": {
+                field: "cases.case_id",
+                operands: [`set_id:${setId}`],
+                operator: "includes",
+              },
+            },
+          } as FilterSet;
+        });
+    }
+
+    const filteredCohortFilters = omit(cohortFilters, "isLoggedIn");
+
+    const addBody = {
+      name: newName,
+      type: "dynamic",
+      filters:
+        Object.keys(filteredCohortFilters.root).length > 0
+          ? buildCohortGqlOperator(filteredCohortFilters)
+          : {},
+    };
+
+    return addBody;
+  };
+
+  return createCohortRequest;
+};
+
 export const useSaveCohort = () => {
   const [addCohort] = useAddCohortMutation();
-  const [createSet] = useCreateCaseSetFromFiltersMutation();
   const updateCohortState = useUpdateCohortState();
+  const createCohortRequest = useCreateCohortRequest();
 
   const handleAddCohort = useDeepCompareCallback(
     async ({
@@ -326,42 +381,14 @@ export const useSaveCohort = () => {
       createStaticCohort: boolean;
       saveAs: boolean;
     }) => {
-      let cohortFilters = filters;
-
-      if (createStaticCohort) {
-        await createSet({
-          filters: buildCohortGqlOperator(filters),
-          case_filters: buildCohortGqlOperator(caseFilters),
-          intent: "portal",
-          set_type: "frozen",
-        })
-          .unwrap()
-          .then((setId: string) => {
-            cohortFilters = {
-              mode: "and",
-              root: {
-                "cases.case_id": {
-                  field: "cases.case_id",
-                  operands: [`set_id:${setId}`],
-                  operator: "includes",
-                },
-              },
-            } as FilterSet;
-          });
-      }
-
-      const filteredCohortFilters = omit(cohortFilters, "isLoggedIn");
-
-      const addBody = {
-        name: newName,
-        type: "dynamic",
-        filters:
-          Object.keys(filteredCohortFilters.root).length > 0
-            ? buildCohortGqlOperator(filteredCohortFilters)
-            : {},
-      };
-
       let result = { cohortAlreadyExists: false, newCohortId: undefined };
+
+      const addBody = await createCohortRequest({
+        filters,
+        caseFilters,
+        newName,
+        createStaticCohort,
+      });
 
       await addCohort({ cohort: addBody, delete_existing: false })
         .unwrap()
@@ -381,7 +408,7 @@ export const useSaveCohort = () => {
 
       return result;
     },
-    [addCohort, createSet, updateCohortState],
+    [addCohort, updateCohortState, createCohortRequest],
   );
 
   return handleAddCohort;
@@ -393,29 +420,30 @@ export const useReplaceCohort = () => {
   const [addCohort] = useAddCohortMutation();
   const [fetchCohortList] = useLazyGetCohortsByContextIdQuery();
   const updateCohortState = useUpdateCohortState();
+  const createCohortRequest = useCreateCohortRequest();
 
   const handleReplaceCohort = useDeepCompareCallback(
     async ({
       newName,
       filters,
+      caseFilters,
+      createStaticCohort,
       cohortId,
       saveAs,
     }: {
       newName: string;
       filters: FilterSet;
+      caseFilters: FilterSet;
+      createStaticCohort: boolean;
       cohortId: string;
       saveAs: boolean;
     }) => {
-      const filteredCohortFilters = omit(filters, "isLoggedIn");
-
-      const addBody = {
-        name: newName,
-        type: "dynamic",
-        filters:
-          Object.keys(filteredCohortFilters.root).length > 0
-            ? buildCohortGqlOperator(filteredCohortFilters)
-            : {},
-      };
+      const addBody = await createCohortRequest({
+        filters,
+        caseFilters,
+        newName,
+        createStaticCohort,
+      });
 
       let result = { newCohortId: undefined };
 
@@ -444,7 +472,14 @@ export const useReplaceCohort = () => {
 
       return result;
     },
-    [addCohort, cohorts, coreDispatch, fetchCohortList, updateCohortState],
+    [
+      addCohort,
+      cohorts,
+      coreDispatch,
+      fetchCohortList,
+      updateCohortState,
+      createCohortRequest,
+    ],
   );
 
   return handleReplaceCohort;


### PR DESCRIPTION
## Description
Replace code path was not creating static cohorts when it should

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
