### PR TITLE
PEAR-2545 - Cohort Bar: Cannot see full name of cohort when it's long

### DIFF
--- a/packages/portal-components/src/cohort/CustomCohortSelectItem.tsx
+++ b/packages/portal-components/src/cohort/CustomCohortSelectItem.tsx
@@ -69,7 +69,9 @@ export const CustomCohortSelectItem = ({
   return (
     <div {...others} className="w-full">
       <span className="flex justify-between gap-2 items-center">
-        <span className="basis-11/12 break-all whitespace-pre">{label}</span>
+        <span className="basis-11/12 break-all whitespace-pre-wrap">
+          {label}
+        </span>
         <div className="basis-1/12 text-right leading-0">
           {!isSavedUnchanged && <UnsavedIcon label={cohortStatusMessage} />}
         </div>


### PR DESCRIPTION
## Description
Caused by https://gdc-ctds.atlassian.net/browse/PEAR-2406. There's conveniently a css property that both wraps and preserves whitespace though. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
