### PR TITLE
chore: Connect DataDog RUM and traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1888,33 +1888,6 @@
         "kuler": "^2.0.0"
       }
     },
-    "node_modules/@datadog/browser-core": {
-      "version": "5.35.1",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@datadog/browser-rum": {
-      "version": "5.35.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@datadog/browser-core": "5.35.1",
-        "@datadog/browser-rum-core": "5.35.1"
-      },
-      "peerDependencies": {
-        "@datadog/browser-logs": "5.35.1"
-      },
-      "peerDependenciesMeta": {
-        "@datadog/browser-logs": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@datadog/browser-rum-core": {
-      "version": "5.35.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@datadog/browser-core": "5.35.1"
-      }
-    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "license": "MIT",
@@ -28386,7 +28359,7 @@
       "license": "Apache-2",
       "dependencies": {
         "@axe-core/react": "^4.10.0",
-        "@datadog/browser-rum": "^5.23.3",
+        "@datadog/browser-rum": "^6.13.0",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
@@ -28453,6 +28426,39 @@
         "ts-node": "^9.1.1",
         "typescript": "^5.8.2",
         "victory": "^36.8.1"
+      }
+    },
+    "packages/portal-proto/node_modules/@datadog/browser-core": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.13.0.tgz",
+      "integrity": "sha512-wWhQ22F8pDjh7kGtvBetJhX5luyKsIVzJQTisjM/6p+A2nchDuoOiZ0GdjajRA5LlPa9pj/PlOoe/g+B9AMELg==",
+      "license": "Apache-2.0"
+    },
+    "packages/portal-proto/node_modules/@datadog/browser-rum": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.13.0.tgz",
+      "integrity": "sha512-VIVpoD+A2WLIskB0PXzO0Gh3bZs7MkOrzhnDpamWMrcbGH/UaX6BUmTlorqtT374Jrre6frzN2IEKGQs7kVamQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.13.0",
+        "@datadog/browser-rum-core": "6.13.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "6.13.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "packages/portal-proto/node_modules/@datadog/browser-rum-core": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.13.0.tgz",
+      "integrity": "sha512-+gp9MEDc24xB5dwvVYsOPoRueujTOy0GNW2Q3XNyWMstzuSQIwXaIuDIRVhCoi8+i4UioUCd7ZO30yEB01Ajwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.13.0"
       }
     },
     "packages/portal-proto/node_modules/@mantine/core": {

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@axe-core/react": "^4.10.0",
-    "@datadog/browser-rum": "^5.23.3",
+    "@datadog/browser-rum": "^6.13.0",
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/modifiers": "^6.0.1",
     "@dnd-kit/sortable": "^7.0.2",

--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -67,6 +67,11 @@ if (process.env.NEXT_PUBLIC_DD_ENABLED) {
     trackViewsManually: true,
     defaultPrivacyLevel: "mask",
     version: `v${PUBLIC_APP_INFO?.version}-${PUBLIC_APP_INFO?.hash}`,
+    allowedTracingUrls: [
+      "https://gdc.cancer.gov",
+      // Matches any subdomain of cancer.gov, such as https://portal.gdc.cancer.gov
+      /^https:\/\/[^\/]+\.cancer\.gov/
+    ],
   });
 }
 

--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -70,7 +70,7 @@ if (process.env.NEXT_PUBLIC_DD_ENABLED) {
     allowedTracingUrls: [
       "https://gdc.cancer.gov",
       // Matches any subdomain of cancer.gov, such as https://portal.gdc.cancer.gov
-      /^https:\/\/[^\/]+\.cancer\.gov/
+      /^https:\/\/[^]+\.cancer\.gov/,
     ],
   });
 }


### PR DESCRIPTION
## Description
- Configured datadogRum to allow tracing for `gdc.cancer.gov` domains to connect traces with APM. [Docs](https://docs.datadoghq.com/tracing/other_telemetry/rum/?tab=browserrum)
- Updated datadog package [SDK upgrade from v5 to v6](https://docs.datadoghq.com/real_user_monitoring/guide/browser-sdk-upgrade/#from-v5-to-v6)
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
