### PR TITLE
update proteinpaint-client to 2.170.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7734,9 +7734,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.3",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.3.tgz",
-      "integrity": "sha512-AGeYYZY0jf32Bzi+FNAnBdo7gW5GOX6Ukx1ROMAipLY1ppmIjgs0nKro5zlTmZG5ASFEnOGqhY3oJDmCKXgKzQ==",
+      "version": "2.170.5",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.5.tgz",
+      "integrity": "sha512-aQMXRfbyQKV/mkX2IisCzhk6PCvK4mIrw60vng/iM7Xrfoc15N94RvsX6EhhDhL5xym/052/d+jQK9aoQ5yF0Q==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -33044,7 +33044,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.3",
+        "@sjcrh/proteinpaint-client": "2.170.5",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.3",
+    "@sjcrh/proteinpaint-client": "2.170.5",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes:
- [SV-2715](https://gdc-ctds.atlassian.net/browse/SV-2715) only allow searching by gene, and not coordinate, for geneVariant term
- [SV-2716](https://gdc-ctds.atlassian.net/browse/SV-2716) fix the visibility of chart button menu when there is a footer div with overflow-y: 'clip'
- [SV-2717]()https://gdc-ctds.atlassian.net/browse/SV-2717 handle missing data for divideBy term in survival plot
- [SV-2718](https://gdc-ctds.atlassian.net/browse/SV-2718) disable the chart-specific download option in survival plot; remove all untagged html text in menu.clear(), previously only tagged children were removed
- [SV-2724](https://gdc-ctds.atlassian.net/browse/SV-2724): the Correlation Plot tool should display a message if the case caching is not yet done


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
