### PR TITLE
Fix the undefined label in correlation plot survival title

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
@@ -183,10 +183,7 @@ function getCorrelationTrack(
         {
           chartType: "survival",
           term: {
-            term: {
-              id: "Overall Survival",
-              type: "survival",
-            },
+            id: "Overall Survival",
           },
           term2: {
             term: {


### PR DESCRIPTION
## Description

This PR branch fixes https://gdc-ctds.atlassian.net/browse/SV-2692, by not over-specifying the survival term in the correlation plot demo which previously prevented the filling-in of additional term attributes like `term.name`.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
