### PR TITLE
update proteinpaint-client to 2.170.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7734,9 +7734,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.7",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.7.tgz",
-      "integrity": "sha512-ySf01fkLeKSqROAnMN3nGw2NEF4ENQdDxNxtVKsFmvuOFuvA+2UAmoV1LrYoY6lN7sN28kQQXXopPfFtR3Xndg==",
+      "version": "2.170.8",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.8.tgz",
+      "integrity": "sha512-3VrxjJm/RCxGl1y7Mfk6M+y7AiHaCaK9ki08LV33Cijw4pdriytQvSyXbgngNmPFhhO3+SLunjBAoVBd/LhFkA==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -33044,7 +33044,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.7",
+        "@sjcrh/proteinpaint-client": "2.170.8",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7734,9 +7734,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.6",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.6.tgz",
-      "integrity": "sha512-Pit5eg7sai9GBijjqhj/nSOBK0YXWCuJXDySnuvKrmsJsyM67FM7I1Z1W9QWSpSyy4vS03fbvoL3+UB1/oPKIg==",
+      "version": "2.170.7",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.7.tgz",
+      "integrity": "sha512-ySf01fkLeKSqROAnMN3nGw2NEF4ENQdDxNxtVKsFmvuOFuvA+2UAmoV1LrYoY6lN7sN28kQQXXopPfFtR3Xndg==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -33044,7 +33044,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.6",
+        "@sjcrh/proteinpaint-client": "2.170.7",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7734,9 +7734,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.5",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.5.tgz",
-      "integrity": "sha512-aQMXRfbyQKV/mkX2IisCzhk6PCvK4mIrw60vng/iM7Xrfoc15N94RvsX6EhhDhL5xym/052/d+jQK9aoQ5yF0Q==",
+      "version": "2.170.6",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.6.tgz",
+      "integrity": "sha512-Pit5eg7sai9GBijjqhj/nSOBK0YXWCuJXDySnuvKrmsJsyM67FM7I1Z1W9QWSpSyy4vS03fbvoL3+UB1/oPKIg==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -33044,7 +33044,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.5",
+        "@sjcrh/proteinpaint-client": "2.170.6",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.5",
+    "@sjcrh/proteinpaint-client": "2.170.6",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.7",
+    "@sjcrh/proteinpaint-client": "2.170.8",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.6",
+    "@sjcrh/proteinpaint-client": "2.170.7",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",

--- a/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
@@ -40,8 +40,8 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
     : buildCohortGqlOperator(currentCohort);
   const userDetails = useFetchUserDetailsQuery();
   const prevData = useRef<any>();
+  const toolApp = useRef<any>();
   const [isLoading, setIsLoading] = useState(false);
-
   const showLoadingOverlay = () => setIsLoading(true);
   const hideLoadingOverlay = () => setIsLoading(false);
   const matrixCallbacks: RxComponentCallbacks = {
@@ -111,10 +111,25 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
           // in case of race condition
           return prevData.current != data;
         },
-      });
+      })
+        .then?.((_app) => {
+          toolApp.current = _app;
+        })
+        .catch((e) => {
+          // the app should either work or display an error in a red banner within the tool container div,
+          // this uncaught-by-app error is unlikely to happen except for bundling issues that are not detected at build time
+          console.error(e);
+        });
+
+      return () => {
+        if (!toolApp.current || window.location.href.includes("Correlation"))
+          return;
+        // cancel unnecessary network requests when this tool app is hidden
+        toolApp.current.triggerAbort();
+      };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filter0, userDetails],
+    [filter0, userDetails?.data],
   );
 
   const divRef = useRef();

--- a/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/CorrelationWrapper.tsx
@@ -111,15 +111,9 @@ export const CorrelationWrapper: FC<PpProps> = (props: PpProps) => {
           // in case of race condition
           return prevData.current != data;
         },
-      })
-        .then?.((_app) => {
-          toolApp.current = _app;
-        })
-        .catch((e) => {
-          // the app should either work or display an error in a red banner within the tool container div,
-          // this uncaught-by-app error is unlikely to happen except for bundling issues that are not detected at build time
-          console.error(e);
-        });
+      }).then?.((_app) => {
+        toolApp.current = _app;
+      });
 
       return () => {
         if (!toolApp.current || window.location.href.includes("Correlation"))

--- a/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/MatrixWrapper.tsx
@@ -219,15 +219,9 @@ export const MatrixWrapper: FC<PpProps> = (props: PpProps) => {
           // in case of race condition
           return prevData.current != data;
         },
-      })
-        .then?.((_app) => {
-          toolApp.current = _app;
-        })
-        .catch((e) => {
-          // the app should either work or display an error in a red banner within the tool container div,
-          // this uncaught-by-app error is unlikely to happen except for bundling issues that are not detected at build time
-          console.error(e);
-        });
+      }).then?.((_app) => {
+        toolApp.current = _app;
+      });
 
       return () => {
         if (!toolApp.current) return;


### PR DESCRIPTION
## Description

Correlation Plot fixes:
- [SV-2725](https://gdc-ctds.atlassian.net/browse/SV-2725)
- [SV-2726](https://gdc-ctds.atlassian.net/browse/SV-2726)
- [SV-2727](https://gdc-ctds.atlassian.net/browse/SV-2727)
- [SV-2728](https://gdc-ctds.atlassian.net/browse/SV-2728)
- [SV-2731](https://gdc-ctds.atlassian.net/browse/SV-2731)
- [SV-2734](https://gdc-ctds.atlassian.net/browse/SV-2734)
- [SV-2735](https://gdc-ctds.atlassian.net/browse/SV-2735)
- [SV-2736](https://gdc-ctds.atlassian.net/browse/SV-2736)
- [SV-2737](https://gdc-ctds.atlassian.net/browse/SV-2737)

From PP release changelog:
- remove all untagged html text in menu.clear(), previously only tagged children were removed
- hide not-fully functional undo-redo buttons in plot and summary components
- make the case count limit message applicable to both correlation plot and gene exp clustering
- remove 5K case limit when doing hiercluster; avoid 1min /cases/ query on empty cohort filter
- lessen GDC API requests by generating sample filter only once in mayGetGeneVariantData()
- add max limit to number of genes supplied to geneVariant gene set
- prevent the submission of plot edits while input variable data is still being loaded
- downgrade missing plot config into a warning, instead of displaying an irrelevant error message
- remove add-to-filter option from correlation plot selection of rendered data; fix the returned GDC API  bins from getData()
- support correlation plot triggerAbort() to cancel stale network requests


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
