### PR TITLE
PEAR-122 updates SSM cancer distribution columns tooltips

### DIFF
--- a/packages/portal-proto/src/features/CancerDistributionTable/GeneCancerDistributionTable/useGeneCancerDistributionColumns.tsx
+++ b/packages/portal-proto/src/features/CancerDistributionTable/GeneCancerDistributionTable/useGeneCancerDistributionColumns.tsx
@@ -145,8 +145,7 @@ export const useGeneCancerDistributionColumns = ({
           header: () => (
             <HeaderTooltip
               title="# SSM Affected Cases"
-              tooltip={`# Cases tested for Simple Somatic Mutations in the Project affected by ${symbol}
-        / # Cases tested for Simple Somatic Mutations in the Project`}
+              tooltip={`# Cases in the Project affected by Simple Somatic Mutations in ${symbol} / # Cases tested for Simple Somatic Mutations in the Project`}
             />
           ),
           cell: ({ row }) => (

--- a/packages/portal-proto/src/features/CancerDistributionTable/SSMSCancerDistributionTable/useSSMCancerDistributionColumns.tsx
+++ b/packages/portal-proto/src/features/CancerDistributionTable/SSMSCancerDistributionTable/useSSMCancerDistributionColumns.tsx
@@ -89,8 +89,7 @@ export const useSSMCancerDistributionColumns = ({
           header: () => (
             <HeaderTooltip
               title="# SSM Affected Cases"
-              tooltip={`# Cases tested for Simple Somatic Mutations in the Project affected by ${symbol}
-        / # Cases tested for Simple Somatic Mutations in the Project`}
+              tooltip={`# Cases in the Project affected by ${symbol} / # Cases tested for Simple Somatic Mutations in the Project`}
             />
           ),
           cell: ({ row }) => (


### PR DESCRIPTION
## Description
- updates tooltips for SSM columns in the cancer distribution tables (both gene and mutation summary page)

## Checklist

- [N/A] Added proper unit tests
- [N/A ] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

<img width="400" alt="Screenshot 2025-05-23 at 12 54 44 PM" src="https://github.com/user-attachments/assets/413b959c-b657-424d-9360-02c006b12e94" />
<img width="323" alt="Screenshot 2025-05-23 at 12 54 53 PM" src="https://github.com/user-attachments/assets/efa5ac00-d16d-4587-a2cf-d7176be90fa9" />
