### PR TITLE
QA-2572 upgrade protobuf

### DIFF
--- a/holmes-py/docker-requirements.txt
+++ b/holmes-py/docker-requirements.txt
@@ -36,7 +36,7 @@ pre-commit==3.5.0
     # via -r requirements.in
     # This is the highest version of docker that can be compiled on Gitlab (as of 03/18/2024)
 
-protobuf==4.25.8
+protobuf==5.29.6
     # via
     #   -r requirements.in
     #   getgauge

--- a/holmes-py/requirements.in
+++ b/holmes-py/requirements.in
@@ -1,7 +1,7 @@
 pre-commit
 getgauge==0.4.11
 playwright==1.53.0
-protobuf==4.25.8
+protobuf==5.29.6
 grpcio==1.71.0
 pillow==10.3.0
 pyautogui==0.9.54

--- a/holmes-py/requirements.txt
+++ b/holmes-py/requirements.txt
@@ -38,7 +38,7 @@ playwright==1.53.0
     # via -r requirements.in
 pre-commit==3.5.0
     # via -r requirements.in
-protobuf==4.25.8
+protobuf==5.29.6
     # via
     #   -r requirements.in
     #   getgauge


### PR DESCRIPTION
## Description
- Upgraded protobuf to resolve vulnerability

I built holmes-py locally, and could successfully execute tests. I also confirmed it builds in gitlab as well.
https://gitlab.datacommons.io/nci-gdc/front-end/gdc-frontend-framework/-/jobs/978562
