### PR TITLE
PEAR-2531 - Make body plot graph more robust

### DIFF
--- a/packages/core/src/features/bodyplot/bodyplotSlice.ts
+++ b/packages/core/src/features/bodyplot/bodyplotSlice.ts
@@ -24,15 +24,21 @@ export const processData = (casesBuckets: Bucket[]): BodyplotData[] => {
 
   casesBuckets.map((bucket) => {
     const primarySiteGroups = HUMAN_BODY_SITES_MAP[bucket.key];
-    for (const primarySiteGroup of primarySiteGroups) {
-      if (groupedResults[primarySiteGroup]) {
-        groupedResults[primarySiteGroup] = [
-          ...(groupedResults[primarySiteGroup] || []),
-          bucket,
-        ];
-      } else {
-        groupedResults[primarySiteGroup] = [bucket];
+    if (primarySiteGroups) {
+      for (const primarySiteGroup of primarySiteGroups) {
+        if (groupedResults[primarySiteGroup]) {
+          groupedResults[primarySiteGroup] = [
+            ...(groupedResults[primarySiteGroup] || []),
+            bucket,
+          ];
+        } else {
+          groupedResults[primarySiteGroup] = [bucket];
+        }
       }
+    } else {
+      console.warn(
+        `Received primary site '${bucket.key}' but it is missing from from Body Plot mappings`,
+      );
     }
   });
 

--- a/packages/core/src/features/bodyplot/constants.ts
+++ b/packages/core/src/features/bodyplot/constants.ts
@@ -353,7 +353,7 @@ export const HUMAN_BODY_MAPPINGS: BodyPlotData = {
     ],
   },
   "Not Reported": {
-    byPrimarySite: ["Not Reported", "unknown"],
+    byPrimarySite: ["Not Reported", "unknown", "Not Applicable"],
     byTissueOrOrganOfOrigin: ["Not Reported", "unknown"],
   },
   "Other and Ill-defined Sites": {

--- a/packages/core/src/features/bodyplot/tests/bodyplotSlice.unit.test.ts
+++ b/packages/core/src/features/bodyplot/tests/bodyplotSlice.unit.test.ts
@@ -15,6 +15,19 @@ describe("test processData for Bodyplot response", () => {
   });
 });
 
+describe("test that unknown primary site gives a warning", () => {
+  test("warning", () => {
+    const warnSpy = jest.spyOn(console, "warn");
+    const unmappedPrimarySiteData = [{ key: "not mapped", doc_count: 100 }];
+
+    const results = processData(unmappedPrimarySiteData);
+    expect(results).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Received primary site 'not mapped' but it is missing from from Body Plot mappings",
+    );
+  });
+});
+
 describe("test indexing human body mapper", () => {
   test("indexing human body mapper byPrimarySite", () => {
     expect(HUMAN_BODY_MAPPER("byPrimarySite")).toEqual({
@@ -53,6 +66,7 @@ describe("test indexing human body mapper", () => {
       "nasal cavity and middle ear": ["Head and Neck"],
       nasopharynx: ["Head and Neck"],
       "not reported": ["Not Reported"],
+      "not applicable": ["Not Reported"],
       oropharynx: ["Head and Neck"],
       "other and ill-defined digestive organs": ["Other and Ill-defined Sites"],
       "other and ill-defined sites": ["Other and Ill-defined Sites"],


### PR DESCRIPTION
## Description
The easiest way to test this is probably to remove an entry from `byPrimarySites` from the mappings here: https://github.com/NCI-GDC/gdc-frontend-framework/blob/develop/packages/core/src/features/bodyplot/constants.ts#L41

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
