### PR TITLE
PEAR-2613 - After unpinning the cohort bar, the pin icon disappears

### DIFF
--- a/packages/portal-proto/src/features/cohortBuilder/StickyControl.tsx
+++ b/packages/portal-proto/src/features/cohortBuilder/StickyControl.tsx
@@ -1,5 +1,5 @@
 import { StickyOffIcon, StickyOnIcon } from "@/utils/icons";
-import { Tooltip, Checkbox, CheckboxProps } from "@mantine/core";
+import { Tooltip, ActionIcon } from "@mantine/core";
 
 const StickyControl = ({
   handleIsSticky,
@@ -8,19 +8,6 @@ const StickyControl = ({
   handleIsSticky: (isSticky: boolean) => void;
   isSticky: boolean;
 }): JSX.Element => {
-  const CheckboxIcon: CheckboxProps["icon"] = ({
-    indeterminate,
-    className,
-  }: {
-    indeterminate: boolean;
-    className: string;
-  }) =>
-    indeterminate ? (
-      <StickyOffIcon size="24px" className={className} />
-    ) : (
-      <StickyOnIcon size="24px" className={className} />
-    );
-
   return (
     <Tooltip
       label={
@@ -31,19 +18,20 @@ const StickyControl = ({
       withArrow
       position="bottom"
     >
-      <Checkbox
+      <ActionIcon
         data-testid="button-pin-unpin-cohort-bar"
         classNames={{
-          input:
-            "bg-primary-darker rounded-md hover:bg-primary-darkest h-12 w-12 border-2 border-transparent hover:border-white focus:border-white cursor-pointer",
-          inner: "h-12 w-12 text-white",
+          root: "bg-primary-darker text-white rounded-md hover:bg-primary-darkest h-12 w-12 border-2 border-transparent hover:border-white focus:border-white cursor-pointer",
         }}
-        icon={CheckboxIcon}
         aria-label="Pin Cohort Bar"
-        checked={isSticky}
-        indeterminate={!isSticky}
-        onChange={() => handleIsSticky(!isSticky)}
-      />
+        onClick={() => handleIsSticky(!isSticky)}
+      >
+        {isSticky ? (
+          <StickyOnIcon size="24px" />
+        ) : (
+          <StickyOffIcon size="24px" />
+        )}
+      </ActionIcon>
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Description
The mantine 8 upgrade changed some of the implementation of checkboxes (see checkbox issues from this [PR](https://github.com/NCI-GDC/gdc-frontend-framework/pull/1639#issuecomment-3638930622)). I felt like this being a checkbox was a little strange anyways so I switched it to a button.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
