### PR TITLE
PEAR-2386 changes name of cohort builder category

### DIFF
--- a/packages/core/src/features/cohort/data/cohort_builder.json
+++ b/packages/core/src/features/cohort/data/cohort_builder.json
@@ -151,8 +151,8 @@
         "indexType": "explore"
       }
     },
-    "molecular_filters": {
-      "label": "Molecular Filters",
+    "genomic_filters": {
+      "label": "Genomic Filters",
       "facets": ["genes.upload.gene_id", "ssms.upload.ssm_id"],
       "queryOptions": {
         "docType": "cases",

--- a/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/dictionary.tsx
@@ -119,7 +119,7 @@ export const useFacetTabLoaded = (tab: string) => {
   const facetResults = useCoreSelector((state) => selectCaseFacets(state));
   const facetTab = tabsConfig[tab];
 
-  if (tab === "custom" || tab === "molecular_filters") {
+  if (tab === "custom" || tab === "genomic_filters") {
     return true;
   }
 


### PR DESCRIPTION
## Description
- changes "Molecular Filters" category name in Cohort Builder to "Genomic Filters"
## Checklist

- [N/A] Added proper unit tests
- [N/A ] Left proper TODO messages for any remaining tasks
- [N/A ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues


## Screenshots/Screen Recordings (if Appropriate)
<img width="1035" alt="Screenshot 2025-05-15 at 12 16 18 PM" src="https://github.com/user-attachments/assets/50311003-f4b5-460d-aa8b-88e606081fb4" />