### PR TITLE
update proteinpaint-client to 2.170.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,7 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1925,6 +1926,7 @@
     "node_modules/@dnd-kit/core": {
       "version": "6.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1981,7 +1983,6 @@
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -1998,13 +1999,11 @@
     },
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
       "version": "1.9.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -2057,8 +2056,7 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
@@ -2067,7 +2065,6 @@
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -2078,8 +2075,7 @@
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -3567,6 +3563,7 @@
     "node_modules/@mantine/core": {
       "version": "8.3.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -3609,6 +3606,7 @@
     "node_modules/@mantine/hooks": {
       "version": "8.3.9",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -3810,6 +3808,7 @@
       "version": "4.0.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.22.1",
         "@babel/register": "7.21.0",
@@ -4661,6 +4660,7 @@
       "version": "4.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -5199,6 +5199,7 @@
     "node_modules/@reduxjs/toolkit": {
       "version": "2.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "immer": "^10.0.3",
         "redux": "^5.0.1",
@@ -5959,9 +5960,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.13",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.13.tgz",
-      "integrity": "sha512-K8p+UmA4xEUCnjP5G4VMRH2+zEh64EBraKNvviy3IdgyamyaUpCmGoe28yYdVYD+Svz/G3O22lbniTt8cEwBvw==",
+      "version": "2.170.15",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.15.tgz",
+      "integrity": "sha512-CvxujGDyz2RzR1rNwNp2PvfNKBaen/Gix+YM3VTQY7PlxLycl8MWY4c+FyMkzCVYP7YkYS9qcGXX2CxtWO6Nog==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -6164,6 +6165,7 @@
       "version": "8.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6313,6 +6315,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6356,7 +6359,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6374,7 +6376,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6392,7 +6393,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6410,7 +6410,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6428,7 +6427,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6462,7 +6460,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6480,7 +6477,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6498,7 +6494,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6516,7 +6511,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6534,7 +6528,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6827,13 +6820,13 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -7522,6 +7515,7 @@
       "version": "6.21.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7777,6 +7771,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7855,6 +7850,7 @@
       "version": "8.12.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8378,7 +8374,6 @@
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -8737,6 +8732,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10519,6 +10515,7 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10680,7 +10677,8 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.19",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -11682,6 +11680,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12600,8 +12599,7 @@
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -14375,6 +14373,7 @@
       "version": "8.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -15306,6 +15305,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16204,6 +16204,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -17599,7 +17600,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -19976,6 +19976,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nrwl/cli": "15.9.7",
         "@nrwl/tao": "15.9.7",
@@ -21166,6 +21167,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -21345,6 +21347,7 @@
       "version": "2.8.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -21854,6 +21857,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21876,6 +21880,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -21965,6 +21970,7 @@
     "node_modules/react-redux": {
       "version": "7.2.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -22468,7 +22474,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-persist": {
       "version": "6.0.0",
@@ -22879,6 +22886,7 @@
       "version": "4.53.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -23750,7 +23758,6 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24307,8 +24314,7 @@
     },
     "node_modules/stylis": {
       "version": "4.2.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -24567,6 +24573,7 @@
       "version": "3.4.19",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -25305,7 +25312,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "1.1.7",
@@ -25543,6 +25551,7 @@
       "version": "0.25.13",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
@@ -27014,6 +27023,7 @@
       "version": "2.3.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -27276,6 +27286,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27310,7 +27321,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.13",
+        "@sjcrh/proteinpaint-client": "2.170.15",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.13",
+    "@sjcrh/proteinpaint-client": "2.170.15",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2753 (reopened), by removing the option for a continuous divide-by variable.

## Checklist

- [x] Added proper unit tests
- [x] Left proper TODO messages for any remaining tasks
- [x] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
