### PR TITLE
update proteipaint-client to 2.154.0 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6170,9 +6170,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.146.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.146.3.tgz",
-      "integrity": "sha512-xKb2QHX00pkoDvk20zNRWinqw1m5st4CKQh2amHG9bZfDUojMODL91aukuFlcZnsp/kDbwJrB7XPQg3n9N50sQ==",
+      "version": "2.154.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.154.0.tgz",
+      "integrity": "sha512-UmiMZtFlT1Lm75dnbE2glqqQEjZbZltEne6vi2i9hOvXUsoic6g8VuS1jQ2ii4o6L/GHlCNI8NfHh41ykV68CA==",
       "license": "SEE LICENSE IN ./LICENSE",
       "peerDependencies": {
         "postcss": "^8.4.41",
@@ -28375,7 +28375,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.146.3",
+        "@sjcrh/proteinpaint-client": "2.154.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.146.3",
+    "@sjcrh/proteinpaint-client": "2.154.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
@@ -30,10 +30,10 @@ export const demoFilter = Object.freeze({
 
 export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
   const isDemoMode = useIsDemoApp();
-  // const demoFilter = {
-  //   op: "in",
-  //   content: { field: "cases.disease_type", value: ["Gliomas"] },
-  // };
+  const demoFilter = {
+    op: "in",
+    content: { field: "cases.disease_type", value: ["Gliomas"] },
+  };
   const currentCohort = useCoreSelector(selectCurrentCohortFilters);
   const filter0 = isDemoMode
     ? cloneDeep(demoFilter)
@@ -53,7 +53,12 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
     "error.gdcCorrelation": hideLoadingOverlay,
     "postRender.gdcCorrelation": hideLoadingOverlay,
   };
-  const initArgs = getCorrelationTrack(props, matrixCallbacks, appCallbacks);
+  const initArgs = getCorrelationTrack(
+    props,
+    matrixCallbacks,
+    appCallbacks,
+    isDemoMode,
+  );
 
   useDeepCompareEffect(
     () => {
@@ -115,7 +120,12 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
   const divRef = useRef();
   return (
     <div className="relative">
-      {isDemoMode && <DemoText>Demo showing cases with Gliomas.</DemoText>}
+      {isDemoMode && (
+        <DemoText>
+          Demo showing correlation of survival with IDH1 mutations/CNV, for
+          cases with Gliomas.
+        </DemoText>
+      )}
       <div
         ref={divRef}
         className="sjpp-wrapper-root-div"
@@ -153,6 +163,7 @@ function getCorrelationTrack(
   props: PpProps,
   matrixCallbacks?: RxComponentCallbacks,
   appCallbacks?: RxComponentCallbacks,
+  isDemoMode?: boolean,
 ): CorrelationArg {
   const arg: CorrelationArg = {
     // host in gdc is just a relative url path,
@@ -165,6 +176,29 @@ function getCorrelationTrack(
       },
     },
   };
+
+  if (isDemoMode) {
+    arg.state = {
+      plots: [
+        {
+          chartType: "survival",
+          term: {
+            term: {
+              id: "Overall Survival",
+              type: "survival",
+            },
+          },
+          term2: {
+            term: {
+              type: "geneVariant",
+              id: "IDH1",
+              name: "IDH1",
+            },
+          },
+        },
+      ],
+    };
+  }
 
   return arg;
 }

--- a/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
@@ -23,8 +23,8 @@ interface PpProps {
 export const demoFilter = Object.freeze({
   op: "in",
   content: Object.freeze({
-    field: "cases.disease_type",
-    value: Object.freeze(["Gliomas"]),
+    field: "cases.project.project_id",
+    value: Object.freeze(["TCGA-LGG"]),
   }),
 });
 
@@ -32,7 +32,7 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
   const isDemoMode = useIsDemoApp();
   const demoFilter = {
     op: "in",
-    content: { field: "cases.disease_type", value: ["Gliomas"] },
+    content: { field: "cases.project.project_id", value: ["TCGA-LGG"] },
   };
   const currentCohort = useCoreSelector(selectCurrentCohortFilters);
   const filter0 = isDemoMode
@@ -122,8 +122,8 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
     <div className="relative">
       {isDemoMode && (
         <DemoText>
-          Demo showing correlation of survival with IDH1 mutations/CNV, for
-          cases with Gliomas.
+          Demo showing correlation of survival with IDH1 Mutation/CNV (TCGA-LGG
+          project).
         </DemoText>
       )}
       <div

--- a/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
+++ b/packages/portal-proto/src/features/user-flow/workflow/registeredApps.tsx
@@ -307,7 +307,7 @@ export const REGISTERED_APPS: AppRegistrationEntry[] = [
       />
     ),
     tags: ["variantAnalysis"],
-    //hasDemo: true,
+    hasDemo: true,
     description:
       "Visualize correlations between clinical and genomic variables.",
     id: "Correlation",


### PR DESCRIPTION
## Description

Addressed in correlation tool feedback:
- Correlation Plot tool displays undefined or null object error: gene expression variable vs MIR16-1 gene will now show `No visible violin plot data to render`
- Demo button is missing (Major) - Suggest adding an example for Mutation vs. CNV (Major): implemented using survival plot with gliomas cohort vs IDH1 Mutations/CNV
- 95% CI – Suggest spelling out (95% Confidence Interval) (Medium)
- Mouseover missing for 95% CI, Censored Symbol, and Default color. Also, Mouseover fades too fast to be able to read, especially for Survival Time Visualized. (Medium)
- Changing the Time Factor and Unit works, but it may result in incorrect information (e.g., Change Time Unit to Days. Days are displayed but the values are still years). (Major)
- BEAT-AML Cohort Correlation Plot Tool Errors
- New feature: geneset UI now has an input for custom name of geneset. Will default to comma-joined list of genes. In case of msigdb geneset, will default to msigdb geneset name.
- Violin plot now reports when no data is available to plot.

Known Issue
- Sandbox title shows `IDH1 SNV/Indel vs undefined` for the demo, should say `vs Survival`
- other feedback items that we're still working on (race condition when switching cohorts in the correlation plot, etc)

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
