### PR TITLE
update proteinpaint-client to 2.129.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,9 +6197,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.129.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.1.tgz",
-      "integrity": "sha512-uBPHX7BpP38rP6BbT4CnGexvuWalZK9ILAP/vHPmjj+GHLe+bqm+txnJJJc7qIxKYDfbbUI91oUrv5f/Yo5x8A==",
+      "version": "2.129.4",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.4.tgz",
+      "integrity": "sha512-6nCapO3XgoL3QbmE4LXk2CxNdK/XprMwl4jDS6B8ytHdTPn5ap/3gs0fMJZuqY6jq3FDBz8iXAjtXc6whrjDhw==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28402,7 +28402,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.129.1",
+        "@sjcrh/proteinpaint-client": "^2.129.4",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.129.1",
+    "@sjcrh/proteinpaint-client": "2.129.4",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.129.4",
+    "@sjcrh/proteinpaint-client": "^2.129.4",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

This PR addresses https://gdc-ctds.atlassian.net/browse/SV-2613 and other PP-based tool issues as used in the GDC portal.

Fixes:
- disable cohortsize check to avoid breaking sunburst for controlled lollipop view, also fix a minor sunburst rendering issue
- remove delete option for hierCluster term group (known issue from 2.16 release)
- loosen gdc recoverableError handling, including clearing it to allow a subsequent recache attempt to complete (follow-up action to https://gdc-ctds.atlassian.net/browse/SV-2605)

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
