### PR TITLE
Merge Sanger release 2.17.6 to develop

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "2.17.2",
+  "version": "2.17.3",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "2.17.3",
+  "version": "2.17.4",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "2.17.0",
+  "version": "2.17.1",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "2.17.5",
+  "version": "2.17.6",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "2.17.1",
+  "version": "2.17.2",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,7 @@
 {
-  "packages": ["packages/*"],
-  "version": "2.17.4",
+  "packages": [
+    "packages/*"
+  ],
+  "version": "2.17.5",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "2.17.5",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "2.16.5",
+  "version": "2.17.0",
   "useWorkspaces": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,9 +6197,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.129.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.1.tgz",
-      "integrity": "sha512-uBPHX7BpP38rP6BbT4CnGexvuWalZK9ILAP/vHPmjj+GHLe+bqm+txnJJJc7qIxKYDfbbUI91oUrv5f/Yo5x8A==",
+      "version": "2.129.4",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.4.tgz",
+      "integrity": "sha512-6nCapO3XgoL3QbmE4LXk2CxNdK/XprMwl4jDS6B8ytHdTPn5ap/3gs0fMJZuqY6jq3FDBz8iXAjtXc6whrjDhw==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28402,7 +28402,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.129.1",
+        "@sjcrh/proteinpaint-client": "^2.129.4",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdc-frontend-framework",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdc-frontend-framework",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -28012,7 +28012,7 @@
     },
     "packages/core": {
       "name": "@gff/core",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "Apache-2.0",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -28062,10 +28062,10 @@
       }
     },
     "packages/enclave-portal": {
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.17.0",
+        "@gff/portal-components": "^2.17.1",
         "@mantine/core": "7.17.4",
         "@mantine/notifications": "7.17.4",
         "next": "^15.2.4"
@@ -28158,7 +28158,7 @@
     },
     "packages/lighthouse": {
       "name": "@gff/lighthouse",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "lighthouse": "^9.6.8",
@@ -28167,7 +28167,7 @@
     },
     "packages/portal-components": {
       "name": "@gff/portal-components",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mantine/core": "7.17.4",
@@ -28382,7 +28382,7 @@
       "license": "MIT"
     },
     "packages/portal-proto": {
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
@@ -28393,8 +28393,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.17.0",
-        "@gff/portal-components": "^2.17.0",
+        "@gff/core": "^2.17.1",
+        "@gff/portal-components": "^2.17.1",
         "@mantine/core": "7.17.4",
         "@mantine/dates": "7.17.4",
         "@mantine/form": "7.17.4",
@@ -28620,7 +28620,7 @@
     },
     "packages/sapien": {
       "name": "@nci-gdc/sapien",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "dependencies": {
         "@babel/preset-react": "^7.24.1",
         "d3": "^7.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdc-frontend-framework",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdc-frontend-framework",
-      "version": "2.16.5",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -28012,7 +28012,7 @@
     },
     "packages/core": {
       "name": "@gff/core",
-      "version": "2.16.5",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -28062,10 +28062,10 @@
       }
     },
     "packages/enclave-portal": {
-      "version": "2.16.5",
+      "version": "2.17.0",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.16.5",
+        "@gff/portal-components": "^2.17.0",
         "@mantine/core": "7.17.4",
         "@mantine/notifications": "7.17.4",
         "next": "^15.2.4"
@@ -28158,7 +28158,7 @@
     },
     "packages/lighthouse": {
       "name": "@gff/lighthouse",
-      "version": "2.16.5",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "lighthouse": "^9.6.8",
@@ -28167,7 +28167,7 @@
     },
     "packages/portal-components": {
       "name": "@gff/portal-components",
-      "version": "2.16.5",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mantine/core": "7.17.4",
@@ -28382,7 +28382,7 @@
       "license": "MIT"
     },
     "packages/portal-proto": {
-      "version": "2.16.5",
+      "version": "2.17.0",
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
@@ -28393,8 +28393,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.16.5",
-        "@gff/portal-components": "^2.16.5",
+        "@gff/core": "^2.17.0",
+        "@gff/portal-components": "^2.17.0",
         "@mantine/core": "7.17.4",
         "@mantine/dates": "7.17.4",
         "@mantine/form": "7.17.4",
@@ -28620,7 +28620,7 @@
     },
     "packages/sapien": {
       "name": "@nci-gdc/sapien",
-      "version": "2.16.5",
+      "version": "2.17.0",
       "dependencies": {
         "@babel/preset-react": "^7.24.1",
         "d3": "^7.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdc-frontend-framework",
-  "version": "2.17.4",
+  "version": "2.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdc-frontend-framework",
-      "version": "2.17.4",
+      "version": "2.17.6",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -28012,7 +28012,7 @@
     },
     "packages/core": {
       "name": "@gff/core",
-      "version": "2.17.5",
+      "version": "2.17.6",
       "license": "Apache-2.0",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -28062,10 +28062,10 @@
       }
     },
     "packages/enclave-portal": {
-      "version": "2.17.5",
+      "version": "2.17.6",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.17.5",
+        "@gff/portal-components": "^2.17.6",
         "@mantine/core": "7.17.4",
         "@mantine/notifications": "7.17.4",
         "next": "^15.2.4"
@@ -28158,7 +28158,7 @@
     },
     "packages/lighthouse": {
       "name": "@gff/lighthouse",
-      "version": "2.17.5",
+      "version": "2.17.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "lighthouse": "^9.6.8",
@@ -28167,7 +28167,7 @@
     },
     "packages/portal-components": {
       "name": "@gff/portal-components",
-      "version": "2.17.5",
+      "version": "2.17.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@mantine/core": "7.17.4",
@@ -28382,7 +28382,7 @@
       "license": "MIT"
     },
     "packages/portal-proto": {
-      "version": "2.17.5",
+      "version": "2.17.6",
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
@@ -28393,8 +28393,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.17.5",
-        "@gff/portal-components": "^2.17.5",
+        "@gff/core": "^2.17.6",
+        "@gff/portal-components": "^2.17.6",
         "@mantine/core": "7.17.4",
         "@mantine/dates": "7.17.4",
         "@mantine/form": "7.17.4",
@@ -28620,7 +28620,7 @@
     },
     "packages/sapien": {
       "name": "@nci-gdc/sapien",
-      "version": "2.17.5",
+      "version": "2.17.6",
       "dependencies": {
         "@babel/preset-react": "^7.24.1",
         "d3": "^7.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28012,7 +28012,7 @@
     },
     "packages/core": {
       "name": "@gff/core",
-      "version": "2.17.4",
+      "version": "2.17.5",
       "license": "Apache-2.0",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -28062,10 +28062,10 @@
       }
     },
     "packages/enclave-portal": {
-      "version": "2.17.4",
+      "version": "2.17.5",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.17.4",
+        "@gff/portal-components": "^2.17.5",
         "@mantine/core": "7.17.4",
         "@mantine/notifications": "7.17.4",
         "next": "^15.2.4"
@@ -28158,7 +28158,7 @@
     },
     "packages/lighthouse": {
       "name": "@gff/lighthouse",
-      "version": "2.17.4",
+      "version": "2.17.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "lighthouse": "^9.6.8",
@@ -28167,7 +28167,7 @@
     },
     "packages/portal-components": {
       "name": "@gff/portal-components",
-      "version": "2.17.4",
+      "version": "2.17.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@mantine/core": "7.17.4",
@@ -28382,7 +28382,7 @@
       "license": "MIT"
     },
     "packages/portal-proto": {
-      "version": "2.17.4",
+      "version": "2.17.5",
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
@@ -28393,8 +28393,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.17.4",
-        "@gff/portal-components": "^2.17.4",
+        "@gff/core": "^2.17.5",
+        "@gff/portal-components": "^2.17.5",
         "@mantine/core": "7.17.4",
         "@mantine/dates": "7.17.4",
         "@mantine/form": "7.17.4",
@@ -28620,7 +28620,7 @@
     },
     "packages/sapien": {
       "name": "@nci-gdc/sapien",
-      "version": "2.17.4",
+      "version": "2.17.5",
       "dependencies": {
         "@babel/preset-react": "^7.24.1",
         "d3": "^7.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdc-frontend-framework",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdc-frontend-framework",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -28012,7 +28012,7 @@
     },
     "packages/core": {
       "name": "@gff/core",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "license": "Apache-2.0",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -28062,10 +28062,10 @@
       }
     },
     "packages/enclave-portal": {
-      "version": "2.17.2",
+      "version": "2.17.3",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.17.2",
+        "@gff/portal-components": "^2.17.3",
         "@mantine/core": "7.17.4",
         "@mantine/notifications": "7.17.4",
         "next": "^15.2.4"
@@ -28158,7 +28158,7 @@
     },
     "packages/lighthouse": {
       "name": "@gff/lighthouse",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "lighthouse": "^9.6.8",
@@ -28167,7 +28167,7 @@
     },
     "packages/portal-components": {
       "name": "@gff/portal-components",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@mantine/core": "7.17.4",
@@ -28382,7 +28382,7 @@
       "license": "MIT"
     },
     "packages/portal-proto": {
-      "version": "2.17.2",
+      "version": "2.17.3",
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
@@ -28393,8 +28393,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.17.2",
-        "@gff/portal-components": "^2.17.2",
+        "@gff/core": "^2.17.3",
+        "@gff/portal-components": "^2.17.3",
         "@mantine/core": "7.17.4",
         "@mantine/dates": "7.17.4",
         "@mantine/form": "7.17.4",
@@ -28620,7 +28620,7 @@
     },
     "packages/sapien": {
       "name": "@nci-gdc/sapien",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "dependencies": {
         "@babel/preset-react": "^7.24.1",
         "d3": "^7.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdc-frontend-framework",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdc-frontend-framework",
-      "version": "2.17.1",
+      "version": "2.17.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -28012,7 +28012,7 @@
     },
     "packages/core": {
       "name": "@gff/core",
-      "version": "2.17.1",
+      "version": "2.17.2",
       "license": "Apache-2.0",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -28062,10 +28062,10 @@
       }
     },
     "packages/enclave-portal": {
-      "version": "2.17.1",
+      "version": "2.17.2",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.17.1",
+        "@gff/portal-components": "^2.17.2",
         "@mantine/core": "7.17.4",
         "@mantine/notifications": "7.17.4",
         "next": "^15.2.4"
@@ -28158,7 +28158,7 @@
     },
     "packages/lighthouse": {
       "name": "@gff/lighthouse",
-      "version": "2.17.1",
+      "version": "2.17.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "lighthouse": "^9.6.8",
@@ -28167,7 +28167,7 @@
     },
     "packages/portal-components": {
       "name": "@gff/portal-components",
-      "version": "2.17.1",
+      "version": "2.17.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@mantine/core": "7.17.4",
@@ -28382,7 +28382,7 @@
       "license": "MIT"
     },
     "packages/portal-proto": {
-      "version": "2.17.1",
+      "version": "2.17.2",
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
@@ -28393,8 +28393,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.17.1",
-        "@gff/portal-components": "^2.17.1",
+        "@gff/core": "^2.17.2",
+        "@gff/portal-components": "^2.17.2",
         "@mantine/core": "7.17.4",
         "@mantine/dates": "7.17.4",
         "@mantine/form": "7.17.4",
@@ -28620,7 +28620,7 @@
     },
     "packages/sapien": {
       "name": "@nci-gdc/sapien",
-      "version": "2.17.1",
+      "version": "2.17.2",
       "dependencies": {
         "@babel/preset-react": "^7.24.1",
         "d3": "^7.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdc-frontend-framework",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdc-frontend-framework",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -28012,7 +28012,7 @@
     },
     "packages/core": {
       "name": "@gff/core",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "license": "Apache-2.0",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -28062,10 +28062,10 @@
       }
     },
     "packages/enclave-portal": {
-      "version": "2.17.3",
+      "version": "2.17.4",
       "license": "Apache-2",
       "dependencies": {
-        "@gff/portal-components": "^2.17.3",
+        "@gff/portal-components": "^2.17.4",
         "@mantine/core": "7.17.4",
         "@mantine/notifications": "7.17.4",
         "next": "^15.2.4"
@@ -28158,7 +28158,7 @@
     },
     "packages/lighthouse": {
       "name": "@gff/lighthouse",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "lighthouse": "^9.6.8",
@@ -28167,7 +28167,7 @@
     },
     "packages/portal-components": {
       "name": "@gff/portal-components",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@mantine/core": "7.17.4",
@@ -28382,7 +28382,7 @@
       "license": "MIT"
     },
     "packages/portal-proto": {
-      "version": "2.17.3",
+      "version": "2.17.4",
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
@@ -28393,8 +28393,8 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/noto-sans": "^4.5.11",
-        "@gff/core": "^2.17.3",
-        "@gff/portal-components": "^2.17.3",
+        "@gff/core": "^2.17.4",
+        "@gff/portal-components": "^2.17.4",
         "@mantine/core": "7.17.4",
         "@mantine/dates": "7.17.4",
         "@mantine/form": "7.17.4",
@@ -28620,7 +28620,7 @@
     },
     "packages/sapien": {
       "name": "@nci-gdc/sapien",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "dependencies": {
         "@babel/preset-react": "^7.24.1",
         "d3": "^7.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,9 +6197,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.129.5-c5a0eaea6.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.5-c5a0eaea6.0.tgz",
-      "integrity": "sha512-fWqhw9oKW5GbzhCz0O+RxSh8r018Lu9uBfqieTs48Ft5IjBCTfvHkH1XEhocqXNI8nca15CUh5zliTFVruU34Q==",
+      "version": "2.129.5-c5a0eaea6.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.5-c5a0eaea6.1.tgz",
+      "integrity": "sha512-qBz2A7s46TvU6g8O5+5TF3VSs4kI9l48/42AHHYRYmH37BJg4A81lHdr4rznfd8pqbK198ZM3T3pxUWhbFFYIA==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28402,7 +28402,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.0",
+        "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.1",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,9 +6197,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.129.4",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.4.tgz",
-      "integrity": "sha512-6nCapO3XgoL3QbmE4LXk2CxNdK/XprMwl4jDS6B8ytHdTPn5ap/3gs0fMJZuqY6jq3FDBz8iXAjtXc6whrjDhw==",
+      "version": "2.129.5-c5a0eaea6.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.129.5-c5a0eaea6.0.tgz",
+      "integrity": "sha512-fWqhw9oKW5GbzhCz0O+RxSh8r018Lu9uBfqieTs48Ft5IjBCTfvHkH1XEhocqXNI8nca15CUh5zliTFVruU34Q==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28402,7 +28402,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "^2.129.4",
+        "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "2.17.4",
+  "version": "2.17.6",
   "description": "The GDC Frontend Framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "2.16.5",
+  "version": "2.17.0",
   "description": "The GDC Frontend Framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "The GDC Frontend Framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "The GDC Frontend Framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "The GDC Frontend Framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "The GDC Frontend Framework",
   "main": "index.js",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/core",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/core",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/core",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/core",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/core",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/core",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/core",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/enclave-portal/package.json
+++ b/packages/enclave-portal/package.json
@@ -1,10 +1,10 @@
 {
   "name": "enclave-portal",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "dependencies": {
+    "@gff/portal-components": "^2.17.0",
     "@mantine/core": "7.17.4",
     "@mantine/notifications": "7.17.4",
-    "@gff/portal-components": "^2.16.5",
     "next": "^15.2.4"
   },
   "peerDependencies": {

--- a/packages/enclave-portal/package.json
+++ b/packages/enclave-portal/package.json
@@ -1,8 +1,8 @@
 {
   "name": "enclave-portal",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "dependencies": {
-    "@gff/portal-components": "^2.17.5",
+    "@gff/portal-components": "^2.17.6",
     "@mantine/core": "7.17.4",
     "@mantine/notifications": "7.17.4",
     "next": "^15.2.4"

--- a/packages/enclave-portal/package.json
+++ b/packages/enclave-portal/package.json
@@ -1,8 +1,8 @@
 {
   "name": "enclave-portal",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "dependencies": {
-    "@gff/portal-components": "^2.17.4",
+    "@gff/portal-components": "^2.17.5",
     "@mantine/core": "7.17.4",
     "@mantine/notifications": "7.17.4",
     "next": "^15.2.4"

--- a/packages/enclave-portal/package.json
+++ b/packages/enclave-portal/package.json
@@ -1,8 +1,8 @@
 {
   "name": "enclave-portal",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "dependencies": {
-    "@gff/portal-components": "^2.17.2",
+    "@gff/portal-components": "^2.17.3",
     "@mantine/core": "7.17.4",
     "@mantine/notifications": "7.17.4",
     "next": "^15.2.4"

--- a/packages/enclave-portal/package.json
+++ b/packages/enclave-portal/package.json
@@ -1,8 +1,8 @@
 {
   "name": "enclave-portal",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "dependencies": {
-    "@gff/portal-components": "^2.17.0",
+    "@gff/portal-components": "^2.17.1",
     "@mantine/core": "7.17.4",
     "@mantine/notifications": "7.17.4",
     "next": "^15.2.4"

--- a/packages/enclave-portal/package.json
+++ b/packages/enclave-portal/package.json
@@ -1,8 +1,8 @@
 {
   "name": "enclave-portal",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "dependencies": {
-    "@gff/portal-components": "^2.17.1",
+    "@gff/portal-components": "^2.17.2",
     "@mantine/core": "7.17.4",
     "@mantine/notifications": "7.17.4",
     "next": "^15.2.4"

--- a/packages/enclave-portal/package.json
+++ b/packages/enclave-portal/package.json
@@ -1,8 +1,8 @@
 {
   "name": "enclave-portal",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "dependencies": {
-    "@gff/portal-components": "^2.17.3",
+    "@gff/portal-components": "^2.17.4",
     "@mantine/core": "7.17.4",
     "@mantine/notifications": "7.17.4",
     "next": "^15.2.4"

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/lighthouse",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "Use lighthouse to audit Portal v2",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/lighthouse",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Use lighthouse to audit Portal v2",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/lighthouse",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Use lighthouse to audit Portal v2",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/lighthouse",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "description": "Use lighthouse to audit Portal v2",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/lighthouse",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "Use lighthouse to audit Portal v2",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/lighthouse",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Use lighthouse to audit Portal v2",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/lighthouse",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Use lighthouse to audit Portal v2",
   "main": "index.js",
   "scripts": {

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/portal-components",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/portal-components",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/portal-components",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/portal-components",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/portal-components",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -22,9 +22,9 @@
   "dependencies": {
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
-    "@mantine/notifications": "7.17.4",
-    "@mantine/modals": "7.17.4",
     "@mantine/form": "7.17.4",
+    "@mantine/modals": "7.17.4",
+    "@mantine/notifications": "7.17.4",
     "react-icons": "^4.12.0"
   },
   "peerDependencies": {
@@ -32,18 +32,18 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^28.0.1",
+    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@swc/core": "^1.9.2",
     "@types/lodash": "4.17.13",
     "@types/node": "22.9.1",
     "@types/react": "^18.3.1",
     "autoprefixer": "^10.4.20",
     "rollup": "^4.27.3",
-    "@swc/core": "^1.9.2",
-    "@rollup/plugin-commonjs": "^28.0.1",
-    "@rollup/plugin-node-resolve": "^15.3.0",
     "rollup-plugin-dts": "6.1.1",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-swc3": "^0.12.1",
     "rollup-swc-preserve-directives": "^0.7.0",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.8.2"
   }

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/portal-components",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gff/portal-components",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-proto",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next",
@@ -22,8 +22,8 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/noto-sans": "^4.5.11",
-    "@gff/core": "^2.17.4",
-    "@gff/portal-components": "^2.17.4",
+    "@gff/core": "^2.17.5",
+    "@gff/portal-components": "^2.17.5",
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
     "@mantine/form": "7.17.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.129.1",
+    "@sjcrh/proteinpaint-client": "^2.129.4",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-proto",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next",
@@ -22,8 +22,8 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/noto-sans": "^4.5.11",
-    "@gff/core": "^2.17.0",
-    "@gff/portal-components": "^2.17.0",
+    "@gff/core": "^2.17.1",
+    "@gff/portal-components": "^2.17.1",
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
     "@mantine/form": "7.17.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.0",
+    "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.1",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-proto",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next",
@@ -22,8 +22,8 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/noto-sans": "^4.5.11",
-    "@gff/core": "^2.16.5",
-    "@gff/portal-components": "^2.16.5",
+    "@gff/core": "^2.17.0",
+    "@gff/portal-components": "^2.17.0",
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
     "@mantine/form": "7.17.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-proto",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next",
@@ -22,8 +22,8 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/noto-sans": "^4.5.11",
-    "@gff/core": "^2.17.5",
-    "@gff/portal-components": "^2.17.5",
+    "@gff/core": "^2.17.6",
+    "@gff/portal-components": "^2.17.6",
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
     "@mantine/form": "7.17.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-proto",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next",
@@ -22,8 +22,8 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/noto-sans": "^4.5.11",
-    "@gff/core": "^2.17.2",
-    "@gff/portal-components": "^2.17.2",
+    "@gff/core": "^2.17.3",
+    "@gff/portal-components": "^2.17.3",
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
     "@mantine/form": "7.17.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "^2.129.4",
+    "@sjcrh/proteinpaint-client": "2.129.5-c5a0eaea6.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-proto",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next",
@@ -22,8 +22,8 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/noto-sans": "^4.5.11",
-    "@gff/core": "^2.17.1",
-    "@gff/portal-components": "^2.17.1",
+    "@gff/core": "^2.17.2",
+    "@gff/portal-components": "^2.17.2",
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
     "@mantine/form": "7.17.4",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-proto",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next",
@@ -22,8 +22,8 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/noto-sans": "^4.5.11",
-    "@gff/core": "^2.17.3",
-    "@gff/portal-components": "^2.17.3",
+    "@gff/core": "^2.17.4",
+    "@gff/portal-components": "^2.17.4",
     "@mantine/core": "7.17.4",
     "@mantine/dates": "7.17.4",
     "@mantine/form": "7.17.4",

--- a/packages/portal-proto/src/features/annotations/AnnotationFilterPanel.tsx
+++ b/packages/portal-proto/src/features/annotations/AnnotationFilterPanel.tsx
@@ -62,6 +62,7 @@ export const AnnotationFacetPanel = (): JSX.Element => {
       allFiltersCollapsed={allFiltersCollapsed}
       handleClearAll={clearAllFilters}
       filtersAppliedCount={filtersAppliedCount}
+      docType="annotations"
     />
   );
 };

--- a/packages/portal-proto/src/features/facets/FilterPanel.tsx
+++ b/packages/portal-proto/src/features/facets/FilterPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useRef, useMemo } from "react";
 import { isEqual } from "lodash";
 import { Text, Modal, LoadingOverlay, Badge, Tooltip } from "@mantine/core";
-import { fieldNameToTitle } from "@gff/core";
+import { fieldNameToTitle, GQLDocType } from "@gff/core";
 import {
   createFacetCards,
   FacetSelection,
@@ -34,6 +34,7 @@ interface FilterPanelProps {
   readonly hideIfEmpty?: boolean;
   readonly showPercent?: boolean;
   readonly isLoading?: boolean;
+  readonly docType?: GQLDocType;
 }
 
 /**
@@ -57,6 +58,7 @@ const FilterPanel = ({
   facetHooks,
   valueLabel,
   app,
+  docType,
   toggleAllFiltersExpanded,
   allFiltersCollapsed,
   customConfig = undefined,
@@ -184,7 +186,7 @@ const FilterPanel = ({
             return fieldNameToTitle(field, 2);
           },
           Chart: EnumFacetChart,
-          queryOptions: { docType: "cases" },
+          queryOptions: { docType: docType ?? "cases" },
         })}
         {createFacetCards({
           facets: defaultFacetDefinitions,
@@ -195,7 +197,7 @@ const FilterPanel = ({
           showPercent,
           facetNameFormatter: fieldNameToTitle,
           Chart: EnumFacetChart,
-          queryOptions: { docType: "cases" },
+          queryOptions: { docType: docType ?? "cases" },
         })}
       </div>
     </div>

--- a/packages/portal-proto/src/features/facets/hooks.ts
+++ b/packages/portal-proto/src/features/facets/hooks.ts
@@ -366,12 +366,13 @@ export const useTotalCounts = ({
   );
 };
 
-export const FacetDocTypeToCountsIndexMap = {
+export const FacetDocTypeToCountsIndexMap: Record<GQLDocType, string> = {
   cases: "caseCounts",
   files: "fileCounts",
   genes: "genesCounts",
   ssms: "mutationCounts",
-  projects: "projectCounts",
+  projects: "projectsCounts",
+  annotations: "annotationCounts",
 };
 
 export const FacetDocTypeToLabelsMap = {
@@ -380,6 +381,7 @@ export const FacetDocTypeToLabelsMap = {
   genes: "Genes",
   ssms: "Mutations",
   projects: "Projects",
+  annotations: "Annotations",
 };
 
 export const useLocalFilters = (

--- a/packages/portal-proto/src/features/genomic/hooks.ts
+++ b/packages/portal-proto/src/features/genomic/hooks.ts
@@ -27,11 +27,7 @@ import {
 } from "@gff/core";
 import { useDeepCompareEffect } from "use-deep-compare";
 import isEqual from "lodash/isEqual";
-import {
-  extractValue,
-  FacetDocTypeToCountsIndexMap,
-  useTotalCounts,
-} from "@/features/facets/hooks";
+import { extractValue, useTotalCounts } from "@/features/facets/hooks";
 import { useAppDispatch, useAppSelector } from "@/features/genomic/appApi";
 import {
   updateGeneAndSSMFilter,
@@ -139,7 +135,7 @@ export const useAllFiltersCollapsed = () => {
 };
 
 export const useTotalGenomicCounts = ({ docType }: { docType: GQLDocType }) => {
-  return useTotalCounts(FacetDocTypeToCountsIndexMap[docType]);
+  return useTotalCounts({ docType });
 };
 
 export const useGenesFacetValues = (field: string) => {

--- a/packages/portal-proto/src/features/projectsCenter/ProjectFacetPanel.tsx
+++ b/packages/portal-proto/src/features/projectsCenter/ProjectFacetPanel.tsx
@@ -58,6 +58,7 @@ export const ProjectFacetPanel = (): JSX.Element => {
       allFiltersCollapsed={allFiltersCollapsed}
       handleClearAll={clearAllFilters}
       filtersAppliedCount={filtersAppliedCount}
+      docType="projects"
     />
   );
 };

--- a/packages/portal-proto/src/features/proteinpaint/dev.sh
+++ b/packages/portal-proto/src/features/proteinpaint/dev.sh
@@ -7,7 +7,7 @@ if [[ "$1" == "unlink" ]]; then
 	# to test the published client package before submitting a PR with an updated pp-client version
 	npm unlink ../proteinpaint/client
 	npm uninstall @sjcrh/proteinpaint-client --save --workspace=packages/portal-proto
-	npm install @sjcrh/proteinpaint-client@2.129.1 --save --workspace=packages/portal-proto
+	npm install @sjcrh/proteinpaint-client --save --save-exact --workspace=packages/portal-proto
 
 else
 	# to test the local PP client code

--- a/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
+++ b/packages/portal-proto/src/features/repositoryApp/FileFacetPanel.tsx
@@ -117,6 +117,7 @@ export const FileFacetPanel = (): JSX.Element => {
         defaultFilters,
         queryOptions: { facetType: "files" },
       }}
+      docType="files"
       isLoading={!isDictionaryReady}
     />
   );

--- a/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
@@ -44,7 +44,9 @@ const SetOperationsSelection = (): JSX.Element => {
       state,
       overwriteSelectedEntities
         ? [{ id: cohort1Id as string }, { id: cohort2Id as string }]
-        : selectedEntities,
+        : selectedEntityType === "cohort"
+        ? selectedEntities
+        : [],
     ),
   );
 
@@ -52,13 +54,13 @@ const SetOperationsSelection = (): JSX.Element => {
     cohort1Id === "demoCohort1Id" && cohort2Id === "demoCohort2Id";
 
   useDeepCompareEffect(() => {
-    if (cohorts.length > 0 || isCohortComparisonDemo) {
+    if (isCohortComparisonDemo || overwriteSelectedEntities) {
       setSelectedEntityType("cohort");
+    }
 
-      // A cohort has been deleted, kick user back to selection screen
-      if (cohorts.length < 2 && !isCohortComparisonDemo) {
-        setSelectionScreenOpen(true);
-      }
+    // A cohort has been deleted, kick user back to selection screen
+    if (cohorts.length < 2 && !isCohortComparisonDemo) {
+      setSelectionScreenOpen(true);
     }
   }, [cohorts, isCohortComparisonDemo, setSelectionScreenOpen]);
 

--- a/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
+++ b/packages/portal-proto/src/features/set-operations/SetOperationsSelection.tsx
@@ -62,7 +62,12 @@ const SetOperationsSelection = (): JSX.Element => {
     if (cohorts.length < 2 && !isCohortComparisonDemo) {
       setSelectionScreenOpen(true);
     }
-  }, [cohorts, isCohortComparisonDemo, setSelectionScreenOpen]);
+  }, [
+    cohorts,
+    isCohortComparisonDemo,
+    setSelectionScreenOpen,
+    overwriteSelectedEntities,
+  ]);
 
   return !ready ? (
     <LoadingOverlay data-testid="loading-spinner" visible />

--- a/packages/sapien/package.json
+++ b/packages/sapien/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nci-gdc/sapien",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "Organ Map of Human Body",
   "browser": true,
   "main": "dist/index.js",

--- a/packages/sapien/package.json
+++ b/packages/sapien/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nci-gdc/sapien",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "Organ Map of Human Body",
   "browser": true,
   "main": "dist/index.js",

--- a/packages/sapien/package.json
+++ b/packages/sapien/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nci-gdc/sapien",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Organ Map of Human Body",
   "browser": true,
   "main": "dist/index.js",

--- a/packages/sapien/package.json
+++ b/packages/sapien/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nci-gdc/sapien",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Organ Map of Human Body",
   "browser": true,
   "main": "dist/index.js",

--- a/packages/sapien/package.json
+++ b/packages/sapien/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nci-gdc/sapien",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Organ Map of Human Body",
   "browser": true,
   "main": "dist/index.js",

--- a/packages/sapien/package.json
+++ b/packages/sapien/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nci-gdc/sapien",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Organ Map of Human Body",
   "browser": true,
   "main": "dist/index.js",

--- a/packages/sapien/package.json
+++ b/packages/sapien/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nci-gdc/sapien",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "description": "Organ Map of Human Body",
   "browser": true,
   "main": "dist/index.js",


### PR DESCRIPTION
## Description
* merges 2.17.6 to develop. This replaces https://github.com/NCI-GDC/gdc-frontend-framework/pull/1561
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
