### PR TITLE
PEAR-2412 standardizes cDAVE category names

### DIFF
--- a/packages/portal-proto/src/features/cDave/Controls/Controls.unit.test.tsx
+++ b/packages/portal-proto/src/features/cDave/Controls/Controls.unit.test.tsx
@@ -39,7 +39,7 @@ describe("<Controls />", () => {
     );
 
     expect(queryByRole("button", { name: "Demographic" })).toBeInTheDocument();
-    expect(queryByRole("button", { name: "Exposures" })).toBeInTheDocument();
+    expect(queryByRole("button", { name: "Exposure" })).toBeInTheDocument();
     expect(queryByRole("button", { name: "Treatment" })).toBeInTheDocument();
     expect(queryByRole("button", { name: "Diagnosis" })).toBeInTheDocument();
     expect(

--- a/packages/portal-proto/src/features/cDave/constants.ts
+++ b/packages/portal-proto/src/features/cDave/constants.ts
@@ -225,7 +225,7 @@ export const TABS = {
   demographic: "Demographic",
   diagnoses: "Diagnosis",
   treatments: "Treatment",
-  exposures: "Exposures",
+  exposures: "Exposure",
   other_clinical_attributes: "Other Clinical Attribute",
 };
 


### PR DESCRIPTION
## Description
- adjusts all cDAVE category names to singular ("Exposures" => "Exposure)

## Checklist

- [N/A] Added proper unit tests
- [N/A] Left proper TODO messages for any remaining tasks
- [N/A] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
<img width="365" height="359" alt="Screenshot 2025-12-24 at 11 49 27 AM" src="https://github.com/user-attachments/assets/bca9f8e1-611b-4343-8897-485d5f6c0308" />
