### PR TITLE
update proteinpaint-client version to 2.123.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5486,7 +5486,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.118.1",
+      "version": "2.123.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.123.0.tgz",
+      "integrity": "sha512-Dwb9IBO1uI3+RaAbed2VCYXHLtqjcSDwtJU2/nUZTzsoe7ikrs9vEoHkyRaNdGGFxXFBhXTiyfzzO72tNbZuTg==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -25632,7 +25634,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.118.1",
+        "@sjcrh/proteinpaint-client": "^2.123.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.118.1",
+    "@sjcrh/proteinpaint-client": "^2.123.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/src/features/apps/CnvSegmentApp.tsx
+++ b/packages/portal-proto/src/features/apps/CnvSegmentApp.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { ProteinPaintWrapper } from "../proteinpaint/ProteinPaintWrapper";
 
 const CnvSegmentApp: FC = () => {
-  return <ProteinPaintWrapper hardcodeCnvOnly={1} />;
+  return <ProteinPaintWrapper hardcodeCnvOnly={true} />;
 };
 
 export default CnvSegmentApp;

--- a/packages/portal-proto/src/features/apps/CnvSegmentApp.tsx
+++ b/packages/portal-proto/src/features/apps/CnvSegmentApp.tsx
@@ -1,0 +1,8 @@
+import { FC } from "react";
+import { ProteinPaintWrapper } from "../proteinpaint/ProteinPaintWrapper";
+
+const CnvSegmentApp: FC = () => {
+  return <ProteinPaintWrapper hardcodeCnvOnly={1} />;
+};
+
+export default CnvSegmentApp;

--- a/packages/portal-proto/src/features/proteinpaint/CnvSegmentWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CnvSegmentWrapper.unit.test.tsx
@@ -45,7 +45,7 @@ jest.mock("@sjcrh/proteinpaint-client", () => ({
   }),
 }));
 
-test("SSM lolliplot arguments", () => {
+test("CNV Segment arguments", () => {
   userDetails = { data: { username: "test" } };
   const { unmount, rerender } = render(
     <MantineProvider
@@ -56,7 +56,7 @@ test("SSM lolliplot arguments", () => {
         },
       }}
     >
-      <ProteinPaintWrapper />
+      <ProteinPaintWrapper hardcodeCnvOnly={true} />
     </MantineProvider>,
   );
   expect(typeof runpparg).toBe("object");
@@ -70,7 +70,7 @@ test("SSM lolliplot arguments", () => {
     attributes: [{ from: "sample_id", to: "cases.case_id", convert: true }],
     callback: runpparg.allow2selectSamples?.callback,
   });
-  expect(runpparg.geneSearch4GDCmds3).toEqual(true);
+  expect(runpparg.geneSearch4GDCmds3).toEqual({ hardcodeCnvOnly: true });
   isDemoMode = true;
   rerender(
     <MantineProvider

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -32,6 +32,7 @@ interface PpProps {
   ssm_id?: string;
   mds3_ssm2canonicalisoform?: mds3_isoform;
   geneSearch4GDCmds3?: boolean;
+  hardcodeCnvOnly?: boolean;
 }
 
 export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
@@ -93,7 +94,9 @@ export const ProteinPaintWrapper: FC<PpProps> = (props: PpProps) => {
       const rootElem = divRef.current as HTMLElement;
       const data = getLollipopTrack(props, filter0, callback);
       if (!data) return;
-      if (isDemoMode) data.geneSymbol = "MYC";
+      if (isDemoMode) {
+        data.geneSymbol = "MYC";
+      }
       // compare the argument to runpp to avoid unnecessary render
       if ((data || prevArg.current) && isEqual(prevArg.current, data)) return;
       prevArg.current = data;
@@ -162,12 +165,17 @@ interface Mds3Arg {
   nobox?: boolean;
   hide_dsHandles?: boolean;
   host: string;
-  genome: string;
   gene2canonicalisoform?: string;
   mds3_ssm2canonicalisoform?: mds3_isoform;
-  geneSearch4GDCmds3?: boolean;
+  geneSearch4GDCmds3?:
+    | boolean
+    | {
+        hardcodeCnvOnly?: boolean;
+      };
   geneSymbol?: string;
-  tracks: Track[];
+  tracks?: Track[];
+  filter0?: FilterSet;
+  allow2selectSamples?: SelectSamples;
 }
 
 interface Track {
@@ -175,6 +183,7 @@ interface Track {
   dslabel: string;
   filter0: FilterSet;
   allow2selectSamples?: SelectSamples;
+  hardcodeCnvOnly?: boolean;
 }
 
 interface mds3_isoform {
@@ -191,25 +200,22 @@ function getLollipopTrack(
     // host in gdc is just a relative url path,
     // using the same domain as the GDC portal where PP is embedded
     host: props.basepath || (basepath as string),
-    genome: "hg38", // hardcoded for gdc
-    tracks: [
-      {
-        type: "mds3",
-        dslabel: "GDC",
-        filter0,
-        // allow2selectSamples: { buttons },
-        allow2selectSamples: {
-          buttonText: "Create Cohort",
-          attributes: [
-            { from: "sample_id", to: "cases.case_id", convert: true },
-          ],
-          callback,
-        },
-      },
-    ],
+    geneSearch4GDCmds3: {
+      hardcodeCnvOnly: props.hardcodeCnvOnly,
+    },
+    filter0,
+    allow2selectSamples: {
+      buttonText: "Create Cohort",
+      attributes: [{ from: "sample_id", to: "cases.case_id", convert: true }],
+      callback,
+    },
   };
 
-  if (props.geneId) {
+  if (props.hardcodeCnvOnly) {
+    arg.geneSearch4GDCmds3 = {
+      hardcodeCnvOnly: true,
+    };
+  } else if (props.geneId) {
     arg.gene2canonicalisoform = props.geneId;
   } else if (props.ssm_id) {
     arg.mds3_ssm2canonicalisoform = {

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -267,6 +267,25 @@ export const REGISTERED_APPS: AppRegistrationEntry[] = [
     noDataTooltip:
       "Current cohort does not have MAF data available for download.",
   },
+  {
+    name: "CNV Segment",
+    icon: (
+      <ProteinPaintIcon
+        height={48}
+        width={80}
+        viewBox="-12 0 80 48"
+        aria-hidden="true"
+      />
+    ),
+    tags: ["variantAnalysis", "cnv"],
+    hasDemo: true,
+    description: "",
+    id: "CnvSegmentApp",
+    countsField: "ssmCaseCount",
+    optimizeRules: ["available data = ssm"],
+    noDataTooltip:
+      "Current cohort does not have SSM data available for visualization.",
+  },
 ];
 
 export const APPTAGS = [


### PR DESCRIPTION
## Description

@craigrbarnes Not sure if the base branch should be `develop`, I can change to the last release branch if that makes more sense to release only proteinpaint changes for the CNV segment tool.

Change Log

CNV Segment Tool
- created ATF card
- prototyped tool features against qa-int API

OncoMatrix and Gene Expression Clustering:
- Remove the GFF "load gene sets" option from Gene set edit UI in unclustered genes panel
- Do not show gene menu submenu content on load if input is not checked

## Checklist

- [x] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
