### PR TITLE
PEAR-2438 - Set Operations: Selection screen - Wrong checkbox is selected if entities have same name

### DIFF
--- a/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
@@ -52,13 +52,13 @@ const SetOperationsSelection = (): JSX.Element => {
     cohort1Id === "demoCohort1Id" && cohort2Id === "demoCohort2Id";
 
   useDeepCompareEffect(() => {
-    if (cohorts.length > 0 || isCohortComparisonDemo) {
+    if (isCohortComparisonDemo || overwriteSelectedEntities) {
       setSelectedEntityType("cohort");
+    }
 
-      // A cohort has been deleted, kick user back to selection screen
-      if (cohorts.length < 2 && !isCohortComparisonDemo) {
-        setSelectionScreenOpen(true);
-      }
+    // A cohort has been deleted, kick user back to selection screen
+    if (cohorts.length < 2 && !isCohortComparisonDemo) {
+      setSelectionScreenOpen(true);
     }
   }, [cohorts, isCohortComparisonDemo, setSelectionScreenOpen]);
 

--- a/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
@@ -44,7 +44,9 @@ const SetOperationsSelection = (): JSX.Element => {
       state,
       overwriteSelectedEntities
         ? [{ id: cohort1Id as string }, { id: cohort2Id as string }]
-        : selectedEntities,
+        : selectedEntityType === "cohort"
+        ? selectedEntities
+        : [],
     ),
   );
 


### PR DESCRIPTION
## Description

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
