### PR TITLE
update proteinpaint-client to 2.166.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6169,14 +6169,10 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.162.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.162.0.tgz",
-      "integrity": "sha512-yRJWWYzdRuv5PC8kVl8H87fVFXe1cFxHacvRYlwfOphQ4ehbkJDCqf25mEUkR3rkXDkGQOlUsXif7OyzNoLpGw==",
-      "license": "SEE LICENSE IN ./LICENSE",
-      "peerDependencies": {
-        "postcss": "^8.4.41",
-        "postcss-import": "^14.1.0"
-      }
+      "version": "2.166.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.166.0.tgz",
+      "integrity": "sha512-ZIsWO51uXaI2TF5UdZ3Xxz7cSxj3v4uW/2cRvbvyZURMFNswSzi/8Fj2Ze41zf19DK25PZdv1hXq1hElcjSTuQ==",
+      "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -21865,8 +21861,8 @@
     },
     "node_modules/postcss-import": {
       "version": "14.1.0",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -22861,6 +22857,7 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -22868,6 +22865,7 @@
     },
     "node_modules/read-cache/node_modules/pify": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28378,7 +28376,7 @@
         "@mantine/notifications": "7.17.4",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.162.0",
+        "@sjcrh/proteinpaint-client": "2.166.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "7.17.4",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.162.0",
+    "@sjcrh/proteinpaint-client": "2.166.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Features/Fixes:
- [x] [SV-2672](https://gdc-ctds.atlassian.net/browse/SV-2672) - fixed by https://github.com/stjude/proteinpaint/pull/3963
- [x] [SV-2678](https://gdc-ctds.atlassian.net/browse/SV-2678) - fixed by https://github.com/stjude/proteinpaint/pull/3964
- [x] [FEAT-900](https://gdc-ctds.atlassian.net/browse/FEAT-900) - fixed by https://github.com/stjude/proteinpaint/pull/3988
- [x] [SV-2674](https://gdc-ctds.atlassian.net/browse/SV-2674) - fixed by https://github.com/stjude/proteinpaint/pull/4003
- [x] [SV-2692](https://gdc-ctds.atlassian.net/browse/SV-2692) - fixed by https://github.com/NCI-GDC/gdc-frontend-framework/pull/1638
- [x] [SV-2668](https://gdc-ctds.atlassian.net/browse/SV-2668) - fixed by https://github.com/stjude/proteinpaint/pull/4005
- [x] [SV-2682](https://gdc-ctds.atlassian.net/browse/SV-2682) - fixed by https://github.com/stjude/proteinpaint/pull/4010
- [x] [SV-2551](https://gdc-ctds.atlassian.net/issues/?filter=12796&selectedIssue=SV-2551) - fixed by https://github.com/stjude/proteinpaint/pull/4015
- [x] [SV-385](https://gdc-ctds.atlassian.net/issues/?filter=12796&selectedIssue=SV-2385) - partially fixed by https://github.com/stjude/proteinpaint/pull/4015

Also
- [x] [SV-2671](https://gdc-ctds.atlassian.net/browse/SV-2671) - issue was caused by the use of `Specimen type` and `Tissue type` terms, which are now excluded (see https://github.com/stjude/proteinpaint/pull/3967)
- [x] [SV-2684](https://gdc-ctds.atlassian.net/browse/SV-2684) - same explanation as above

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
