### PR TITLE
Qa 2361 add initial authenticated tests

### DIFF
--- a/holmes-py/README.md
+++ b/holmes-py/README.md
@@ -157,6 +157,26 @@ consistency of test results. Anymore than 6, and there would be some flakey test
 
 If a test does fail, rerun them individually before reporting results.
 
+### How to Execute Each Type of Test Suite
+The tests should be ran by tag. We have open-access and controlled-access tests that are not compatible to be ran together.
+The controlled-access tests require you to manually login when prompted. The other tests do not have to be interacted with
+once execution begins. Any of the commands below can also be ran in parallel or with de-bug mode. See above for commands.
+
+#### Regression Test
+````
+gauge run specs --tags "regression"
+````
+
+#### Data Test
+````
+gauge run specs --tags "data-release"
+````
+
+#### Controlled Access Test
+````
+gauge run specs --tags "controlled-access"
+````
+
 ### Gauge Execution Documentation
 See [Run Gauge Specifications](https://docs.gauge.org/execution.html?os=macos&language=python&ide=vscode)
 

--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_cart.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_cart.spec
@@ -4,7 +4,8 @@ Version			    : 1.0
 Owner		        : GDC QA
 Description		  : Manifest and Download Cart
 Test-Case       : PEAR-2246
-tags            : gdc-data-portal-v2, regression, cart
+
+tags: gdc-data-portal-v2, regression, cart
 
 
 ## Remove Any Files From Cart

--- a/holmes-py/specs/gdc_data_portal_v2/file_summary/cart_file_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/file_summary/cart_file_download.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Add and Remove from cart, download file
 Test-Case       : PEAR-540
 
-tags: gdc-data-portal-v2, file-summary, cart, file-download, smoke-test, sanity-test
+tags: gdc-data-portal-v2, file-summary, cart, file-download, smoke-test, sanity-test, regression
 
 ## File Summary Page - Navigate to a file summary page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/file_summary/download_controlled_access.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/file_summary/download_controlled_access.spec
@@ -1,0 +1,24 @@
+# File Summary - Download Controlled Access File
+Date Created    : 05/06/2025
+Version			    : 1.0
+Owner		        : GDC QA
+Description		  : Download controlled access file
+Test-Case       : PEAR-540
+
+tags: gdc-data-portal-v2, file-summary, controlled-access
+
+## Navigate to a Controlled Access File
+* On GDC Data Portal V2 app
+* Quick search for "8b965c3f-087e-4bae-84bc-3a7b961b295c" and go to its page
+
+## Download Controlled Access File
+* Select "Download" on File Summary page
+* Select checkbox "Download Agreement"
+* Download "File" from "Controlled Access Modal"
+* Read metadata from compressed "File from Controlled Access Modal"
+* Verify that "File from Controlled Access Modal" has expected information
+  |required_info                          |
+  |---------------------------------------|
+  |8b965c3f-087e-4bae-84bc-3a7b961b295c   |
+  |6346d32432fcd6e0bff972a2d850a3f1       |
+  |13093                                  |

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/file_summary_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/file_summary_page.py
@@ -9,6 +9,8 @@ class FileSummaryLocators:
     ADD_TO_CART_BUTTON_IDENT = 'text="Add to Cart" >> nth=0'
     REMOVE_FROM_CART_BUTTON_IDENT = 'text="Remove From Cart" >> nth=0'
 
+    BUTTON_FILE_SUMMARY_PAGE = lambda button_name: f"[data-testid='button-{button_name}-file-summary']"
+
     ADDED_TO_CART_MESSAGE_IDENT = 'p:has-text("Added")'
     REMOVED_FROM_CART_MESSAGE_IDENT = 'p:has-text("Removed")'
 
@@ -38,6 +40,12 @@ class FileSummaryPage(BasePage):
         self.click(remove_file_button_locator)
         removed_file_message = FileSummaryLocators.REMOVED_FROM_CART_MESSAGE_IDENT
         self.wait_until_locator_is_visible(removed_file_message)
+
+    def click_button(self, button_name):
+        """Clicks specified button on File Summary page"""
+        button_name = self.normalize_button_identifier(button_name)
+        locator = FileSummaryLocators.BUTTON_FILE_SUMMARY_PAGE(button_name)
+        self.click(locator)
 
     def click_download_file_button(self):
         """Clicks download file button in upper-left corner"""

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/header_section.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/header_section.py
@@ -6,6 +6,8 @@ import time
 
 class HeaderSectionLocators:
     BUTTON_IDENT = lambda button_name: f"[data-testid='button-header-{button_name}']"
+    BUTTON_LOGIN = "[data-testid='button-header-login'] >> nth=1"
+    BUTTON_USERNAME = "[data-testid='button-header-username'] >> nth=1"
 
     # These are all locators that only appear when the respective page has fully loaded
     ANALYSIS_CENTER_WAIT_FOR_ELEMENT = "[data-testid='Clinical Data Analysis-tool']"
@@ -80,3 +82,11 @@ class HeaderSection(BasePage):
         self.wait_for_loading_spinner_table_to_detatch()
         self.wait_for_loading_spinner_to_detatch()
         self.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
+
+    def login_to_data_portal_if_possible(self):
+        login_locator = HeaderSectionLocators.BUTTON_LOGIN
+        if self.is_visible(login_locator):
+            self.click(login_locator)
+            wait_for_username_locator = HeaderSectionLocators.BUTTON_USERNAME
+            self.wait_until_locator_is_visible(wait_for_username_locator, 60000)
+            self.wait_for_loading_spinners_to_detach()

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/modal.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/modal.py
@@ -8,6 +8,7 @@ import time
 class ModalLocators:
     TEXT_IN_TEMPORARY_MODAL_MESSAGE = lambda expected_text: f'div[role="alert"]:has-text("{expected_text}")'
     ACCEPT_BUTTON = 'button[data-testid="button-intro-warning-accept"]'
+    BUTTON_DOWNLOAD = '[data-testid="button-download"]'
 
     TAB_LIST = lambda tab_name: f'[data-testid="modal-tab-list"] >> text="{tab_name}"'
     TEXT_SET_COUNT = lambda set_name: f'[data-testid="text-{set_name}-set-count"]'
@@ -49,6 +50,10 @@ class Modal(BasePage):
     def click_tab_name(self, tab_name):
         tab_locator = ModalLocators.TAB_LIST(tab_name)
         self.click(tab_locator)
+
+    def click_download_button(self):
+        locator = ModalLocators.BUTTON_DOWNLOAD
+        self.click(locator)
 
     def wait_for_text_in_temporary_message(self, text, action="remove modal"):
         """

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/file_summary_page_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/file_summary_page_steps.py
@@ -18,6 +18,10 @@ def add_file_to_cart():
 def add_file_to_cart():
     APP.file_summary_page.remove_file_from_cart()
 
+@step("Select <button_name> on File Summary page")
+def click_file_summary_page_button(button_name: str):
+    APP.file_summary_page.click_button(button_name)
+
 @step("Select file download button on the file summary page")
 def click_download_file():
     APP.file_summary_page.click_download_file_button()

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -54,6 +54,19 @@ def setup_test_run():
     time.sleep(2)
 
 
+@before_spec("<controlled-access>")
+def before_spec_hook():
+    """
+    Before each spec is ran, automation will check if the file contains the tag "controlled-access".
+    If it does, automation will check the data portal to see if the user is logged in. If not, automation
+    will click the login button and we will manually login to the data portal.
+
+    Gauge does not allow for this kind of tag checking in before_suite, so this is my workaround. To do
+    it before spec in an 'if' statement.
+    """
+    APP.header_section.login_to_data_portal_if_possible()
+
+
 @after_spec
 def setup_next_spec_run():
     """
@@ -177,6 +190,7 @@ def download_file_at_file_table(file: str, source: str):
         "Cohort Summary View Clinical": APP.cohort_case_view_page.click_clinical_summary_view,
         "Cohort Table View Biospecimen": APP.cohort_case_view_page.click_biospecimen_table_view,
         "Cohort Table View Clinical": APP.cohort_case_view_page.click_clinical_table_view,
+        "Controlled Access Modal": APP.modal.click_download_button,
         "File Summary": APP.file_summary_page.click_download_button,
         "File Summary Annotation Table": APP.file_summary_page.click_annotation_table_download_option,
         "File Summary File Versions": APP.file_summary_page.click_file_version_download_option,
@@ -911,9 +925,16 @@ def click_link_data_testid(link_data_testid: str):
 
 @step("Select the following checkboxes <table>")
 def click_checkboxes(table):
+    """Selects checkboxes given from table exactly as typed"""
     for k, v in enumerate(table):
         APP.shared.click_checkbox(v[0])
         time.sleep(0.1)
+
+@step("Select checkbox <checkbox_name>")
+def click_checkbox_normalize_ident(checkbox_name:str):
+    """Normalizes the checkbox name, then attempts to check"""
+    APP.shared.click_checkbox_normalize_ident(checkbox_name)
+    time.sleep(0.1)
 
 @step("Select the radio button <button_name>")
 def click_radio_data_testid_button(button_name:str):

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -676,6 +676,12 @@ class BasePage:
         locator = GenericLocators.CHECKBOX_IDENT(checkbox_name)
         self.click(locator)
 
+    def click_checkbox_normalize_ident(self, checkbox_name):
+        """Clicks a checkbox with given, unmodified name"""
+        checkbox_name = self.normalize_button_identifier(checkbox_name)
+        locator = GenericLocators.CHECKBOX_IDENT(checkbox_name)
+        self.click(locator)
+
     def click_radio_button(self, radio_name):
         """Clicks a radio button in a filter card"""
         locator = GenericLocators.RADIO_BUTTON_IDENT(radio_name)


### PR DESCRIPTION
## Description
- Added initial controlled-access test

How to Test:
qa-int, vpn2
Near the start of the test, after the cohort is made, it will prompt you to login to the data portal (the login screen will appear). Login with your credentials and then the test will continue uninterrupted. 

gauge run specs/gdc_data_portal_v2/file_summary/download_controlled_access.spec
