### PR TITLE
update proteinpaint-client to 2.146.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6170,9 +6170,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.138.3-7",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.138.3-7.tgz",
-      "integrity": "sha512-zB4Pt+Eaq0xvqtRLhBvARmGoZfamW3khenhjNlToE2etrqBNXri+xWPK+LWWT/8DWVb7oRef0dpqUZUZO/185A==",
+      "version": "2.146.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.146.2.tgz",
+      "integrity": "sha512-Wwfx0aHoAbvY4dyaDw86ODXVaoGKgFgApv6aoXx776V5LyakKtpX5ii1oUd9Mi3y+p/ltpCQ1hqb6AQAjrff+g==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28375,7 +28375,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.138.3-7",
+        "@sjcrh/proteinpaint-client": "2.146.2",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.138.3-7",
+    "@sjcrh/proteinpaint-client": "2.146.2",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes:
- Gene Exp Clustering: if the genes are not clustered, after users reorder the genes, the submit button should not be disabled
- revised correlation plot features


## Checklist

- [x] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
