### PR TITLE
PEAR-2302+2475: Remove extra `totalCounts` call + Number of cases missing from homepage

### DIFF
--- a/packages/core/src/features/summary/totalCountsSlice.ts
+++ b/packages/core/src/features/summary/totalCountsSlice.ts
@@ -55,8 +55,18 @@ const CountsGraphQLQuery = `
   }
 }`;
 
+export interface TotalCounts {
+  readonly caseCounts: number;
+  readonly fileCounts: number;
+  readonly genesCounts: number;
+  readonly mutationCounts: number;
+  readonly projectsCounts: number;
+  readonly primarySiteCounts: number;
+  readonly annotationCounts: number;
+}
+
 export interface TotalCountsState {
-  readonly counts: Record<string, number>;
+  readonly counts: TotalCounts;
   readonly status: DataStatus;
   readonly error?: string;
   readonly requestId?: string;
@@ -130,7 +140,7 @@ export const totalCountsReducer = slice.reducer;
 
 export const selectTotalCountsData = (
   state: CoreState,
-): CoreDataSelectorResponse<Record<string, number>> => {
+): CoreDataSelectorResponse<TotalCounts> => {
   return {
     data: state.summary.counts,
     status: state.summary.status,
@@ -138,12 +148,12 @@ export const selectTotalCountsData = (
   };
 };
 
-export const selectTotalCounts = (state: CoreState): Record<string, number> =>
+export const selectTotalCounts = (state: CoreState): TotalCounts =>
   state.summary.counts;
 
 export const selectTotalCountsByName = (
   state: CoreState,
-  name: string,
+  name: keyof TotalCounts,
 ): number => {
   const counts = state.summary.counts;
   return counts[name];

--- a/packages/portal-proto/src/features/facets/hooks.ts
+++ b/packages/portal-proto/src/features/facets/hooks.ts
@@ -32,6 +32,7 @@ import {
   CoreState,
   selectCohortBuilderConfig,
   selectFacetDefinition,
+  TotalCounts,
 } from "@gff/core";
 import isEqual from "lodash/isEqual";
 import { getFacetInfo } from "@/features/cohortBuilder/utils";
@@ -366,7 +367,10 @@ export const useTotalCounts = ({
   );
 };
 
-export const FacetDocTypeToCountsIndexMap: Record<GQLDocType, string> = {
+export const FacetDocTypeToCountsIndexMap: Record<
+  GQLDocType,
+  keyof TotalCounts
+> = {
   cases: "caseCounts",
   files: "fileCounts",
   genes: "genesCounts",

--- a/packages/portal-proto/src/features/homepage/HorizontalSummaryTotalsPanel.tsx
+++ b/packages/portal-proto/src/features/homepage/HorizontalSummaryTotalsPanel.tsx
@@ -1,5 +1,5 @@
 import { SummaryStatsItem } from "@/features/homepage/SummaryStatsItem";
-import { useTotalCounts, useVersionInfoDetails } from "@gff/core";
+import { TotalCounts, useVersionInfoDetails } from "@gff/core";
 import { AnchorLink } from "@/components/AnchorLink";
 import ProjectsIcon from "public/user-flow/icons/summary/projects.svg";
 import PrimarySitesIcon from "public/user-flow/icons/summary/primary-sites.svg";
@@ -8,10 +8,13 @@ import FilesIcon from "public/user-flow/icons/summary/files.svg";
 import GenesIcon from "public/user-flow/icons/summary/genes.svg";
 import MutationsIcon from "public/user-flow/icons/summary/gene-mutation.svg";
 
-const HorizontalSummaryTotalsPanel = (): JSX.Element => {
+const HorizontalSummaryTotalsPanel = ({
+  countsInfo,
+}: {
+  countsInfo: TotalCounts;
+}): JSX.Element => {
   const { data: versionInfo, isSuccess: isVersionInfoSuccess } =
     useVersionInfoDetails();
-  const { data: countsInfo } = useTotalCounts();
   const IconFormatted = ({
     Icon,
     label,

--- a/packages/portal-proto/src/features/homepage/index.tsx
+++ b/packages/portal-proto/src/features/homepage/index.tsx
@@ -44,7 +44,7 @@ const Homepage = (): JSX.Element => {
           >
             Explore Our Cancer Datasets
           </Link>
-          <HorizontalSummaryTotalsPanel />
+          <HorizontalSummaryTotalsPanel countsInfo={countsInfo} />
         </div>
 
         <div
@@ -61,7 +61,7 @@ const Homepage = (): JSX.Element => {
         body={
           <>
             High-quality datasets spanning{" "}
-            {countsInfo?.caseCount?.toLocaleString()} cases from cancer genomic
+            {countsInfo?.caseCounts?.toLocaleString()} cases from cancer genomic
             studies such as{" "}
             <strong className="italic font-bold">
               The Cancer Genomic Atlas (TCGA), Human Cancer Models Initiative


### PR DESCRIPTION
## Description
I removed 1 extra call. 
It would be bit complex to lower it down to just 1 call given the current implementation.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
