### PR TITLE
PEAR-2605 - "Apps" should be "GDC Apps" for the label of the Apps cube in the header

### DIFF
--- a/packages/portal-components/src/context.tsx
+++ b/packages/portal-components/src/context.tsx
@@ -4,6 +4,7 @@ import { MantineThemeOverride } from "@mantine/core";
 import { ImageComponentType, LinkComponentType } from "./types";
 
 interface AppContextType {
+  readonly appName?: string;
   readonly path?: string;
   readonly theme?: MantineThemeOverride;
   readonly Image: ImageComponentType;
@@ -11,6 +12,7 @@ interface AppContextType {
 }
 
 export const AppContext = createContext<AppContextType>({
+  appName: undefined,
   path: undefined,
   theme: undefined,
   // eslint-disable-next-line

--- a/packages/portal-components/src/layout/ExternalAppMenu.tsx
+++ b/packages/portal-components/src/layout/ExternalAppMenu.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import {
   MdOutlineApps as AppsIcon,
   MdArrowDropDown as ArrowDropDownIcon,
@@ -6,6 +6,7 @@ import {
 import { Menu, MenuItem } from "@mantine/core";
 import HeaderLink from "./Header/HeaderLink";
 import { HeaderLinkItem } from "./Header/types";
+import { AppContext } from "src/context";
 
 const appMenuClass = "hover:bg-primary-lightest p-0 m-0";
 
@@ -16,6 +17,8 @@ interface ExternalAppMenuProps {
 const ExternalAppMenu: React.FC<ExternalAppMenuProps> = ({
   externalAppLinks,
 }: ExternalAppMenuProps) => {
+  const { appName } = useContext(AppContext);
+
   return (
     <Menu
       width="450"
@@ -36,7 +39,7 @@ const ExternalAppMenu: React.FC<ExternalAppMenuProps> = ({
             className="text-primary-darkest"
             aria-hidden="true"
           />
-          <p className="font-heading">Apps</p>
+          <p className="font-heading">{appName ? `${appName} Apps` : "Apps"}</p>
           <ArrowDropDownIcon size="24px" className="-ml-1" aria-hidden="true" />
         </button>
       </Menu.Target>

--- a/packages/portal-proto/src/pages/_app.tsx
+++ b/packages/portal-proto/src/pages/_app.tsx
@@ -301,6 +301,7 @@ const PortalApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
             >
               <AppContext.Provider
                 value={{
+                  appName: "GDC",
                   Link: Link as LinkComponentType,
                   Image: Image as ImageComponentType,
                   path: router.pathname,


### PR DESCRIPTION
## Description

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
