### PR TITLE
PEAR-2540 - Add Government URLs to the list of sites that the GDC Data Portal is allowed to talk to

### DIFF
--- a/packages/portal-proto/next.config.js
+++ b/packages/portal-proto/next.config.js
@@ -9,6 +9,8 @@ const connectSrc = [
   "https://browser-intake-datadoghq.com",
   "https://api.gdc.cancer.gov",
   "https://www.google-analytics.com",
+  "https://dap.digitalgov.gov",
+  "https://metrics.cancer.gov",
   // Uncomment to use mock server for testing
   //"https://localhost:3100",
 ];


### PR DESCRIPTION
## Description
I wasn't actually seeing an error for `https://metrics.cancer.gov` when I was testing, that may have been coming from the government shutdown banner? But .... it'll be there for next time.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
