### PR TITLE
PEAR-2541 adds genecards link to gene summary page

### DIFF
--- a/packages/portal-proto/src/features/GeneSummary/GeneSummary.tsx
+++ b/packages/portal-proto/src/features/GeneSummary/GeneSummary.tsx
@@ -162,6 +162,7 @@ const GeneView = ({
       external_db_ids: { entrez_gene, uniprotkb_swissprot, hgnc, omim_gene },
       gene_id,
       civic,
+      symbol,
     } = data;
 
     const externalLinksObj = {
@@ -171,6 +172,7 @@ const GeneView = ({
       omim_gene,
       ensembl: gene_id,
       civic,
+      genecards: symbol,
     };
 
     let externalReferenceLinksobj = {};

--- a/packages/portal-proto/src/utils/index.ts
+++ b/packages/portal-proto/src/utils/index.ts
@@ -78,6 +78,7 @@ export const externalLinkNames = {
   hgnc: "HGNC",
   omim_gene: "OMIM",
   uniprotkb_swissprot: "UniProtKB Swiss-Prot",
+  genecards: "GeneCards",
 };
 
 export const geneExternalLinkNames = {
@@ -86,6 +87,7 @@ export const geneExternalLinkNames = {
   hgnc: "HGNC",
   omim_gene: "OMIM",
   uniprotkb_swissprot: "UniProtKB Swiss-Prot",
+  genecards: "GeneCards",
 };
 
 export const externalLinks = {
@@ -100,6 +102,8 @@ export const externalLinks = {
   ensembl: (id: string): string =>
     `http://nov2020.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${id}`,
   entrez_gene: (id: string): string => `http://www.ncbi.nlm.nih.gov/gene/${id}`,
+  genecards: (id: string): string =>
+    `https://www.genecards.org/cgi-bin/carddisp.pl?gene=${id}`,
   hgnc: (id: string): string =>
     `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${id}`,
   omim_gene: (id: string): string => `http://omim.org/entry/${id}`,

--- a/packages/portal-proto/src/utils/index.ts
+++ b/packages/portal-proto/src/utils/index.ts
@@ -81,15 +81,6 @@ export const externalLinkNames = {
   genecards: "GeneCards",
 };
 
-export const geneExternalLinkNames = {
-  civic: "CIViC",
-  entrez_gene: "NCBI Gene",
-  hgnc: "HGNC",
-  omim_gene: "OMIM",
-  uniprotkb_swissprot: "UniProtKB Swiss-Prot",
-  genecards: "GeneCards",
-};
-
 export const externalLinks = {
   civic: (id: string): string => `https://civicdb.org/links/gene/${id}`,
   civicMutaton: (id: string): string =>


### PR DESCRIPTION
## Description
- adds the GeneCards external link to the gene summary page
- removes dupe `geneExternalLinkNames`

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="1290" height="513" alt="Screenshot 2025-11-07 at 4 11 04 PM" src="https://github.com/user-attachments/assets/497c7d83-2dbc-4068-9660-3de912d7741c" />

