### PR TITLE
update proteinpaint-client to 2.129.0; update the Copy Number Segment icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,9 +6197,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.128.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.128.1.tgz",
-      "integrity": "sha512-Hq6cgSRPILDBDqs/VRXgmgW6QJ+9qw+jEk3jtqjIqttXKb/9wf7+Hy8Q45gTaa0uBcj8R+mFUx5CbpyKeAk/xg==",
+      "version": "2.129.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.0.tgz",
+      "integrity": "sha512-8b9py8EeOZnYLoR68I+/rTOWgHSe3/JQOYzCoyFR7lzRhpMBWHQl7jPA5PgLmqRF7wxVTMwlx0fK/9sgPRV4Jw==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28402,7 +28402,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.128.1",
+        "@sjcrh/proteinpaint-client": "^2.129.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",
@@ -28666,111 +28666,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
-      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
-      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
-      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
-      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
-      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
-      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
-      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.128.1",
+    "@sjcrh/proteinpaint-client": "2.129.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/public/user-flow/icons/apps/CopyNumberSegment.svg
+++ b/packages/portal-proto/public/user-flow/icons/apps/CopyNumberSegment.svg
@@ -1,0 +1,19 @@
+<svg id="Copy_Num_Seg-white" xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <rect id="Rectangle_448" data-name="Rectangle 448" width="48" height="48" rx="3" fill="#fff"/>
+  <path id="Path_369" data-name="Path 369" d="M12.01,5.09H33.48a1.272,1.272,0,0,1,1.27,1.27v4.03a1.272,1.272,0,0,1-1.27,1.27H12.01a1.272,1.272,0,0,1-1.27-1.27V6.36a1.272,1.272,0,0,1,1.27-1.27Z" fill="#2a72a5"/>
+  <rect id="Rectangle_449" data-name="Rectangle 449" width="3.86" height="6.56" rx="1.27" transform="translate(39.61 5.09)" fill="#2a72a5"/>
+  <path id="Path_370" data-name="Path 370" d="M31.43,15.51H42.19a1.272,1.272,0,0,1,1.27,1.27v4.03a1.272,1.272,0,0,1-1.27,1.27H31.43a1.272,1.272,0,0,1-1.27-1.27V16.78a1.272,1.272,0,0,1,1.27-1.27Z" fill="#fcd242"/>
+  <path id="Path_371" data-name="Path 371" d="M15.26,15.51h6.16a1.272,1.272,0,0,1,1.27,1.27v4.03a1.272,1.272,0,0,1-1.27,1.27H15.26a1.272,1.272,0,0,1-1.27-1.27V16.78A1.272,1.272,0,0,1,15.26,15.51Z" fill="#fcd242"/>
+  <path id="Path_372" data-name="Path 372" d="M11.97,15.51a1.272,1.272,0,0,0-1.27,1.27v4.03a1.272,1.272,0,0,0,1.27,1.27h0a1.272,1.272,0,0,0,1.27-1.27V16.78a1.272,1.272,0,0,0-1.27-1.27Z" fill="#fcd242"/>
+  <path id="Path_373" data-name="Path 373" d="M15.26,25.93H33.49a1.272,1.272,0,0,1,1.27,1.27v4.03a1.272,1.272,0,0,1-1.27,1.27H15.26a1.272,1.272,0,0,1-1.27-1.27V27.2a1.272,1.272,0,0,1,1.27-1.27Z" fill="#ee5251"/>
+  <rect id="Rectangle_450" data-name="Rectangle 450" width="7.96" height="6.56" rx="1.27" transform="translate(35.5 25.93)" fill="#ee5251"/>
+  <path id="Path_374" data-name="Path 374" d="M36.77,36.35H42.2a1.272,1.272,0,0,1,1.27,1.27v4.03a1.272,1.272,0,0,1-1.27,1.27H36.77a1.272,1.272,0,0,1-1.27-1.27V37.62A1.272,1.272,0,0,1,36.77,36.35Z" fill="#00ba8b"/>
+  <path id="Path_375" data-name="Path 375" d="M8.77,36.35h3.2a1.272,1.272,0,0,1,1.27,1.27v4.03a1.272,1.272,0,0,1-1.27,1.27H8.77A1.272,1.272,0,0,1,7.5,41.65V37.62a1.272,1.272,0,0,1,1.27-1.27Z" fill="#00ba8b"/>
+  <rect id="Rectangle_451" data-name="Rectangle 451" width="5.47" height="0.75" transform="translate(4.53 7.99)" fill="#313131"/>
+  <rect id="Rectangle_452" data-name="Rectangle 452" width="3.36" height="0.75" transform="translate(35.5 7.99)" fill="#313131"/>
+  <rect id="Rectangle_453" data-name="Rectangle 453" width="5.42" height="0.75" transform="translate(4.53 18.41)" fill="#313131"/>
+  <rect id="Rectangle_454" data-name="Rectangle 454" width="5.98" height="0.75" transform="translate(23.43 18.41)" fill="#313131"/>
+  <rect id="Rectangle_455" data-name="Rectangle 455" width="8.71" height="0.75" transform="translate(4.53 28.84)" fill="#313131"/>
+  <rect id="Rectangle_456" data-name="Rectangle 456" width="20.76" height="0.75" transform="translate(13.99 39.26)" fill="#313131"/>
+  <rect id="Rectangle_457" data-name="Rectangle 457" width="2.22" height="0.75" transform="translate(4.53 39.26)" fill="#313131"/>
+</svg>

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -16,6 +16,7 @@ import ProteinPaintIcon from "public/user-flow/icons/apps/ProteinPaint.svg";
 import OncoMatrixIcon from "public/user-flow/icons/apps/OncoMatrix.svg";
 import GeneExpressionIcon from "public/user-flow/icons/apps/GeneExpression.svg";
 import ScRNASeqIcon from "public/user-flow/icons/apps/scRNASeq.svg";
+import CopyNumberSegmentIcon from "public/user-flow/icons/apps/CopyNumberSegment.svg";
 import { useLazyScRNAseqCaseCountQuery } from "../../proteinpaint/scRNAseqCaseCount";
 import { useLazyCnvSegmentCaseCountQuery } from "../../proteinpaint/CnvSegmentCaseCount";
 import { CountHookRegistry } from "@gff/core";
@@ -276,7 +277,7 @@ export const REGISTERED_APPS: AppRegistrationEntry[] = [
   {
     name: "Copy Number Segment",
     icon: (
-      <ProteinPaintIcon
+      <CopyNumberSegmentIcon
         height={48}
         width={80}
         viewBox="-12 0 80 48"


### PR DESCRIPTION
## Description

(NOTE: We will be making at least 1 more PP release by tomorrow's freeze date).

CNV tool updates

Features:
- mds3 tk cnv piles up as density plot when too many

Fixes:
- cancel a stale gdc cache fetch loop to prevent race condition issues
- apply ds specific cutoffs of maxReturnCutoff densityViewCutoff for cnv view
- properly display cnv entries in mds3 tk sample table, support cnv data download

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
