### PR TITLE
PEAR-2512: In some graph dropdown, multiple download loading spinners cannot appear 

### DIFF
--- a/packages/portal-components/src/analysis/context.ts
+++ b/packages/portal-components/src/analysis/context.ts
@@ -29,18 +29,18 @@ export const DashboardDownloadContext = createContext<{
   dispatch: Dispatch<{ type: "add" | "remove"; payload: ChartDownloadInfo[] }>;
 }>({ state: [], dispatch: () => {} });
 
-export type DownloadType = "svg" | "png" | null;
+export type DownloadType = "svg" | "png";
 
 export const DownloadProgressContext = createContext<{
-  downloadInProgress: boolean;
-  downloadType: DownloadType;
-  setDownloadProgress:
-    | ((inProgress: boolean, type: DownloadType) => void)
-    | undefined;
+  activeDownloads: Set<DownloadType>;
+  startDownload: (type: DownloadType) => void;
+  finishDownload: (type: DownloadType) => void;
+  isDownloading: (type: DownloadType) => boolean;
 }>({
-  downloadInProgress: false,
-  downloadType: null,
-  setDownloadProgress: undefined,
+  activeDownloads: new Set(),
+  startDownload: () => {},
+  finishDownload: () => {},
+  isDownloading: () => false,
 });
 
 // Selection screen context

--- a/packages/portal-components/src/hooks/index.ts
+++ b/packages/portal-components/src/hooks/index.ts
@@ -1,0 +1,3 @@
+import { useDownloadProgress } from "./useDownloadProgress";
+
+export { useDownloadProgress };

--- a/packages/portal-components/src/hooks/useDownloadProgress.ts
+++ b/packages/portal-components/src/hooks/useDownloadProgress.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from "react";
+import { DownloadType } from "src/analysis";
+
+/**
+ * A custom hook to manage the download progress state for a component.
+ * Each component that calls this hook will get its own independent state.
+ * This is used for DownloadProgressContext
+ */
+export const useDownloadProgress = () => {
+  const [activeDownloads, setActiveDownloads] = useState<Set<DownloadType>>(
+    new Set(),
+  );
+
+  const startDownload = useCallback((type: DownloadType) => {
+    setActiveDownloads((prev) => new Set(prev).add(type));
+  }, []);
+
+  const finishDownload = useCallback((type: DownloadType) => {
+    setActiveDownloads((prev) => {
+      const next = new Set(prev);
+      next.delete(type);
+      return next;
+    });
+  }, []);
+
+  const isDownloading = useCallback(
+    (type: DownloadType) => activeDownloads.has(type),
+    [activeDownloads],
+  );
+
+  return { activeDownloads, startDownload, finishDownload, isDownloading };
+};

--- a/packages/portal-components/src/index.ts
+++ b/packages/portal-components/src/index.ts
@@ -6,3 +6,4 @@ export * from "./cohort";
 export * from "./modals";
 export * from "./facets";
 export * from "./common";
+export * from "./hooks";

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { Card, ActionIcon, Tooltip, SegmentedControlItem } from "@mantine/core";
 import { useScrollIntoView } from "@mantine/hooks";
 import {
@@ -10,8 +10,8 @@ import {
 } from "@gff/core";
 import {
   DownloadProgressContext,
-  DownloadType,
   SegmentedControl,
+  useDownloadProgress,
 } from "@gff/portal-components";
 import ContinuousData from "./ContinuousData";
 import CategoricalData from "./CategoricalData";
@@ -47,9 +47,9 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
   cohortFilters,
   yTotal,
 }: CDaveCardProps) => {
+  const { activeDownloads, startDownload, finishDownload, isDownloading } =
+    useDownloadProgress();
   const [chartType, setChartType] = useState<ChartTypes>("histogram");
-  const [downloadInProgress, setDownloadInProgress] = useState(false);
-  const [downloadType, setDownloadType] = useState<DownloadType>(null);
   const { scrollIntoView, targetRef } = useScrollIntoView<HTMLDivElement>();
   const displayDataDimension = useDataDimension(field);
   const facet = useCoreSelector((state) =>
@@ -76,14 +76,6 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
     // this should only happen on initial component mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const setDownloadProgress = useCallback(
-    (inProgress: boolean, type: DownloadType) => {
-      setDownloadInProgress(inProgress);
-      setDownloadType(type);
-    },
-    [],
-  );
 
   const chartButtons: SegmentedControlItem[] = [
     {
@@ -156,14 +148,14 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
                 DATA_DIMENSIONS?.[field]?.unit,
               ]}
               onChange={(d) => setDataDimension(d as DataDimension)}
-              disabled={noData || downloadInProgress}
+              disabled={noData || activeDownloads.size > 0}
               padding={1}
             />
           )}
           <SegmentedControl
             data={chartButtons}
             onChange={(c) => setChartType(c as ChartTypes)}
-            disabled={noData || downloadInProgress}
+            disabled={noData || activeDownloads.size > 0}
             padding={1}
           />
           <Tooltip
@@ -188,7 +180,12 @@ const CDaveCard: React.FC<CDaveCardProps> = ({
         </div>
       </div>
       <DownloadProgressContext.Provider
-        value={{ downloadInProgress, downloadType, setDownloadProgress }}
+        value={{
+          activeDownloads,
+          startDownload,
+          finishDownload,
+          isDownloading,
+        }}
       >
         {noData ? (
           <div className="h-[32.1rem] w-full flex flex-col justify-start">

--- a/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/CDaveHistogram.tsx
@@ -52,7 +52,7 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
 }: HistogramProps) => {
   const [displayPercent, setDisplayPercent] = useState(false);
   const downloadChartRef = useRef<HTMLElement>();
-  const { downloadInProgress, downloadType, setDownloadProgress } = useContext(
+  const { startDownload, finishDownload, isDownloading } = useContext(
     DownloadProgressContext,
   );
 
@@ -137,21 +137,19 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
               <Menu.Dropdown data-testid="dropdown-menu-options">
                 <Tooltip
                   label={ADDITIONAL_DOWNLOAD_MESSAGE}
-                  disabled={!downloadInProgress || downloadType !== "svg"}
+                  disabled={!isDownloading("svg")}
                 >
                   <Menu.Item
                     onClick={async () => {
-                      setDownloadProgress(true, "svg");
+                      startDownload("svg");
                       await handleDownloadSVG(
                         downloadChartRef,
                         `${downloadFileName}.svg`,
                       );
-                      setDownloadProgress(false, null);
+                      finishDownload("svg");
                     }}
                     leftSection={
-                      downloadInProgress && downloadType === "svg" ? (
-                        <Loader size={16} />
-                      ) : null
+                      isDownloading("svg") ? <Loader size={16} /> : null
                     }
                   >
                     SVG
@@ -160,21 +158,19 @@ const CDaveHistogram: React.FC<HistogramProps> = ({
 
                 <Tooltip
                   label={ADDITIONAL_DOWNLOAD_MESSAGE}
-                  disabled={!downloadInProgress || downloadType !== "png"}
+                  disabled={!isDownloading("png")}
                 >
                   <Menu.Item
                     onClick={async () => {
-                      setDownloadProgress(true, "png");
+                      startDownload("png");
                       await handleDownloadPNG(
                         downloadChartRef,
                         `${downloadFileName}.png`,
                       );
-                      setDownloadProgress(false, null);
+                      finishDownload("png");
                     }}
                     leftSection={
-                      downloadInProgress && downloadType === "png" ? (
-                        <Loader size={16} />
-                      ) : null
+                      isDownloading("png") ? <Loader size={16} /> : null
                     }
                   >
                     PNG

--- a/packages/portal-proto/src/features/cDave/DownloadAllButton.tsx
+++ b/packages/portal-proto/src/features/cDave/DownloadAllButton.tsx
@@ -1,28 +1,53 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { handleDownloadPNG, handleDownloadSVG } from "@/features/charts/utils";
 import { DropdownWithIcon } from "@/components/DropdownWithIcon/DropdownWithIcon";
 import { DashboardDownloadContext } from "@gff/portal-components";
 import { DownloadIcon } from "@/utils/icons";
+import { Loader } from "@mantine/core";
+import { ADDITIONAL_DOWNLOAD_MESSAGE } from "@/utils/constants";
 
 const DownloadAllButton: React.FC = () => {
   const { state } = useContext(DashboardDownloadContext);
-  const downloadAllSvg = () => {
-    state.map((download) => {
-      handleDownloadSVG(download.chartRef, `${download.filename}.svg`);
-    });
+  const [isAllSvgDownloading, setIsAllSvgDownloading] = useState(false);
+  const [isAllPngDownloading, setIsAllPngDownloading] = useState(false);
+
+  const downloadAllSvg = async () => {
+    setIsAllSvgDownloading(true);
+    await Promise.all(
+      state.map((download) =>
+        handleDownloadSVG(download.chartRef, `${download.filename}.svg`),
+      ),
+    );
+    setIsAllSvgDownloading(false);
   };
 
-  const downloadAllPng = () => {
-    state.map((download) => {
-      handleDownloadPNG(download.chartRef, `${download.filename}.png`);
-    });
+  const downloadAllPng = async () => {
+    setIsAllPngDownloading(true);
+    await Promise.all(
+      state.map((download) =>
+        handleDownloadPNG(download.chartRef, `${download.filename}.png`),
+      ),
+    );
+    setIsAllPngDownloading(false);
   };
 
   return (
     <DropdownWithIcon
       dropdownElements={[
-        { title: "SVG", onClick: downloadAllSvg },
-        { title: "PNG", onClick: downloadAllPng },
+        {
+          title: "SVG",
+          onClick: downloadAllSvg,
+          icon: isAllSvgDownloading ? <Loader size="xs" /> : null,
+          isLoading: isAllSvgDownloading,
+          loadingTooltip: ADDITIONAL_DOWNLOAD_MESSAGE,
+        },
+        {
+          title: "PNG",
+          onClick: downloadAllPng,
+          icon: isAllPngDownloading ? <Loader size="xs" /> : null,
+          isLoading: isAllPngDownloading,
+          loadingTooltip: ADDITIONAL_DOWNLOAD_MESSAGE,
+        },
       ]}
       TargetButtonChildren={"Download All Images"}
       LeftSection={<DownloadIcon aria-hidden="true" size="1rem" />}

--- a/packages/portal-proto/src/features/charts/SurvivalPlot/SurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/charts/SurvivalPlot/SurvivalPlot.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-} from "react";
+import React, { useContext, useState, useEffect, useRef } from "react";
 import { Box, Menu, Tooltip, Loader, ActionIcon } from "@mantine/core";
 import isNumber from "lodash/isNumber";
 import { useMouse } from "@mantine/hooks";
@@ -13,7 +7,7 @@ import { SummaryModalContext } from "src/utils/contexts";
 import {
   DashboardDownloadContext,
   DownloadProgressContext,
-  DownloadType,
+  useDownloadProgress,
 } from "@gff/portal-components";
 import OffscreenWrapper from "@/components/OffscreenWrapper";
 import {
@@ -208,7 +202,7 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
     return () => dispatch({ type: "remove", payload: charts });
   }, [dispatch, downloadFileName]);
 
-  const { downloadInProgress, downloadType, setDownloadProgress } = useContext(
+  const { startDownload, finishDownload, isDownloading } = useContext(
     DownloadProgressContext,
   );
 
@@ -244,35 +238,27 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
             <Menu.Dropdown data-testid="dropdown-menu-options">
               <Menu.Item
                 onClick={async () => {
-                  setDownloadProgress(true, "svg");
+                  startDownload("svg");
                   await handleDownloadSVG(
                     downloadRef,
                     `${downloadFileName}.svg`,
                   );
-                  setDownloadProgress(false, null);
+                  finishDownload("svg");
                 }}
-                leftSection={
-                  downloadInProgress && downloadType === "svg" ? (
-                    <Loader size={16} />
-                  ) : null
-                }
+                leftSection={isDownloading("svg") ? <Loader size={16} /> : null}
               >
                 SVG
               </Menu.Item>
               <Menu.Item
                 onClick={async () => {
-                  setDownloadProgress(true, "png");
+                  startDownload("png");
                   await handleDownloadPNG(
                     downloadRef,
                     `${downloadFileName}.png`,
                   );
-                  setDownloadProgress(false, null);
+                  finishDownload("png");
                 }}
-                leftSection={
-                  downloadInProgress && downloadType === "png" ? (
-                    <Loader size={16} />
-                  ) : null
-                }
+                leftSection={isDownloading("png") ? <Loader size={16} /> : null}
               >
                 PNG
               </Menu.Item>
@@ -378,20 +364,12 @@ const ExternalDownloadStateSurvivalPlot: React.FC<SurvivalPlotProps> = ({
 };
 
 const SurvivalPlot = (props: SurvivalPlotProps) => {
-  const [downloadInProgress, setDownloadInProgress] = useState(false);
-  const [downloadType, setDownloadType] = useState<DownloadType>(null);
-
-  const setDownloadProgress = useCallback(
-    (inProgress: boolean, type: DownloadType) => {
-      setDownloadInProgress(inProgress);
-      setDownloadType(type);
-    },
-    [],
-  );
+  const { activeDownloads, startDownload, finishDownload, isDownloading } =
+    useDownloadProgress();
 
   return (
     <DownloadProgressContext.Provider
-      value={{ downloadInProgress, downloadType, setDownloadProgress }}
+      value={{ activeDownloads, startDownload, finishDownload, isDownloading }}
     >
       <ExternalDownloadStateSurvivalPlot {...props} />
     </DownloadProgressContext.Provider>


### PR DESCRIPTION
## Description
Updated context so that it keeps track up multiple download type at once.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
