### PR TITLE
PEAR-2527 - Include Legend in the CNV Histogram Download on the Gene Summary Page

### DIFF
--- a/packages/portal-proto/src/features/charts/BarChart.tsx
+++ b/packages/portal-proto/src/features/charts/BarChart.tsx
@@ -20,6 +20,7 @@ export interface BarChartData {
  * @property marginTop - margin top of the chart
  * @property padding - padding of the chart
  * @property orientation - orientation of the chart
+ * @property showLegend - whether to display the chart legend
  * @property onClickHandler - callback function for click event
  * @property stacked - whether the chart is stacked
  * @property divId - id of the div
@@ -35,6 +36,7 @@ interface BarChartProps {
   readonly marginTop?: number;
   readonly padding?: number;
   readonly orientation?: string;
+  readonly showLegend?: boolean;
   readonly onClickHandler?: (mouseEvent: PlotMouseEvent) => void;
   readonly stacked?: boolean;
   readonly divId: string;
@@ -48,6 +50,7 @@ interface BarChartProps {
  * @param marginTop - margin top of the chart
  * @param padding - padding of the chart
  * @param orientation   - orientation of the chart
+ * @param showLegend - whether to display the chart legend
  * @param onClickHandler  - callback function for click event
  * @param divId - id of the div
  * @param stacked - whether the chart is stacked
@@ -59,6 +62,7 @@ const BarChart: React.FC<BarChartProps> = ({
   marginTop = 30,
   padding = 4,
   orientation = "v",
+  showLegend = false,
   onClickHandler,
   divId,
   stacked = false,
@@ -73,7 +77,8 @@ const BarChart: React.FC<BarChartProps> = ({
     hovertemplate: dataset.hovertemplate,
     customdata: dataset.customdata,
     textposition: "none",
-    showlegend: false,
+    name: dataset?.name,
+    showlegend: showLegend,
     uniformtext_mode: "hide",
     title: null,
     marker: {
@@ -93,7 +98,7 @@ const BarChart: React.FC<BarChartProps> = ({
       ? {
           xaxis: {
             // (bars are vertical)
-            automargin: false,
+            automargin: true,
             ticks: "outside",
             tickwidth: 2,
             tickcolor: "#aaaaaa",
@@ -132,11 +137,15 @@ const BarChart: React.FC<BarChartProps> = ({
             duration: 500,
             easing: "cubic-in-out",
           },
+          legend: {
+            orientation: "h",
+            y: -0.3,
+          },
         }
       : {
           // (bars are horizontal)
           yaxis: {
-            automargin: false,
+            automargin: true,
             ticks: "outside",
             tickwidth: 2,
             tickcolor: "#aaaaaa",

--- a/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
+++ b/packages/portal-proto/src/features/charts/CNVPlot/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "./utils";
 import { PlotMouseEvent } from "plotly.js";
 import { useDeepCompareMemo } from "use-deep-compare";
+import OffscreenWrapper from "@/components/OffscreenWrapper";
 
 const BarChart = dynamic(() => import("../BarChart"), {
   ssr: false,
@@ -126,13 +127,19 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
     }
     return Object.entries(cnvMapping)
       .filter(([key]) => checkboxState[key])
-      .map(([_, { prop, color }]) => ({
-        y: top20ChartData.map((d) => (d[prop] / d.total) * 100),
-        x: top20ChartData.map((d) => d.project),
-        hovertemplate,
-        customdata: top20ChartData.map((d) => [d[prop], d.total]),
-        marker: { color },
-      }));
+      .map(([key, { prop, color }]) => {
+        const checkboxConfig = checkboxConfigs.find(
+          (config) => config.key === key,
+        );
+        return {
+          y: top20ChartData.map((d) => (d[prop] / d.total) * 100),
+          x: top20ChartData.map((d) => d.project),
+          hovertemplate,
+          customdata: top20ChartData.map((d) => [d[prop], d.total]),
+          marker: { color },
+          name: checkboxConfig.label,
+        };
+      });
   }, [checkboxState, top20ChartData, anyCheckboxSelected]);
 
   const chartConfig = useDeepCompareMemo(
@@ -198,7 +205,7 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
           <ChartTitleBar
             title={title}
             filename="cancer-distribution-bar-chart"
-            divId={chartDivId}
+            divId={`${chartDivId}-download`}
             jsonData={jsonData}
           />
         </div>
@@ -212,6 +219,16 @@ const CNVPlot: React.FC<CNVPlotProps> = ({
             onAfterPlot={handleOnAfterPlot}
           />
         </div>
+        <OffscreenWrapper>
+          <BarChart
+            divId={`${chartDivId}-download`}
+            data={chartConfig}
+            height={height}
+            stacked
+            onAfterPlot={handleOnAfterPlot}
+            showLegend={anyCheckboxSelected}
+          />
+        </OffscreenWrapper>
 
         {/* checkboxes */}
         <div className="justify-center text-sm flex flex-wrap gap-4">


### PR DESCRIPTION
## Description
\+ PEAR-2528 - Gene Summary Page: downloaded CNV histogram image cuts off last project ID

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="700" height="500" alt="cancer-distribution-bar-chart (1)" src="https://github.com/user-attachments/assets/1c42486d-ea30-4ea0-a6ab-090a748a603a" />
