### PR TITLE
PEAR-2296 Update JSON download names for Cancer Distribution charts

### DIFF
--- a/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
+++ b/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
@@ -164,10 +164,10 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
       return orderBy(
         preparedData,
         [
-          "amplification",
-          "gain",
-          "heterozygous deletion",
-          "homozygous deletion",
+          "cnv_amplification_percent",
+          "cnv_gain_percent:",
+          "cnv_heterozygous_deletion_percent",
+          "cnv_homozygous_deletion_percent",
         ],
         ["desc", "desc", "desc", "desc"],
       );

--- a/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
+++ b/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
@@ -145,22 +145,17 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
 
   const jsonData = useDeepCompareMemo(() => {
     const preparedData = top20ChartData.map(
-      ({
-        project: symbol,
-        amplification,
-        gain,
-        loss,
-        homozygousDeletion,
-        total,
-      }) => ({
-        symbol,
-        amplification: amplification ? (amplification / total) * 100 : 0,
-        gain: gain ? (gain / total) * 100 : 0,
-        "heterozygous deletion": loss ? (loss / total) * 100 : 0,
-        "homozygous deletion": homozygousDeletion
+      ({ project, amplification, gain, loss, homozygousDeletion, total }) => ({
+        project,
+        cnv_amplification_percent: amplification
+          ? (amplification / total) * 100
+          : 0,
+        cnv_gain_percent: gain ? (gain / total) * 100 : 0,
+        cnv_heterozygous_deletion_percent: loss ? (loss / total) * 100 : 0,
+        cnv_homozygous_deletion_percent: homozygousDeletion
           ? (homozygousDeletion / total) * 100
           : 0,
-        total,
+        num_cnv_cases_total: total,
       }),
     );
 

--- a/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
+++ b/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
@@ -165,7 +165,7 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
         preparedData,
         [
           "cnv_amplification_percent",
-          "cnv_gain_percent:",
+          "cnv_gain_percent",
           "cnv_heterozygous_deletion_percent",
           "cnv_homozygous_deletion_percent",
         ],

--- a/packages/portal-proto/src/features/charts/SSMPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SSMPlot.tsx
@@ -124,10 +124,10 @@ const SSMPlot: React.FC<SSMPlotProps> = ({
           filename="cancer-distribution-bar-chart"
           divId={chartDivId}
           jsonData={[
-            ...sortedData.map(({ project: label, percent: value }) => {
+            ...sortedData.map(({ project, percent }) => {
               return {
-                label,
-                value,
+                project,
+                affected_cases_percent: percent,
               };
             }),
           ]}


### PR DESCRIPTION
## Description
- updates the property names in JSON downloads from Cancer Distribution charts

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)

<img width="515" alt="Screenshot 2025-06-27 at 12 05 30 PM" src="https://github.com/user-attachments/assets/f311e75a-d608-47b3-a26d-82bdf3a24ee2" />
<img width="439" alt="Screenshot 2025-06-27 at 12 05 50 PM" src="https://github.com/user-attachments/assets/6236e4c3-6c70-4b44-b7b3-53b265a91133" />
