### PR TITLE
Qa 2558 update holmes py 2.18.0 round 3

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
@@ -36,7 +36,6 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |required_info                        |
     |-------------------------------------|
     |follow_ups.barretts_esophagus_goblet_cells_present     |
-    |follow_ups.dlco_ref_predictive_percent|
     |follow_ups.recist_targeted_regions_sum|
     |molecular_tests.biospecimen_volume   |
     |molecular_tests.test_analyte_type    |
@@ -232,7 +231,6 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |1305158400                           |
     |samples.biospecimen_anatomic_site    |
     |samples.initial_weight               |
-    |samples.oct_embedded                 |
     |samples.preservation_method          |
     |samples.time_between_clamping_and_freezing|
     |samples.tumor_code_id                |

--- a/holmes-py/specs/gdc_data_portal_v2/case_summary/validate_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/case_summary/validate_tables.spec
@@ -124,7 +124,6 @@ tags: gdc-data-portal-v2, case-summary, clinical-biospecimen-download, regressio
     |exposures.cigarettes_per_day           |
     |exposures.exposure_type                |
     |Tobacco                                |
-    |exposures.respirable_crystalline_silica_exposure |
     |exposures.tobacco_smoking_status       |
     |Current Reformed Smoker for > 15 yrs   |
     |diagnosis_id                           |
@@ -288,7 +287,6 @@ tags: gdc-data-portal-v2, case-summary, clinical-biospecimen-download, regressio
     |-------------------------------------------------|
     |follow_ups.cause_of_response                     |
     |follow_ups.barretts_esophagus_goblet_cells_present|
-    |follow_ups.hysterectomy_margins_involved         |
     |follow_ups.recist_targeted_regions_number        |
     |Lactate Dehydrogenase                            |
     |molecular_tests.molecular_analysis_method        |
@@ -571,7 +569,6 @@ tags: gdc-data-portal-v2, case-summary, clinical-biospecimen-download, regressio
     |analytes.experimental_protocol_type    |
     |analytes.spectrophotometer_method      |
     |mirVana (Allprep DNA) RNA              |
-    |analytes.analyte_type_id               |
     |slide_id                               |
     |88217dc9-06a0-4839-8269-85ce0798ef89   |
     |slides.percent_inflam_infiltration     |

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/clinical_properties.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/clinical_properties.spec
@@ -103,7 +103,7 @@ tags: gdc-data-portal-v2, clinical-data-analysis, regression
 * Check clinical properties
    |property                  |group    |
    |--------------------------|---------|
-   |Alcohol History           |Exposures|
+   |Alcohol History           |Exposure |
    |Alcohol Intensity         |         |
    |Tobacco Smoking Status    |         |
    |Alcohol Days Per Week     |         |

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/only_show_properties_with_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/only_show_properties_with_data.spec
@@ -10,7 +10,7 @@ tags: gdc-data-portal-v2, clinical-data-analysis, regression
 ## Create Cohort for Test
 * On GDC Data Portal V2 app
 * Navigate to "Cohort" from "Header" "section"
-* Create and save a cohort named "CC_Compare_1" with these filters
+* Create and save a cohort named "cdave_show_properties_with_data" with these filters
   |tab_name               |facet_name           |selection                      |
   |-----------------------|---------------------|-------------------------------|
   |Exposure               |Alcohol History      |unknown                        |

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec
@@ -136,7 +136,6 @@ tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecime
     |-------------------------------------|
     |cases.submitter_id                   |
     |follow_ups.evidence_of_recurrence_type|
-    |follow_ups.immunosuppressive_treatment_type|
     |follow_ups.progression_or_recurrence_type|
     |molecular_tests.gene_symbol          |
     |molecular_tests.submitter_id         |
@@ -155,7 +154,6 @@ tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecime
     |pathology_details.zone_of_origin_prostate|
     |exposures.age_at_last_exposure       |
     |exposures.parent_with_radiation_exposure|
-    |exposures.years_smoked               |
     |family_histories.relationship_age_at_diagnosis|
     |family_histories.relationship_primary_diagnosis|
     |family_histories.relative_with_cancer_history|

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_header.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_header.spec
@@ -113,7 +113,6 @@ tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecime
     |follow_ups.days_to_follow_up           |
     |follow_ups.evidence_of_recurrence_type |
     |follow_ups.submitter_id                |
-    |follow_ups.pregnancy_outcome           |
     |molecular_tests.laboratory_test        |
     |f7253ebc-424c-4506-a5f4-727c819d50fd   |
     |d185b62d-3811-43c1-8b50-0823e06646fa   |
@@ -128,7 +127,6 @@ tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecime
     |demographic.occupation_duration_years  |
     |family_histories.relationship_primary_diagnosis|
     |family_histories.relatives_with_cancer_history_count|
-    |demographic.weeks_gestation_at_birth   |
     |diagnoses.child_pugh_classification    |
     |diagnoses.first_symptom_longest_duration|
     |treatments.prescribed_dose_units       |

--- a/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
@@ -9,6 +9,7 @@ tags: gdc-data-portal-v2, regression, header, navigation
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app
+* Is text "GDC Apps" present on the page
 
 ## Validate Navigation Links - different tab
 * These links on the "Header" should take the user to correct page in a new tab

--- a/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
@@ -18,7 +18,7 @@ tags: gdc-data-portal-v2, regression, header, navigation
   |Obtaining Access to Controlled Data        |In order to obtain access to controlled data available in the  |
 
 ## Validate Apps Links
-* These Apps links should take the user to correct page in the same tab
+* These Apps links should take the user to correct page in new tab
   |button_text                                |text_on_expected_page                                          |
   |-------------------------------------------|---------------------------------------------------------------|
   |Website                                    |The GDC supports several cancer genome programs at the NCI     |

--- a/holmes-py/specs/gdc_data_portal_v2/project_summary/validate_header_options.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/project_summary/validate_header_options.spec
@@ -122,7 +122,6 @@ tags: gdc-data-portal-v2, regression, project-summary, clinical-biospecimen-down
     |follow_up_id                           |
     |0eb870af-e683-48ea-a3fb-b6bfcd99356d   |
     |follow_ups.progression_or_recurrence_anatomic_site|
-    |follow_ups.undescended_testis_corrected_laterality|
     |molecular_tests.blood_test_normal_range_upper|
     |molecular_tests.test_result            |
     |diagnoses.submitter_id                 |

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -67,7 +67,7 @@ class AnalysisCenterPage(BasePage):
 
     def get_analysis_tool_cases_count(self, tool_name):
         """Returns case count on given analysis tool"""
-        self.wait_for_loading_spinner_to_detatch()
+        self.wait_for_loading_spinners_to_detach()
         locator = AnalysisCenterLocators.TEXT_CASES_COUNT_ON_TOOL_CARD(tool_name)
         # If we get " " or " Cases" on return, that means the analysis card is still loading information. We wait until
         # it fully loads or 10 seconds elapses before returning text.

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/case_summary_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/case_summary_page.py
@@ -66,14 +66,17 @@ class CaseSummaryPage(BasePage):
 
     def click_clinical_table_download_button(self, download_type):
         """Clicks download TSV or JSON in Clinical table"""
-        download_button = CaseSummaryLocators.BUTTON_CLINICAL_TABLE_DOWNLOAD
-        self.click(download_button)
+        if not self.is_dropdown_option_text_present(download_type):
+            download_button = CaseSummaryLocators.BUTTON_CLINICAL_TABLE_DOWNLOAD
+            self.click(download_button)
         self.click_text_option_from_dropdown_menu(download_type)
+
 
     def click_biospecimen_table_download_button(self, download_type):
         """Clicks download TSV or JSON in Biospecimen table"""
-        download_button = CaseSummaryLocators.BUTTON_BIOSPECIMEN_TABLE_DOWNLOAD
-        self.click(download_button)
+        if not self.is_dropdown_option_text_present(download_type):
+            download_button = CaseSummaryLocators.BUTTON_BIOSPECIMEN_TABLE_DOWNLOAD
+            self.click(download_button)
         self.click_text_option_from_dropdown_menu(download_type)
 
     def search_in_files_table(self, text_to_send):

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/clinical_data_analysis.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/clinical_data_analysis.py
@@ -124,7 +124,7 @@ class ClinicalDataAnalysisPage(BasePage):
         self.click(ClinicalDataAnalysisLocators.GROUP_TABLE_PLUS_BUTTON("Demographic"))
         self.click(ClinicalDataAnalysisLocators.GROUP_TABLE_PLUS_BUTTON("Diagnosis"))
         self.click(ClinicalDataAnalysisLocators.GROUP_TABLE_PLUS_BUTTON("Treatment"))
-        self.click(ClinicalDataAnalysisLocators.GROUP_TABLE_PLUS_BUTTON("Exposures"))
+        self.click(ClinicalDataAnalysisLocators.GROUP_TABLE_PLUS_BUTTON("Exposure"))
         if self.is_visible(ClinicalDataAnalysisLocators.GROUP_TABLE_PLUS_BUTTON("Other Clinical Attribute")):
             self.click(ClinicalDataAnalysisLocators.GROUP_TABLE_PLUS_BUTTON("Other Clinical Attribute"))
 

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_case_view.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_case_view.py
@@ -66,13 +66,17 @@ class CohortCaseViewPage(BasePage):
         self.click(locator)
 
     def click_biospecimen_summary_view(self, dropdown_option):
-        locator = CohortCaseViewLocators.BUTTON_BIOSPECIMEN_SUMMARY_VIEW
-        self.click(locator)
+        # If the option text is not already present, click the dropdown menu button
+        if not self.is_dropdown_option_text_present(dropdown_option):
+            locator = CohortCaseViewLocators.BUTTON_BIOSPECIMEN_SUMMARY_VIEW
+            self.click(locator)
         self.click_text_option_from_dropdown_menu(dropdown_option)
 
     def click_clinical_summary_view(self, dropdown_option):
-        locator = CohortCaseViewLocators.BUTTON_CLINICAL_SUMMARY_VIEW
-        self.click(locator)
+        # If the option text is not already present, click the dropdown menu button
+        if not self.is_dropdown_option_text_present(dropdown_option):
+            locator = CohortCaseViewLocators.BUTTON_CLINICAL_SUMMARY_VIEW
+            self.click(locator)
         self.click_text_option_from_dropdown_menu(dropdown_option)
 
     def click_table_view_button(self, button_name):

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/header_section.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/header_section.py
@@ -26,8 +26,11 @@ class HeaderSection(BasePage):
     def __init__(self, driver: Page, url):
         self.driver = driver  # driver is PW page
 
-    def navigate_with_apps_menu(self, apps_link:str):
+    def click_apps_menu(self):
        self.click(HeaderSectionLocators.BUTTON_APPS_MENU)
+
+    def navigate_with_apps_menu(self, apps_link:str):
+       self.click_apps_menu()
        self.click_header_button(apps_link)
 
     def navigate_to_main_pages(self, button_name: str):

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/header_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/header_steps.py
@@ -1,3 +1,5 @@
+import time
+
 from getgauge.python import step, before_spec
 
 from ..app import GDCDataPortalV2App
@@ -7,6 +9,22 @@ from ....base.webdriver import WebDriver
 def start_app():
     global APP
     APP = GDCDataPortalV2App(WebDriver.page)
+
+@step("These Apps links should take the user to correct page in new tab <table>")
+def click_apps_link_new_tab(table):
+    """
+    Clicks open the Apps Menu in upper-right corner of header, and clicks on specified link in menu.
+    Then, checks for expected text on the new tab to indicate it opened correctly.
+    """
+    for k, v in enumerate(table):
+        APP.header_section.click_apps_menu()
+        new_tab = APP.shared.perform_action_handle_new_tab("Header", v[0])
+        is_text_visible = APP.shared.is_text_visible_on_new_tab(new_tab, v[1])
+        new_tab.close()
+        time.sleep(0.4)
+        assert (
+            is_text_visible
+        ), f"After click on '{v[0]}', the expected text '{v[1]}' in NOT present"
 
 @step("These Apps links should take the user to correct page in the same tab <table>")
 def click_apps_link_same_tab(table):

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -576,6 +576,11 @@ class BasePage:
         is_button_disabled = self.is_disabled(locator)
         return is_button_disabled
 
+    def is_dropdown_option_text_present(self, dropdown_text_option):
+        locator = GenericLocators.TEXT_DROPDOWN_MENU_OPTION(dropdown_text_option)
+        is_button_text_present = self.is_visible(locator)
+        return is_button_text_present
+
     def is_button_area_expanded(self, button_name):
         """Returns if the data-testid button is expanded"""
         button_name = self.normalize_button_identifier(button_name)


### PR DESCRIPTION
## Description
- Removed properties that are no longer available
- Updated download logic in cohort case table
- Updated expected links from gdc apps  

Test:
qa-yellow
`gauge run -p -n=3 specs/gdc_data_portal_v2/header/link_checking.spec specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec specs/gdc_data_portal_v2/cohort_case_view/table_view_header.spec`