### PR TITLE
update proteinpaint-client to 2.170.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5960,9 +5960,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.16",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.16.tgz",
-      "integrity": "sha512-OqtF6ZPp5pb4K/W9GgqHQJLRwtD7AR5ofq2RWYOX16fc0h2Ec2IEAK9EvUD1oyQEOy7usSiYjs4Zs3zzari+Kw==",
+      "version": "2.170.18",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.18.tgz",
+      "integrity": "sha512-xxYSHrEc4shUfQHiF4olaFlHcGj8WdPfG69NK45WgUaMxb8Xc1t3WKX912KnlQnMgJfES02/gkM1LVzPBQeKWA==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -27321,7 +27321,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.16",
+        "@sjcrh/proteinpaint-client": "2.170.18",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.16",
+    "@sjcrh/proteinpaint-client": "2.170.18",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes the reopened https://gdc-ctds.atlassian.net/browse/SV-2753 with
- https://github.com/stjude/proteinpaint/pull/4249
- https://github.com/stjude/proteinpaint/pull/4252


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
