### PR TITLE
PEAR-2376: Fix for Left-hand filters render in a tiny panel

### DIFF
--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -17,6 +17,7 @@ import {
   useMemo,
   createContext,
   useContext,
+  useLayoutEffect,
 } from "react";
 import { useDeepCompareEffect, useDeepCompareMemo } from "use-deep-compare";
 import { LoadingOverlay } from "@mantine/core";
@@ -112,7 +113,6 @@ function VerticalTable<TData>({
 
   const ref = useRef<HTMLDivElement>();
   const { xPosition, setXPosition } = useContext(TableXPositionContext);
-  const bottomXCoor = ref?.current?.getBoundingClientRect()?.bottom;
   useEffect(() => {
     if (sortingStatus && announcementTimestamp) {
       liveRegionRef.current.textContent = sortingStatus;
@@ -169,16 +169,24 @@ function VerticalTable<TData>({
   });
 
   // Only set xPosition on initial load, not when table options change
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (
-      setXPosition &&
-      xPosition === undefined &&
-      status === "fulfilled" &&
-      table.getRowModel().rows.length > 0
+      !setXPosition ||
+      xPosition !== undefined ||
+      status !== "fulfilled" ||
+      table.getRowModel().rows.length === 0 ||
+      !ref.current
     ) {
-      setXPosition(bottomXCoor);
+      return;
     }
-  }, [setXPosition, bottomXCoor, xPosition, status, table]);
+
+    requestAnimationFrame(() => {
+      if (ref.current) {
+        const tableBottom = ref.current.getBoundingClientRect().bottom;
+        setXPosition(tableBottom);
+      }
+    });
+  }, [setXPosition, xPosition, status, table]);
 
   const handleSorting = (
     header: Header<TData, unknown>,

--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -105,14 +105,17 @@ function VerticalTable<TData>({
   customBreakpoint,
 }: TableProps<TData>): JSX.Element {
   const [tableData, setTableData] = useState(data);
-  const liveRegionRef = useRef(null);
   const [sortingStatus, setSortingStatus] = useState("");
   const [announcementTimestamp, setAnnouncementTimestamp] = useState(
     Date.now(),
   );
 
+  const [clickedColumnId, setClickedColumnId] = useState<string>(null);
+
+  const liveRegionRef = useRef(null);
   const ref = useRef<HTMLDivElement>();
   const { xPosition, setXPosition } = useContext(TableXPositionContext);
+
   useEffect(() => {
     if (sortingStatus && announcementTimestamp) {
       liveRegionRef.current.textContent = sortingStatus;
@@ -146,7 +149,6 @@ function VerticalTable<TData>({
   const coreRowModel = useMemo(() => getCoreRowModel<TData>(), []);
   const sortedRowModel = useMemo(() => getSortedRowModel<TData>(), []);
 
-  const [clickedColumnId, setClickedColumnId] = useState<string>(null);
   const table = useReactTable({
     columns,
     data: tableData,
@@ -171,21 +173,14 @@ function VerticalTable<TData>({
   // Only set xPosition on initial load, not when table options change
   useLayoutEffect(() => {
     if (
-      !setXPosition ||
-      xPosition !== undefined ||
-      status !== "fulfilled" ||
-      table.getRowModel().rows.length === 0 ||
-      !ref.current
+      setXPosition &&
+      xPosition === undefined &&
+      status === "fulfilled" &&
+      table.getRowModel().rows.length > 0 &&
+      ref.current
     ) {
-      return;
+      setXPosition(ref?.current?.getBoundingClientRect()?.bottom);
     }
-
-    requestAnimationFrame(() => {
-      if (ref.current) {
-        const tableBottom = ref.current.getBoundingClientRect().bottom;
-        setXPosition(tableBottom);
-      }
-    });
   }, [setXPosition, xPosition, status, table]);
 
   const handleSorting = (

--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -180,7 +180,7 @@ function VerticalTable<TData>({
     ) {
       setXPosition(ref?.current?.getBoundingClientRect()?.bottom);
     }
-  }, [setXPosition, xPosition, status, table]);
+  }, [setXPosition, xPosition, status, table.getRowModel().rows.length]);
 
   const handleSorting = (
     header: Header<TData, unknown>,

--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -109,7 +109,6 @@ function VerticalTable<TData>({
   const [announcementTimestamp, setAnnouncementTimestamp] = useState(
     Date.now(),
   );
-
   const [clickedColumnId, setClickedColumnId] = useState<string>(null);
 
   const liveRegionRef = useRef(null);

--- a/packages/portal-proto/src/features/facets/FilterPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useRef, useMemo } from "react";
+import React, { useState, useContext, useRef, useLayoutEffect } from "react";
 import { isEqual } from "lodash";
 import { Text, Modal, LoadingOverlay, Badge, Tooltip } from "@mantine/core";
 import { fieldNameToTitle } from "@gff/core";
@@ -67,13 +67,16 @@ const FilterPanel = ({
 }: FilterPanelProps) => {
   const [opened, setOpened] = useState(false);
   const ref = useRef<HTMLDivElement>();
+  const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined);
 
   const facetFields = facetDefinitions.map((x) => x.field);
 
   const { xPosition } = useContext(TableXPositionContext);
-  const maxHeight = useMemo(() => {
-    const calcHeight = xPosition - ref?.current?.getBoundingClientRect().top;
-    return isNaN(calcHeight) ? undefined : calcHeight;
+
+  useLayoutEffect(() => {
+    if (!ref.current || !xPosition) return;
+    const calcHeight = xPosition - ref.current.getBoundingClientRect().top;
+    setMaxHeight(calcHeight > 0 ? calcHeight : undefined);
   }, [xPosition]);
 
   const customFacetDefinitions = customConfig

--- a/packages/portal-proto/src/features/facets/FilterPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useRef, useLayoutEffect } from "react";
+import React, { useState, useContext, useRef, useMemo } from "react";
 import { isEqual } from "lodash";
 import { Text, Modal, LoadingOverlay, Badge, Tooltip } from "@mantine/core";
 import { fieldNameToTitle } from "@gff/core";
@@ -67,16 +67,13 @@ const FilterPanel = ({
 }: FilterPanelProps) => {
   const [opened, setOpened] = useState(false);
   const ref = useRef<HTMLDivElement>();
-  const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined);
+  const { xPosition } = useContext(TableXPositionContext);
 
   const facetFields = facetDefinitions.map((x) => x.field);
 
-  const { xPosition } = useContext(TableXPositionContext);
-
-  useLayoutEffect(() => {
-    if (!ref.current || !xPosition) return;
-    const calcHeight = xPosition - ref.current.getBoundingClientRect().top;
-    setMaxHeight(calcHeight > 0 ? calcHeight : undefined);
+  const maxHeight = useMemo(() => {
+    const calcHeight = xPosition - ref?.current?.getBoundingClientRect().top;
+    return isNaN(calcHeight) ? undefined : calcHeight;
   }, [xPosition]);
 
   const customFacetDefinitions = customConfig


### PR DESCRIPTION
## Description
I could reproduce this error just once that too unknowingly.

I am using `useLayoutEffect` instead of `useEffect` because it gets fired before the screen is repainted and it's used mostly for layout measurement.
 
## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
