### PR TITLE
update proteinpaint-client to 2.129.5-c5a0eaea6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,9 +6197,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.129.4",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.4.tgz",
-      "integrity": "sha512-6nCapO3XgoL3QbmE4LXk2CxNdK/XprMwl4jDS6B8ytHdTPn5ap/3gs0fMJZuqY6jq3FDBz8iXAjtXc6whrjDhw==",
+      "version": "2.129.5-c5a0eaea6.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.5-c5a0eaea6.0.tgz",
+      "integrity": "sha512-fWqhw9oKW5GbzhCz0O+RxSh8r018Lu9uBfqieTs48Ft5IjBCTfvHkH1XEhocqXNI8nca15CUh5zliTFVruU34Q==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28402,7 +28402,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.129.4",
+        "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.129.4",
+    "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

This fixes the priority bug in https://gdc-ctds.atlassian.net/browse/SV-2614, required before code freeze.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
