### PR TITLE
Jira sv 2633

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6170,9 +6170,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.135.3-1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.135.3-1.tgz",
-      "integrity": "sha512-awY+Y/DfzYNledR96AJwoTlxDQ9RXBeEyMUAsS9cm2DJWoy37eWwBzUnzsXXDLUoihMDsIDScYGUwXfEJB4CCw==",
+      "version": "2.137.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.137.1.tgz",
+      "integrity": "sha512-sEJ8gVTac4/3eGsHlgFEPLa7wcajCVp3W8air1ow9pdwD33Ead1pLW9dofBeX7z0STcGelveCidpmr9Y7MNb0Q==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28375,7 +28375,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.135.3-1",
+        "@sjcrh/proteinpaint-client": "2.137.1",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.135.3-1",
+    "@sjcrh/proteinpaint-client": "2.137.1",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState, useEffect, FC } from "react";
+import { useRef, useCallback, useState, FC } from "react";
 import { useDeepCompareEffect } from "use-deep-compare";
 import { bindProteinPaint } from "@sjcrh/proteinpaint-client";
 import { useIsDemoApp } from "@/hooks/useIsDemoApp";
@@ -60,7 +60,7 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
     : buildCohortGqlOperator(currentCohort);
   const userDetails = useFetchUserDetailsQuery();
   const prevData = useRef<any>();
-  const abortCtrl = useRef<any>();
+  const toolApp = useRef<any>();
   const coreDispatch = useCoreDispatch();
   const [showSaveCohortModal, setShowSaveCohortModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -94,20 +94,6 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
     },
     [createSet],
   );
-
-  useEffect(() => {
-    return () => {
-      console.log(98, window.location.href);
-      if (window.location.href.includes("OncoMatrix")) return;
-      console.log(
-        100,
-        "MatrixWrapper abortCtrl.current.abort()",
-        abortCtrl.current,
-      );
-      abortCtrl.current?.abort(); //(`${props.chartType} was closed/hidden`)
-      console.log(102, "abortCtrl.current?.signal", abortCtrl.current?.signal);
-    };
-  }, []);
 
   // a set for the new cohort is created, now show the save cohort modal
   useDeepCompareEffect(() => {
@@ -192,12 +178,10 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
         (data || prevData.current) && !isEqual(prevData.current, data);
       if (hasUpdates) prevData.current = data;
       const rootElem = divRef.current as HTMLElement;
-      abortCtrl.current = new AbortController();
-      const abortSignal = abortCtrl.current.signal;
 
       let updateArgs;
       if (hasUpdates) {
-        updateArgs = { filter0: data.filter0, abortSignal };
+        updateArgs = { filter0: data.filter0 };
         if (lastGeneSetRequestId != genesRequestId) {
           setLastGeneSetRequestId(genesRequestId);
           updateArgs.genes = geneDetailData.hits.map((h) => ({
@@ -221,7 +205,6 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
         hide_dsHandles: true,
         filter0: data.filter0,
       });
-      initArgs.opts.app.abortSignal = abortSignal;
 
       // bindProteinPaint() handles rapid update requests/race condition,
       // so no need to include debouncing and promise code in this wrapper
@@ -236,7 +219,22 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
           // in case of race condition
           return prevData.current != data;
         },
-      });
+      })
+        .then?.((_app) => {
+          toolApp.current = _app;
+        })
+        .catch((e) => {
+          throw e;
+        });
+
+      return () => {
+        if (!toolApp.current) return;
+        const toolName =
+          props.chartType == "hierCluster" ? "GeneExpression" : "OncoMatrix";
+        if (window.location.href.includes(toolName)) return;
+        // cancel unnecessary network requests when this tool app is hidden
+        toolApp.current.triggerAbort();
+      };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [filter0, userDetails, geneDetailData],
@@ -305,7 +303,6 @@ interface MatrixArgOpts {
 
 interface MatrixArgOptsApp {
   callbacks?: RxComponentCallbacks;
-  abortSignal?: AbortSignal;
 }
 
 interface MatrixArgOptsMatrix {

--- a/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
@@ -221,7 +221,8 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
         },
       })
         .then?.((_app) => {
-          // set the app, could be OncoMatrix or Gene Expression Clustering depending on props.chartType
+          // set the app, could be OncoMatrix or Gene Expression Clustering,
+          // depending on props.chartType
           toolApp.current = _app;
         })
         .catch((e) => {

--- a/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState, FC } from "react";
+import { useRef, useCallback, useState, useEffect, FC } from "react";
 import { useDeepCompareEffect } from "use-deep-compare";
 import { bindProteinPaint } from "@sjcrh/proteinpaint-client";
 import { useIsDemoApp } from "@/hooks/useIsDemoApp";
@@ -60,6 +60,7 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
     : buildCohortGqlOperator(currentCohort);
   const userDetails = useFetchUserDetailsQuery();
   const prevData = useRef<any>();
+  const abortCtrl = useRef<any>();
   const coreDispatch = useCoreDispatch();
   const [showSaveCohortModal, setShowSaveCohortModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -93,6 +94,20 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
     },
     [createSet],
   );
+
+  useEffect(() => {
+    return () => {
+      console.log(98, window.location.href);
+      if (window.location.href.includes("OncoMatrix")) return;
+      console.log(
+        100,
+        "MatrixWrapper abortCtrl.current.abort()",
+        abortCtrl.current,
+      );
+      abortCtrl.current?.abort(); //(`${props.chartType} was closed/hidden`)
+      console.log(102, "abortCtrl.current?.signal", abortCtrl.current?.signal);
+    };
+  }, []);
 
   // a set for the new cohort is created, now show the save cohort modal
   useDeepCompareEffect(() => {
@@ -177,10 +192,12 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
         (data || prevData.current) && !isEqual(prevData.current, data);
       if (hasUpdates) prevData.current = data;
       const rootElem = divRef.current as HTMLElement;
+      abortCtrl.current = new AbortController();
+      const abortSignal = abortCtrl.current.signal;
 
       let updateArgs;
       if (hasUpdates) {
-        updateArgs = { filter0: data.filter0 };
+        updateArgs = { filter0: data.filter0, abortSignal };
         if (lastGeneSetRequestId != genesRequestId) {
           setLastGeneSetRequestId(genesRequestId);
           updateArgs.genes = geneDetailData.hits.map((h) => ({
@@ -204,6 +221,7 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
         hide_dsHandles: true,
         filter0: data.filter0,
       });
+      initArgs.opts.app.abortSignal = abortSignal;
 
       // bindProteinPaint() handles rapid update requests/race condition,
       // so no need to include debouncing and promise code in this wrapper
@@ -287,6 +305,7 @@ interface MatrixArgOpts {
 
 interface MatrixArgOptsApp {
   callbacks?: RxComponentCallbacks;
+  abortSignal?: AbortSignal;
 }
 
 interface MatrixArgOptsMatrix {

--- a/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
@@ -221,6 +221,7 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
         },
       })
         .then?.((_app) => {
+          // set the app, could be OncoMatrix or Gene Expression Clustering depending on props.chartType
           toolApp.current = _app;
         })
         .catch((e) => {


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2633. 

Tested with:
- open the analysis tools page and the Network tab in Chrome dev tools
- click on the OncoMatrix or Gene Expression card to open the tool
- while the topMutatedGenes or topVariablyExpressedGenes is still loading, close the tool to return to the analysis page: the network request should get canceled and allow other GFF tools to load quickly
- click on the tool card again, but wait after the top genes request is done, but close the tool while the /termdb?for=matrix or /termdb/cluster is still loading: the network request should get canceled and allow other GFF tools to load quickly


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
