### PR TITLE
Qa 2337 cohort name replace with button automation

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
@@ -59,11 +59,11 @@ tags: gdc-data-portal-v2, end-to-end, regression
 * Verify "S1 Union S2 Union S3 Count Set Operations" and "Cohort Bar Case Count" are "Equal"
 
 * Verify the table "Summary Set Operations" is displaying this information
-    |text_to_validate                       |
-    |---------------------------------------|
-    |replace_cohort_1                       |
-    |replace_cohort_2                       |
-    |replace_cohort_3                       |
+  |text_to_validate                       |
+  |---------------------------------------|
+  |replace_cohort_1                       |
+  |replace_cohort_2                       |
+  |replace_cohort_3                       |
 
 ## Cohort Comparison Replace
 * Navigate to "Analysis" from "Header" "section"
@@ -91,7 +91,9 @@ tags: gdc-data-portal-v2, end-to-end, regression
 * Collect Cohort Bar Case Count for comparison
 * Verify "Cohort Bar Case Count" and "CC_Vital_Status_Dead_2 Count" are "Equal"
 
-## Project Page Replace
+## Project Summary Replace
+* Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
+* "replace_cohort_1" should be the active cohort
 * Navigate to "Analysis" from "Header" "section"
 * Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
 * Quick search for "FM-AD" and go to its page
@@ -108,3 +110,135 @@ tags: gdc-data-portal-v2, end-to-end, regression
 * Navigate to "Analysis" from "Header" "section"
 * Collect Cohort Bar Case Count for comparison
 * Verify "Cohort Bar Case Count" and "Case Count Project Summary" are "Equal"
+
+## Case Summary Replace
+* Switch cohort to "replace_cohort_2" from the Cohort Bar dropdown list
+* "replace_cohort_2" should be the active cohort
+* Quick search for "5a9cdffd-9532-4a16-9b08-6cec926e88f8" and go to its page
+* Verify the table "Summary Case Summary" is displaying this information
+  |text_to_validate                       |
+  |---------------------------------------|
+  |5a9cdffd-9532-4a16-9b08-6cec926e88f8   |
+* Collect button labels in table "Most Frequent Somatic Mutations" for comparison
+  |button_label                                     |row  |column |
+  |-------------------------------------------------|-----|-------|
+  |First Row # Affected Cases in MP2PRT-PAPGZW      |1    |6      |
+* Select value from table "Most Frequent Somatic Mutations" by row and column
+  |row   |column|
+  |------|------|
+  |1     |6     |
+* Name the cohort "replace_cohort_2" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                                  |Keep or Remove Modal|
+  |-----------------|-----------------------------------------------------------|--------------------|
+  |Replace          |Cohort has been saved.                                     |Remove Modal        |
+* Navigate to "Analysis" from "Header" "section"
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "First Row # Affected Cases in MP2PRT-PAPGZW" are "Equal"
+
+## Gene Summary Replace
+* Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
+* "replace_cohort_1" should be the active cohort
+
+* Quick search for "CDKN2A" and go to its page
+* Verify the table "Summary Gene Summary" body text is correct
+  |expected_text                          |row  |column |
+  |---------------------------------------|-----|-------|
+  |CDKN2A                                 |1    |2      |
+* Collect button labels in table for comparison
+  |button_label                                     |row  |column |
+  |-------------------------------------------------|-----|-------|
+  |CDKN2A SSM Affected Cases in Cohort              |1    |4      |
+* Select value from table by row and column
+  |row   |column|
+  |------|------|
+  |1     |4     |
+* Name the cohort "replace_cohort_1" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                                      |Keep or Remove Modal|
+  |-----------------|---------------------------------------------------------------|--------------------|
+  |Replace          |Cohort has been saved.                                         |Remove Modal        |
+
+
+* Collect button labels in table for comparison
+  |button_label                                     |row  |column |
+  |-------------------------------------------------|-----|-------|
+  |CDKN2A CNV Amplifications                        |1    |5      |
+* Select value from table by row and column
+  |row   |column|
+  |------|------|
+  |1     |5     |
+* Name the cohort "replace_cohort_2" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                                      |Keep or Remove Modal|
+  |-----------------|---------------------------------------------------------------|--------------------|
+  |Replace          |replace_cohort_2 has been saved.                               |Remove Modal        |
+
+
+* Collect button labels in table for comparison
+  |button_label                                     |row  |column |
+  |-------------------------------------------------|-----|-------|
+  |CDKN2A CNV Homozygous Deletions                  |1    |6      |
+* Select value from table by row and column
+  |row   |column|
+  |------|------|
+  |1     |6     |
+* Name the cohort "replace_cohort_3" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                                      |Keep or Remove Modal|
+  |-----------------|---------------------------------------------------------------|--------------------|
+  |Replace          |replace_cohort_3 has been saved.                               |Remove Modal        |
+
+
+* Navigate to "Analysis" from "Header" "section"
+* Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
+* "replace_cohort_1" should be the active cohort
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "CDKN2A SSM Affected Cases in Cohort" are "Equal"
+
+* Navigate to "Analysis" from "Header" "section"
+* Switch cohort to "replace_cohort_2" from the Cohort Bar dropdown list
+* "replace_cohort_2" should be the active cohort
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "CDKN2A CNV Amplifications" are "Equal"
+
+* Navigate to "Analysis" from "Header" "section"
+* Switch cohort to "replace_cohort_3" from the Cohort Bar dropdown list
+* "replace_cohort_3" should be the active cohort
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "CDKN2A CNV Homozygous Deletions" are "Equal"
+
+## Mutation Summary Replace
+* Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
+* "replace_cohort_1" should be the active cohort
+* Quick search for "84aef48f-31e6-52e4-8e05-7d5b9ab15087" and go to its page
+* Verify the table "Summary Mutation Summary" body text is correct
+  |expected_text                          |row  |column |
+  |---------------------------------------|-----|-------|
+  |chr7:g.140753336A>T                    |2    |2      |
+
+* Collect button labels in table for comparison
+  |button_label                                                     |row  |column |
+  |-----------------------------------------------------------------|-----|-------|
+  |chr7:g.140753336A>T SSM Affected Cases in Cohort                 |1    |4      |
+* Select value from table by row and column
+  |row   |column|
+  |------|------|
+  |1     |4     |
+* Name the cohort "replace_cohort_1" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                                      |Keep or Remove Modal|
+  |-----------------|---------------------------------------------------------------|--------------------|
+  |Replace          |Cohort has been saved.                                         |Remove Modal        |
+
+* Navigate to "Analysis" from "Header" "section"
+
+* Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
+* "replace_cohort_1" should be the active cohort
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "chr7:g.140753336A>T SSM Affected Cases in Cohort" are "Equal"

--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
@@ -1,0 +1,110 @@
+# End to End - Replace Cohort With Filtered Cohort Button
+Date Created        : 06/12/2025
+Version			    : 1.0
+Owner		        : GDC QA
+Description		    : Replace Cohort with Various Filtered Cohort Buttons
+Test-case           :
+
+tags: gdc-data-portal-v2, end-to-end, regression
+
+## Create Initial Cohorts
+* On GDC Data Portal V2 app
+* Navigate to "Cohort" from "Header" "section"
+
+* Create and save a cohort named "replace_cohort_3" with these filters
+  |tab_name               |facet_name           |selection                      |
+  |-----------------------|---------------------|-------------------------------|
+  |General                |Program              |TCGA                           |
+* Create and save a cohort named "replace_cohort_2" with these filters
+  |tab_name               |facet_name           |selection                      |
+  |-----------------------|---------------------|-------------------------------|
+  |Demographic            |Gender               |male                           |
+* Create and save a cohort named "replace_cohort_1" with these filters
+  |tab_name               |facet_name           |selection                      |
+  |-----------------------|---------------------|-------------------------------|
+  |Demographic            |Gender               |female                         |
+
+## Set Operations Replace
+* Navigate to "Analysis" from "Header" "section"
+* Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
+* Navigate to "Set Operations" from "Analysis" "app"
+* Change number of entries shown in the table to "100"
+* Select the following checkboxes in the Set Operations selection screen
+  |checkbox_name                |
+  |-----------------------------|
+  |replace_cohort_1             |
+  |replace_cohort_2             |
+  |replace_cohort_3             |
+* Run analysis on Set Operations
+* Select the following checkboxes in the Set Operations analysis screen
+  |checkbox_name                |
+  |-----------------------------|
+  |S2 intersect S3 minus S1     |
+  |S1 intersect S3 minus S2     |
+  |S1 minus S2 union S3         |
+  |S2 minus S1 union S3         |
+  |S3 minus S1 union S2         |
+* Pause "8" seconds
+* Collect union row save set item count as "S1 Union S2 Union S3" on the Set Operations analysis screen
+
+* Select Union Row to save as a new set in the Set Operations analysis screen
+* Name the cohort "replace_cohort_1" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                                  |Keep or Remove Modal|
+  |-----------------|-----------------------------------------------------------|--------------------|
+  |Replace          |Cohort has been saved.                                     |Remove Modal        |
+
+* Collect Cohort Bar Case Count for comparison
+* Verify "S1 Union S2 Union S3 Count Set Operations" and "Cohort Bar Case Count" are "Equal"
+
+* Verify the table "Summary Set Operations" is displaying this information
+    |text_to_validate                       |
+    |---------------------------------------|
+    |replace_cohort_1                       |
+    |replace_cohort_2                       |
+    |replace_cohort_3                       |
+
+## Cohort Comparison Replace
+* Navigate to "Analysis" from "Header" "section"
+* Navigate to "Cohort Comparison" from "Analysis" "app"
+* Change number of entries shown in the table to "100"
+* Select cohort "replace_cohort_2" for comparison on the cohort comparison selection screen
+* Run analysis on Cohort Comparison
+
+* Collect case counts on save cohort buttons from an analysis card on Cohort Comparison
+  |analysis_card          |Filter Row                       |Cohort Number  |Collect Case Count Name              |
+  |-----------------------|---------------------------------|---------------|-------------------------------------|
+  |Vital Status           |alive                            |1              |CC_Vital_Status_Alive_1 Count        |
+  |Vital Status           |dead                             |2              |CC_Vital_Status_Dead_2 Count         |
+
+* Replace active cohort with one from an analysis card on Cohort Comparison
+  |analysis_card          |Filter Row                       |Cohort Number  |Cohort Name                    |Expected Message                   |
+  |-----------------------|---------------------------------|---------------|-------------------------------|-----------------------------------|
+  |Vital Status           |alive                            |1              |replace_cohort_1               |Cohort has been saved.             |
+  |Vital Status           |dead                             |2              |replace_cohort_3               |replace_cohort_3 has been saved.   |
+
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "CC_Vital_Status_Alive_1 Count" are "Equal"
+
+* Switch cohort to "replace_cohort_3" from the Cohort Bar dropdown list
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "CC_Vital_Status_Dead_2 Count" are "Equal"
+
+## Project Page Replace
+* Navigate to "Analysis" from "Header" "section"
+* Switch cohort to "replace_cohort_1" from the Cohort Bar dropdown list
+* Quick search for "FM-AD" and go to its page
+* Collect "Case Count" on Project Summary page
+* Select "Save New Cohort" on Project Summary page
+
+* Name the cohort "replace_cohort_1" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                                  |Keep or Remove Modal|
+  |-----------------|-----------------------------------------------------------|--------------------|
+  |Replace          |Cohort has been saved.                                     |Remove Modal        |
+
+* Navigate to "Analysis" from "Header" "section"
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "Case Count Project Summary" are "Equal"

--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
@@ -1,9 +1,9 @@
 # End to End - Replace Cohort With Filtered Cohort Button
 Date Created        : 06/12/2025
-Version			    : 1.0
-Owner		        : GDC QA
-Description		    : Replace Cohort with Various Filtered Cohort Buttons
-Test-case           :
+Version			        : 1.0
+Owner		            : GDC QA
+Description		      : Replace Cohort with Various Filtered Cohort Buttons
+Test-case           : PEAR-2458
 
 tags: gdc-data-portal-v2, end-to-end, regression
 

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/create_filtered_cohort_button.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/create_filtered_cohort_button.spec
@@ -209,3 +209,59 @@ Note: This is to resolve flaky test
 * Verify "Cohort Bar Case Count" and "chr1:g.6197725delT Affected Cases in Cohort" are "Equal"
 * Verify "Cohort Bar Case Count" and "Home Page Cases Count" are "Not Equal"
 * Search the table for ""
+
+## Mutations - Replace with Affected Cases in Cohort
+* Switch cohort to "Blank - Mutation Frequency" from the Cohort Bar dropdown list
+* "Blank - Mutation Frequency" should be the active cohort
+Note: This is to resolve flaky test
+* Select value from table "Most Frequent Somatic Mutations" by row and column
+  |row   |column|
+  |------|------|
+  |1     |1     |
+  |1     |1     |
+* Pause "1" seconds
+* Collect button labels in table for comparison
+  |button_label                                 |row  |column |
+  |---------------------------------------------|-----|-------|
+  |First Row Affected Cases in Cohort           |1    |8      |
+* Select value from table by row and column
+  |row   |column|
+  |------|------|
+  |1     |8     |
+* Name the cohort "Blank - Mutation Frequency" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                  |Keep or Remove Modal|
+  |-----------------|-------------------------------------------|--------------------|
+  |Replace          |Cohort has been saved                      |Remove Modal        |
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "First Row Affected Cases in Cohort" are "Equal"
+* Verify "Cohort Bar Case Count" and "Home Page Cases Count" are "Not Equal"
+
+## Genes - Replace with Affected Cases in Cohort
+* Switch to "Genes" tab in the Mutation Frequency app
+* Is text "Distribution of Most Frequently Mutated Genes" present on the page
+Note: This is to resolve flaky test
+* Select value from table "Genes" by row and column
+  |row   |column|
+  |------|------|
+  |1     |1     |
+  |1     |1     |
+* Pause "1" seconds
+* Collect button labels in table for comparison
+  |button_label                         |row  |column |
+  |-------------------------------------|-----|-------|
+  |First Row SSM Affected Cases in Cohort|1    |6      |
+* Select value from table by row and column
+  |row   |column|
+  |------|------|
+  |1     |6     |
+* Name the cohort "Blank - Mutation Frequency" in the Cohort Bar section
+* Select button "Save Name"
+* Perform action and validate modal text
+  |Action to Perform|Text to validate in modal                  |Keep or Remove Modal|
+  |-----------------|-------------------------------------------|--------------------|
+  |Replace          |Cohort has been saved                      |Remove Modal        |
+* Collect Cohort Bar Case Count for comparison
+* Verify "Cohort Bar Case Count" and "First Row SSM Affected Cases in Cohort" are "Equal"
+* Verify "Cohort Bar Case Count" and "Home Page Cases Count" are "Not Equal"

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/create_filtered_cohort_button.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/create_filtered_cohort_button.spec
@@ -3,7 +3,7 @@ Date Created   : 09/17/2023
 Version			   : 1.0
 Owner		       : GDC QA
 Description		 : Create a Filtered Cohort Using Different Table Buttons
-Test-Case      : PEAR-1510
+Test-Case      : PEAR-1510, PEAR-2458
 
 tags: gdc-data-portal-v2, mutation-frequency, regression
 

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_comparison_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_comparison_steps.py
@@ -146,3 +146,28 @@ def save_cohort_analysis_card_cohort_comparison(table):
         )
         APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
         time.sleep(2)
+
+@step("Replace active cohort with one from an analysis card on Cohort Comparison <table>")
+def save_cohort_analysis_card_cohort_comparison(table):
+    """
+    save_cohort_analysis_card_cohort_comparison Save a cohort from an analysis card
+    on the cohort comparison main screen.
+
+    :param v[0]: Analysis Card
+    :param v[1]: Filter Row Name
+    :param v[2]: Cohort Number to select (i.e 1 or 2)
+    :param v[3]: Cohort Name
+    :param v[4]: Expected Message
+    """
+    for k, v in enumerate(table):
+        APP.cohort_comparison_page.click_save_cohort_button_on_analysis_card_cohort_comparison(
+            v[0], v[1], v[2]
+        )
+        APP.shared.send_text_into_text_box(v[3], "Name Input Field")
+        APP.shared.click_button_in_modal_with_displayed_text_name("Save")
+        APP.shared.click_button_in_modal_with_displayed_text_name("Replace")
+        APP.cohort_bar.wait_for_text_in_temporary_message(
+            "Cohort has been saved.", "Remove Modal"
+        )
+        APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
+        time.sleep(2)

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -1113,6 +1113,7 @@ def select_table_value_by_row_column(table):
     Selects values from tables by giving a row and column
     Row and Column indexing begins at '1'
     """
+    APP.shared.wait_for_loading_spinner_table_to_detatch()
     for k, v in enumerate(table):
         APP.shared.select_table_by_row_column(v[0], v[1])
         time.sleep(1)
@@ -1132,6 +1133,7 @@ def select_table_value_by_row_column(table_name:str, table):
     In specified table, selects values from tables by giving a row and column
     Row and Column indexing begins at '1'
     """
+    APP.shared.wait_for_loading_spinner_table_to_detatch()
     for k, v in enumerate(table):
         APP.shared.select_specified_table_by_row_column(table_name, v[0], v[1])
         time.sleep(1)

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -1024,7 +1024,7 @@ def click_named_button_in_modal_and_wait_for_temp_message_text(table):
     APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
     for k, v in enumerate(table):
         APP.shared.click_button_in_modal_with_displayed_text_name(v[0])
-        is_cohort_message_present = APP.cohort_bar.wait_for_text_in_temporary_message(
+        is_cohort_message_present = APP.shared.wait_for_text_in_temporary_message(
             v[1], v[2]
         )
         assert is_cohort_message_present, f"The text '{v[1]}' is NOT present"

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -427,7 +427,7 @@ class BasePage:
         """
         text_locator = GenericLocators.TEXT_IN_PARAGRAPH(text)
         try:
-            self.wait_until_locator_is_visible(text_locator)
+            self.wait_until_locator_is_visible(text_locator, 60000)
             if action.lower() == "remove modal":
                 # On occasion, the automation will move so fast and click the close 'x' button
                 # it changes what the active cohort is. I cannot reproduce it manually, and it stops


### PR DESCRIPTION
## Description
- Automated test to replace cohort using create filtered cohort button in various places across the data portal

Test:
caracal vpn, prod-green
`gauge run -p -n=2  specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec specs/gdc_data_portal_v2/mutation_frequency/create_filtered_cohort_button.spec`

