### PR TITLE
PEAR-2418: Fix for Projects page, table, primary site and disease type overlap

### DIFF
--- a/packages/portal-proto/src/components/SubrowPrimarySiteDiseaseType/SubrowPrimarySiteDiseaseType.tsx
+++ b/packages/portal-proto/src/components/SubrowPrimarySiteDiseaseType/SubrowPrimarySiteDiseaseType.tsx
@@ -38,7 +38,10 @@ function SubrowPrimarySiteDiseaseType<T>({
         <div className="columns-4 font-content text-sm">
           {values.map((value) => (
             <div className="flex items-center" key={value}>
-              <CircleIcon size="0.65em" className="text-primary shrink-0" />
+              <CircleIcon
+                size="0.65em"
+                className="text-primary shrink-0 self-start mt-1.5"
+              />
               <p className="pl-2">{value}</p>
             </div>
           ))}

--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -383,7 +383,10 @@ function VerticalTable<TData>({
                     )}
                   >
                     {/* 2nd row is a custom 1 cell row */}
-                    <td colSpan={row.getVisibleCells().length}>
+                    <td
+                      colSpan={row.getVisibleCells().length}
+                      className="relative"
+                    >
                       {/* Need to pass in the SubRow component to render here */}
                       {renderSubComponent({ row, clickedColumnId })}
                     </td>

--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -381,6 +381,7 @@ function VerticalTable<TData>({
                       /\W/g,
                       "_",
                     )}
+                    className="border border-base-lighter"
                   >
                     {/* 2nd row is a custom 1 cell row */}
                     <td


### PR DESCRIPTION
## Description
Realized that the subrow `td` doesn't have `relative` positioning so that children conforms to it.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
