### PR TITLE
PEAR-2413 - cDAVE Treatment Dose plots: axis labels cut off and overlapping

### DIFF
--- a/packages/portal-proto/src/features/cDave/CDaveCard/BoxPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/BoxPlot.tsx
@@ -150,6 +150,13 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         crossAxis={false}
         tickCount={8}
         tickLabelComponent={emptyChart ? <></> : undefined}
+        tickFormat={(value: number) =>
+          value.toLocaleString("en-US", {
+            maximumFractionDigits: 2,
+            notation: "compact",
+            compactDisplay: "short",
+          })
+        }
       />
       <VictoryBoxPlot
         style={{

--- a/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/QQPlot.tsx
@@ -151,6 +151,12 @@ const QQPlot: React.FC<QQPlotProps> = ({
           fontSize: 12,
           color: "black",
           fontFamily: "Noto Sans",
+          formatter: (value: number) =>
+            value.toLocaleString("en-US", {
+              maximumFractionDigits: 2,
+              notation: "compact",
+              compactDisplay: "short",
+            }),
         },
         axisTick: {
           length: 6,


### PR DESCRIPTION
## Description
- Adds string formatting to QQ/Box plot labels so that larger values aren't cut off

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1128" alt="Screenshot 2025-05-08 at 10 11 47 AM" src="https://github.com/user-attachments/assets/c71850a8-5e46-4dad-99a7-68c7ecf9a019" />
