### PR TITLE
ensure enough space to show entire chart menus in the Correlation Plot tool

### DIFF
--- a/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
@@ -129,6 +129,7 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
       <div
         ref={divRef}
         className="sjpp-wrapper-root-div"
+        style={{ minHeight: "440px" }}
         //userDetails={userDetails}
       />
 


### PR DESCRIPTION
## Description

This PR fixes the issue where new chart menus may be cutoff/overlapped by the page footer. 
Fixes https://gdc-ctds.atlassian.net/browse/SV-2702.

@craigrbarnes Please note we want this fix for the release/feature freeze. Please let me know if I should change the PR's target base branch (instead of `develop`).

Without fix:
<img width="1299" height="458" alt="Screenshot 2026-01-06 at 11 15 30 AM" src="https://github.com/user-attachments/assets/e11b45bc-0029-4110-bb85-29b43a661a33" />

With fix:
<img width="1388" height="596" alt="Screenshot 2026-01-06 at 11 29 17 AM" src="https://github.com/user-attachments/assets/20a3af2c-c4d3-4642-866b-476f4496d0fe" />

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
