### PR TITLE
update the proteinpaint-client version to 2.170.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7734,9 +7734,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.1.tgz",
-      "integrity": "sha512-kUZCXf8quBUoI0v8dey9AWGL/PJ8SH3cvhmA7naab4z+Ju5bAiZti6tkijAZXg5lf8s0V9/G4D0lMe9TmTfUmg==",
+      "version": "2.170.2",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.2.tgz",
+      "integrity": "sha512-T6nFsNnBY5PonciCnceBw4DSPcQ5pHvF09NxZkwL4bHRB3w3KxGzENd70FyMTpRUixer8GNfkVmLs9rMY0H0GQ==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -33044,7 +33044,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.1",
+        "@sjcrh/proteinpaint-client": "2.170.2",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.1",
+    "@sjcrh/proteinpaint-client": "2.170.2",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2708.

Correlation Plot:
- show loading and error messages when switching to barchart tab in correlation plot

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
