### PR TITLE
update proteinpaint-client to 2.170.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7734,9 +7734,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.10",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.10.tgz",
-      "integrity": "sha512-Q5osInwtl3ukUv3WuKgRzyClPQd08WEdz3IEyOAy3s/v91/6SVgJ1+cgp5soj2F/AboVmx8Waf17xAxfZ7Kmmw==",
+      "version": "2.170.12",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.12.tgz",
+      "integrity": "sha512-buSjPmr4TvEt2752+mAlLRSKZQa56O935tQ7PtxLyWi2BGBll1ByElv4wtsjiVsloCY/TlNeGEIpw3se5Sra8w==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -33044,7 +33044,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.10",
+        "@sjcrh/proteinpaint-client": "2.170.12",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.10",
+    "@sjcrh/proteinpaint-client": "2.170.12",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes
- https://gdc-ctds.atlassian.net/browse/SV-2743
- https://gdc-ctds.atlassian.net/browse/SV-2744
- https://gdc-ctds.atlassian.net/browse/SV-2745
- https://gdc-ctds.atlassian.net/browse/SV-2746
- https://gdc-ctds.atlassian.net/browse/SV-2749

From the PP changelog:
Fixes
- prevent excessive memory usage during OncoMatrix data requests
- do not allow repeated term id for correlation plot primary, correlation, and divide-by variables
- hide survival terms in dictionary tree for violin and boxplot
- do not allow hiding all chart serieses/overlay, there should at least be one visible rendered data 
- fix bug to show gene symbol rather than tw.$id in gene exp hiercluster dendrogram click

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
