### PR TITLE
update proteinpaint-client to 2.170.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,7 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1925,6 +1926,7 @@
     "node_modules/@dnd-kit/core": {
       "version": "6.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1981,7 +1983,6 @@
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -1998,13 +1999,11 @@
     },
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
       "version": "1.9.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -2057,8 +2056,7 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
@@ -2067,7 +2065,6 @@
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -2078,8 +2075,7 @@
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -3567,6 +3563,7 @@
     "node_modules/@mantine/core": {
       "version": "8.3.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -3609,6 +3606,7 @@
     "node_modules/@mantine/hooks": {
       "version": "8.3.9",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -3817,6 +3815,7 @@
       "version": "4.0.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.22.1",
         "@babel/register": "7.21.0",
@@ -4682,6 +4681,7 @@
       "version": "4.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -5220,6 +5220,7 @@
     "node_modules/@reduxjs/toolkit": {
       "version": "2.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "immer": "^10.0.3",
         "redux": "^5.0.1",
@@ -5980,9 +5981,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.170.18",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.18.tgz",
-      "integrity": "sha512-xxYSHrEc4shUfQHiF4olaFlHcGj8WdPfG69NK45WgUaMxb8Xc1t3WKX912KnlQnMgJfES02/gkM1LVzPBQeKWA==",
+      "version": "2.170.20",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.170.20.tgz",
+      "integrity": "sha512-lF3g4ofGcQ35mb0x3+d60fmrV7HqCLwrRKgX9l+InTmSECyVp44Vj71RV93YE3YoiArAU+B9iAcEntbwJAyyEA==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -6185,6 +6186,7 @@
       "version": "8.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6334,6 +6336,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6377,7 +6380,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6395,7 +6397,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6413,7 +6414,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6431,7 +6431,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6449,7 +6448,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6483,7 +6481,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6501,7 +6498,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6519,7 +6515,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6537,7 +6532,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6555,7 +6549,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6848,13 +6841,13 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -7543,6 +7536,7 @@
       "version": "6.21.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7798,6 +7792,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7876,6 +7871,7 @@
       "version": "8.12.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8399,7 +8395,6 @@
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -8758,6 +8753,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10540,6 +10536,7 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10701,7 +10698,8 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.19",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -11703,6 +11701,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12621,8 +12620,7 @@
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -14396,6 +14394,7 @@
       "version": "8.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -15327,6 +15326,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16225,6 +16225,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -17622,7 +17623,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -19999,6 +19999,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nrwl/cli": "15.9.7",
         "@nrwl/tao": "15.9.7",
@@ -21189,6 +21190,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -21368,6 +21370,7 @@
       "version": "2.8.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -21877,6 +21880,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21899,6 +21903,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -21988,6 +21993,7 @@
     "node_modules/react-redux": {
       "version": "7.2.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -22491,7 +22497,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-persist": {
       "version": "6.0.0",
@@ -22902,6 +22909,7 @@
       "version": "4.53.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -23773,7 +23781,6 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24330,8 +24337,7 @@
     },
     "node_modules/stylis": {
       "version": "4.2.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -24590,6 +24596,7 @@
       "version": "3.4.19",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -25328,7 +25335,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "1.1.7",
@@ -25566,6 +25574,7 @@
       "version": "0.25.13",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
@@ -27037,6 +27046,7 @@
       "version": "2.3.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -27299,6 +27309,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27333,7 +27344,7 @@
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^9.5.5",
         "@reduxjs/toolkit": "~2.5.0",
-        "@sjcrh/proteinpaint-client": "2.170.18",
+        "@sjcrh/proteinpaint-client": "2.170.20",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -31,7 +31,7 @@
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^9.5.5",
     "@reduxjs/toolkit": "~2.5.0",
-    "@sjcrh/proteinpaint-client": "2.170.18",
+    "@sjcrh/proteinpaint-client": "2.170.20",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2771 for Uhlenbeck release.

The fix was implemented in https://github.com/stjude/proteinpaint/pull/4260.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
