### PR TITLE
Qa 2591 update holmes py pipeline

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/analysis_center/navigation.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/analysis_center/navigation.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Test analysis center navigation
 Test-Case       : N/A
 
-tags: gdc-data-portal-v2, navigation, analysis-center, smoke-test, regression
+tags: gdc-data-portal-v2, navigation, analysis-center, smoke-test, regression, gitlab
 
 ## Navigate to the analysis center
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/analysis_center/tools_text.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/analysis_center/tools_text.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Analysis Tool and Core Tool text
 Test-Case       : PEAR-475
 
-tags: gdc-data-portal-v2, navigation, analysis-center, regression
+tags: gdc-data-portal-v2, navigation, analysis-center, regression, gitlab
 
 ## Tool Text Test Begin
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/annotation/browse_annotations_table.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/annotation/browse_annotations_table.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate Main Table in Browse Annotations
 Test-Case           : PEAR-2420
 
-tags: gdc-data-portal-v2, regression, annotations
+tags: gdc-data-portal-v2, regression, gitlab, annotations
 
 ## Navigate to Browse Annotations
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/annotation/downloads.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/annotation/downloads.spec
@@ -5,7 +5,7 @@ Owner		            : GDC QA
 Description		      : JSON and TSV Downloads
 Test-Case           : PEAR-2423
 
-tags: gdc-data-portal-v2, regression, annotations
+tags: gdc-data-portal-v2, regression, gitlab, annotations
 
 ## Navigate to Browse Annotations
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/annotation/filter_check.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/annotation/filter_check.spec
@@ -5,7 +5,7 @@ Owner		            : GDC QA
 Description		      : Test Filters in Browse Annotations
 Test-Case           : PEAR-2420
 
-tags: gdc-data-portal-v2, regression, annotations
+tags: gdc-data-portal-v2, regression, gitlab, annotations
 
 ## Navigate to Browse Annotations
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/annotation/summary_page_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/annotation/summary_page_tables.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate Tables in Annotation Summary Page
 Test-Case           : PEAR-2419
 
-tags: gdc-data-portal-v2, regression, annotations
+tags: gdc-data-portal-v2, regression, gitlab, annotations
 
 ## Navigate to Summary Page: 00e91bc8-2882-41b1-93de-938f71259e91
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Download Associated Data Dropdown Options
 Test-Case       : PEAR-2246
 
-tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
+tags: gdc-data-portal-v2, regression, gitlab, cart, clinical-biospecimen-download
 
 ## Add Files to Cart
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_cart.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_cart.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Manifest and Download Cart
 Test-Case       : PEAR-2246
 
-tags: gdc-data-portal-v2, regression, cart
+tags: gdc-data-portal-v2, regression, gitlab, cart
 
 
 ## Remove Any Files From Cart

--- a/holmes-py/specs/gdc_data_portal_v2/cart/miscellaneous_scenarios.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/miscellaneous_scenarios.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Instructions Description and Empty Cart Page
 Test-Case           : PEAR-2245
 
-tags: gdc-data-portal-v2, regression, cart
+tags: gdc-data-portal-v2, regression, gitlab, cart
 
 ## Add Files to Cart
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cart/validate_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/validate_tables.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Validate Authorization Level, Count by Projects, and Cart Item Tables
 Test-Case       : PEAR-2244
 
-tags: gdc-data-portal-v2, regression, cart
+tags: gdc-data-portal-v2, regression, gitlab, cart
 
 ## Add Files to Cart
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/case_summary/cart_file_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/case_summary/cart_file_download.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Add and Remove from cart, download file
 Test-Case       : N/A
 
-tags: gdc-data-portal-v2, case-summary, cart, file-download, regression
+tags: gdc-data-portal-v2, case-summary, cart, file-download, regression, gitlab
 
 ## Case Summary Page - Navigate to a case summary page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/case_summary/save_edit_mutation_set.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/case_summary/save_edit_mutation_set.spec
@@ -5,7 +5,7 @@ Owner		            : GDC QA
 Description		      : Most Frequent Somatic Mutations Table - Save/Edit Mutation Set
 Test-Case           : PEAR-464
 
-tags: gdc-data-portal-v2, regression, case-summary, mutations
+tags: gdc-data-portal-v2, regression, gitlab, case-summary, mutations
 
 ## Navigate to Case Summary Page: 3ea880f4-7a78-4cb7-bfe4-54b3c30a812e
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/case_summary/validate_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/case_summary/validate_tables.spec
@@ -439,7 +439,6 @@ tags: gdc-data-portal-v2, case-summary, clinical-biospecimen-download, regressio
     |Tumor Descriptor                       |
     |Specimen Type                          |
     |Preservation Method                    |
-    |Tumor Code ID                          |
     |Shortest Dimension                     |
     |Intermediate Dimension                 |
     |Longest Dimension                      |

--- a/holmes-py/specs/gdc_data_portal_v2/case_summary/validate_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/case_summary/validate_tables.spec
@@ -5,7 +5,7 @@ Owner		            : GDC QA
 Description		      : Validate All Tables and Sections in Case Summary Page
 Test-Case           : PEAR-2139, PEAR-464
 
-tags: gdc-data-portal-v2, case-summary, clinical-biospecimen-download, regression
+tags: gdc-data-portal-v2, case-summary, clinical-biospecimen-download, regression, gitlab
 
 ## Navigate to Case Summary Page: TCGA-13-0920
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/clinical_properties.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/clinical_properties.spec
@@ -4,7 +4,7 @@ Version			: 1.1
 Owner		      : GDC QA
 Description		: Test clinical data properties section
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Navigate to Clinical Data Analysis
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/customize_bin_categorical.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/customize_bin_categorical.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description     : cDAVE customize bin categorical values
 Test-Case       : PEAR-606
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Navigate to Clinical Data Analysis
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/customize_bin_continuous.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/customize_bin_continuous.spec
@@ -5,7 +5,7 @@ Owner		         : GDC QA
 Description       : cDAVE continuous bin continuous values
 Test-Case         : PEAR-610
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Navigate to Clinical Data Analysis
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/demo_mode.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/demo_mode.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description     : cDAVE Demo Mode
 Test-Case       : PEAR-603
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Navigate to Clinical Data Analysis Demo
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/only_show_properties_with_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/only_show_properties_with_data.spec
@@ -5,7 +5,7 @@ Owner		      : GDC QA
 Description		: Validate behavior of the Only Show Properties With Data button
 Test-Case     : PEAR-2529
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Create Cohort for Test
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/rule_check_bin_categorical.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/rule_check_bin_categorical.spec
@@ -5,7 +5,7 @@ Owner		         : GDC QA
 Description       : cDAVE Negative Rule Checking for Categorical Bin
 Test-Case         : PEAR-1584
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression, negative-test, negative-custom-bin-test
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab, negative-test, negative-custom-bin-test
 
 ## Navigate to Clinical Data Analysis
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/rule_check_bin_continuous.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/rule_check_bin_continuous.spec
@@ -5,7 +5,7 @@ Owner		         : GDC QA
 Description       : cDAVE Negative Rule Checking for Continuous Bin
 Test-Case         : PEAR-1584
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression, negative-test, negative-custom-bin-test
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab, negative-test, negative-custom-bin-test
 
 ## Navigate to Clinical Data Analysis
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/save_new_cohort.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/save_new_cohort.spec
@@ -5,7 +5,7 @@ Owner		      : GDC QA
 Description	  : Save New Cohort with Dropdown Options
 Test-Case     : PEAR-620
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Create Cohort for Test
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/survival_plot.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/survival_plot.spec
@@ -5,7 +5,7 @@ Owner		  : GDC QA
 Description	  : Survival Plot Graphing
 Test-Case     : PEAR-604
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Create Cohort for Test
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/tsv_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/clinical_data_analysis/tsv_download.spec
@@ -4,7 +4,7 @@ Version			  : 1.0
 Owner		      : GDC QA
 Description		: Download TSV in Different Analysis Cards
 
-tags: gdc-data-portal-v2, clinical-data-analysis, regression
+tags: gdc-data-portal-v2, clinical-data-analysis, regression, gitlab
 
 ## Create Cohort for Test
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/discard_changes.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/discard_changes.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Cohort Bar Discard Changes
 Test-case       : PEAR-1139
 
-tags: gdc-data-portal-v2, regression, cohort-bar
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar
 
 ## Collect Data Portal Statistics
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/export_cohort.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/export_cohort.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Cohort Bar - exporting a cohort
 Test-case       : PEAR-501
 
-tags: gdc-data-portal-v2, regression, cohort-bar, download
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar, download
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/general_cohort_functions.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/general_cohort_functions.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Cohort Bar - saving, switching, and deleting a cohort
 Test-case       : PEAR-492,PEAR-493,PEAR-498
 
-tags: gdc-data-portal-v2, regression, cohort-bar, smoke-test
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar, smoke-test
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/import_cohort.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/import_cohort.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Cohort Bar - impoting a cohort
 Test-case       : PEAR-499
 
-tags: gdc-data-portal-v2, regression, cohort-bar
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar
 
 ## Collect Data Portal Statistics
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/only_one_unsaved_cohort.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/only_one_unsaved_cohort.spec
@@ -5,7 +5,7 @@ Owner		          : GDC QA
 Description		    : Cohort Bar - Enforce there can only be one unsaved cohort at a time
 Test-case         : PEAR-1748
 
-tags: gdc-data-portal-v2, regression, cohort-bar
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar
 
 ## Add an Unsaved Cohort
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/query_expression_expand_collapse.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/query_expression_expand_collapse.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Cohort Query Expression Area Expand/Collapse Rows and Filters
 Test-case       : PEAR-2270
 
-tags: gdc-data-portal-v2, regression, cohort-bar
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar
 
 
 ## Navigate to Cohort Builder

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/save_as.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/save_as.spec
@@ -5,7 +5,7 @@ Owner		          : GDC QA
 Description		    : Cohort Bar - Save As Feature
 Test-case         : PEAR-1747
 
-tags: gdc-data-portal-v2, regression, cohort-bar
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_bar/unique_name_replace.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_bar/unique_name_replace.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Cohort Bar Unique Cohort Name and Replacement
 Test-case       : PEAR-1460
 
-tags: gdc-data-portal-v2, regression, cohort-bar
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/categories_facet_card_presence.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/categories_facet_card_presence.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Cohort Builder - category and facet presence
 Test-case       : PEAR-796
 
-tags: gdc-data-portal-v2, cohort-builder, facet-cards, regression
+tags: gdc-data-portal-v2, cohort-builder, facet-cards, regression, gitlab
 
 ## Navigate to Cohort Builder
 

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/cohort_builder_main.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/cohort_builder_main.spec
@@ -5,17 +5,13 @@ Owner		        : GDC QA
 Description		  : Test Cohort Builder - card functions
 Test-case       : PEAR-792
 
-tags: gdc-data-portal-v2, cohort-builder, filter-card, regression
+tags: gdc-data-portal-v2, cohort-builder, filter-card, regression, gitlab
 
 ## Navigate to Cohort Builder
-
-tags: regression, smoke, cohort-builder
-
 * On GDC Data Portal V2 app
 * Navigate to "Cohort" from "Header" "section"
 
 ## Cohort Builder - General Card Functions
-tags: cohort-selections
 * Expand or contract a facet from "General Diagnosis" tab on the Cohort Builder page
   |facet_name               |selection                    |
   |-------------------------|-----------------------------|

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/cohort_builder_search_bar.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/cohort_builder_search_bar.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Cohort Builder - Searching
 Test-case       : PEAR-797
 
-tags: gdc-data-portal-v2, cohort-builder, search-bar, regression
+tags: gdc-data-portal-v2, cohort-builder, search-bar, regression, gitlab
 
 ## Navigate to Cohort Builder
 

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/custom_filter.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/custom_filter.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Cohort Builder - test custom filter tab and modal
 Test-case       : PEAR-795
 
-tags: gdc-data-portal-v2, cohort-builder, regression
+tags: gdc-data-portal-v2, cohort-builder, regression, gitlab
 
 ## Navigate to Cohort Builder
 

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/custom_filter_removal.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/custom_filter_removal.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Validate custom filters that have been removed are not present
 Test-case       : PEAR-2269
 
-tags: gdc-data-portal-v2, cohort-builder, regression
+tags: gdc-data-portal-v2, cohort-builder, regression, gitlab
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/filter_by_gene_set.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/filter_by_gene_set.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Create gene set using filter card. Filter cohort by Gene Sets.
 Test-case       : PEAR-792
 
-tags: gdc-data-portal-v2, cohort-builder, filter-card, regression
+tags: gdc-data-portal-v2, cohort-builder, filter-card, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/filter_by_identifier.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/filter_by_identifier.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Cohort Builder - Filter by Case, Gene, Mutation Identifier
 Test-case       : PEAR-792
 
-tags: gdc-data-portal-v2, cohort-builder, filter-card, regression
+tags: gdc-data-portal-v2, cohort-builder, filter-card, regression, gitlab
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/filter_by_mutation_set.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/filter_by_mutation_set.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Create mutation  set using filter card. Filter cohort by Mutation Sets.
 Test-case       : PEAR-792
 
-tags: gdc-data-portal-v2, cohort-builder, filter-card, regression
+tags: gdc-data-portal-v2, cohort-builder, filter-card, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/other_clinical_attributes.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/other_clinical_attributes.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Other Clinical Attributes in Cohort Builder
 Test-case           :
 
-tags: gdc-data-portal-v2, regression, cohort-builder
+tags: gdc-data-portal-v2, regression, gitlab, cohort-builder
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_builder/race_condition.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_builder/race_condition.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Add filters quickly and ensure case counts are accurate
 Test-case       :
 
-tags: gdc-data-portal-v2, cohort-builder, filter-card, regression
+tags: gdc-data-portal-v2, cohort-builder, filter-card, regression, gitlab
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_filters.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_filters.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Summary View Filters
 Test-Case       : PEAR-2207
 
-tags: gdc-data-portal-v2, regression, cohort-bar, case-view
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar, case-view
 
 ## Navigate to Summary View
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Summary View Header
 Test-Case       : PEAR-2207, PEAR-1048
 
-tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecimen-download
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar, case-view, clinical-biospecimen-download
 
 ## Navigate to Summary View
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_cohort.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_cohort.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Save New Cohort Button with Dropdown Options
 Test-Case           : PEAR-1013
 
-tags: gdc-data-portal-v2, regression, cohort-bar, case-view
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar, case-view
 
 ## Make Blank Cohort
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_header.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_header.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate Cohort Header
 Test-Case           : PEAR-1052
 
-tags: gdc-data-portal-v2, regression, cohort-bar, case-view, clinical-biospecimen-download
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar, case-view, clinical-biospecimen-download
 
 ## Navigate to Table View
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_table.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_case_view/table_view_table.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate Cohort Table
 Test-Case           : PEAR-1052
 
-tags: gdc-data-portal-v2, regression, cohort-bar, case-view
+tags: gdc-data-portal-v2, regression, gitlab, cohort-bar, case-view
 
 ## Navigate to Table View
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/demo.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/demo.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Cohort Comparison - Demo
 Test-case       : PEAR-483
 
-tags: gdc-data-portal-v2, regression, cohort-comparison
+tags: gdc-data-portal-v2, regression, gitlab, cohort-comparison
 
 ## Travel to Cohort Comparison Demo
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/download_tsv.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/download_tsv.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Cohort Comparison - Download TSV
 Test-case       : PEAR-816
 
-tags: gdc-data-portal-v2, regression, cohort-comparison, cohort-comparison-download-tsv
+tags: gdc-data-portal-v2, regression, gitlab, cohort-comparison, cohort-comparison-download-tsv
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/main_page.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/main_page.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Cohort Comparison - Main Page
 Test-case       : PEAR-817
 
-tags: gdc-data-portal-v2, regression, cohort-comparison
+tags: gdc-data-portal-v2, regression, gitlab, cohort-comparison
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/selection_screen.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cohort_comparison/selection_screen.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Cohort Comparison - selection screen
 Test-case       : PEAR-819
 
-tags: gdc-data-portal-v2, regression, cohort-comparison
+tags: gdc-data-portal-v2, regression, gitlab, cohort-comparison
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/absolute_cnv_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/absolute_cnv_data.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : CNV Index Points to ABSOLUTE
 Test-case           :
 
-tags: gdc-data-portal-v2, end-to-end, regression
+tags: gdc-data-portal-v2, end-to-end, regression, gitlab
 
 ## Navigate to Repository
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/cohort_with_multiple_types_of_filters.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/cohort_with_multiple_types_of_filters.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Cohort End to End Test with Multiple Types of Filters
 Test-case       : PEAR-1448
 
-tags: gdc-data-portal-v2, end-to-end, regression
+tags: gdc-data-portal-v2, end-to-end, regression, gitlab
 
 ## Save a cohort with multiple types of filters
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/expression_array.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/expression_array.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Test New Experimental Strategy Expression Array
 Test-case           :
 
-tags: gdc-data-portal-v2, end-to-end, regression
+tags: gdc-data-portal-v2, end-to-end, regression, gitlab
 
 ## Navigate to Summary Page: dc60add8-9c21-4d98-bd3d-93ccf5ded9b9
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/other_clinical_attributes.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/other_clinical_attributes.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Other Clinical Attributes
 Test-case           :
 
-tags: gdc-data-portal-v2, end-to-end, regression
+tags: gdc-data-portal-v2, end-to-end, regression, gitlab
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/end_to_end/replace_cohort_filtered_button.spec
@@ -5,7 +5,7 @@ Owner		            : GDC QA
 Description		      : Replace Cohort with Various Filtered Cohort Buttons
 Test-case           : PEAR-2458
 
-tags: gdc-data-portal-v2, end-to-end, regression
+tags: gdc-data-portal-v2, end-to-end, regression, gitlab
 
 ## Create Initial Cohorts
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/file_summary/bam_metrics.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/file_summary/bam_metrics.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate BAM Metrics Table
 Test-Case           : PEAR-474
 
-tags: gdc-data-portal-v2, regression, file-summary
+tags: gdc-data-portal-v2, regression, gitlab, file-summary
 
 ## Navigate to Summary Page: 93a3d4d5-a8ec-4a8b-8297-ee76c03ed3d7
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/file_summary/cart_file_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/file_summary/cart_file_download.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Add and Remove from cart, download file
 Test-Case       : PEAR-540
 
-tags: gdc-data-portal-v2, file-summary, cart, file-download, smoke-test, sanity-test, regression
+tags: gdc-data-portal-v2, file-summary, cart, file-download, smoke-test, sanity-test, regression, gitlab
 
 ## File Summary Page - Navigate to a file summary page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/file_summary/validate_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/file_summary/validate_tables.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate Various Tables
 Test-Case           : PEAR-474, PEAR-476, PEAR-463
 
-tags: gdc-data-portal-v2, regression, file-summary
+tags: gdc-data-portal-v2, regression, gitlab, file-summary
 
 ## Navigate to Summary Page: 0b439a6e-9f34-4d45-8a1a-b76c8e0ca8f3
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/cancer_distribution.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/cancer_distribution.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Validate Cancer Distribution Area
 Test-Case       : PEAR-2286
 
-tags: gdc-data-portal-v2, regression, gene-summary
+tags: gdc-data-portal-v2, regression, gitlab, gene-summary
 
 ## Navigate to Gene Summary Page: RBM15
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/most_frequent_somatic_mutations.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/most_frequent_somatic_mutations.spec
@@ -5,7 +5,7 @@ Owner		      : GDC QA
 Description		: Validate Most Frequent Somatic Mutations Table
 Test-Case     : PEAR-2286
 
-tags: gdc-data-portal-v2, regression, gene-summary
+tags: gdc-data-portal-v2, regression, gitlab, gene-summary
 
 ## Navigate to Gene Summary Page: RDH14
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Header - Links
 Test-case       : PEAR-2518
 
-tags: gdc-data-portal-v2, regression, header, navigation
+tags: gdc-data-portal-v2, regression, gitlab, header, navigation
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/header/navigation.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/navigation.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Test header navigation
 Test-Case       : N/A
 
-tags: gdc-data-portal-v2, regression, navigation, header
+tags: gdc-data-portal-v2, regression, gitlab, navigation, header
 
 ## Open the data portal
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/header/quick_search.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/quick_search.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test results from quick search bar
 Test-Case       : PEAR-937
 
-tags: gdc-data-portal-v2, regression, search-bar, smoke-test
+tags: gdc-data-portal-v2, regression, gitlab, search-bar, smoke-test
 
 ## Search - File
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/home_page/access_gdc_cookie.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/home_page/access_gdc_cookie.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description	    : Check Cookie - Home Page
 Test-case       : QA-2074
 
-tags: gdc-data-portal-v2, regression, home-page, cookie
+tags: gdc-data-portal-v2, regression, gitlab, home-page, cookie
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/home_page/body_plot_graph.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/home_page/body_plot_graph.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Home Page - Create Cohorts using Body Plot Graph
 Test-case       : PEAR-1104
 
-tags: gdc-data-portal-v2, regression, home-page, cohort-bar
+tags: gdc-data-portal-v2, regression, gitlab, home-page, cohort-bar
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/home_page/live_statistics.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/home_page/live_statistics.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Home Page - Live Stats
 Test-case       : PEAR-939
 
-tags: gdc-data-portal-v2, regression, home-page
+tags: gdc-data-portal-v2, regression, gitlab, home-page
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/home_page/navigation.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/home_page/navigation.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Home Page - Navigation
 Test-case       : PEAR-939
 
-tags: gdc-data-portal-v2, regression, home-page, navigation
+tags: gdc-data-portal-v2, regression, gitlab, home-page, navigation
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/manage_sets/gene_set.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/manage_sets/gene_set.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Gene Set - Create, Edit, Download, Delete
 Test-Case       : PEAR-1619
 
-tags: gdc-data-portal-v2, manage-sets, regression
+tags: gdc-data-portal-v2, manage-sets, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/manage_sets/miscellaneous_and_negative_path.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/manage_sets/miscellaneous_and_negative_path.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Negative Scenarios, Text, and Links Validation
 Test-Case       : PEAR-1620
 
-tags: gdc-data-portal-v2, manage-sets, regression
+tags: gdc-data-portal-v2, manage-sets, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/manage_sets/mutation_set.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/manage_sets/mutation_set.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Mutation Set - Create, Edit, Download, Delete
 Test-Case       : PEAR-1619
 
-tags: gdc-data-portal-v2, manage-sets, regression
+tags: gdc-data-portal-v2, manage-sets, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/create_filtered_cohort_button.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/create_filtered_cohort_button.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Create a Filtered Cohort Using Different Table Buttons
 Test-Case      : PEAR-1510, PEAR-2458
 
-tags: gdc-data-portal-v2, mutation-frequency, regression
+tags: gdc-data-portal-v2, mutation-frequency, regression, gitlab
 
 ## Collect Data Portal Statistics
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/custom_gene_mutation_filter.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/custom_gene_mutation_filter.spec
@@ -5,7 +5,7 @@ Owner		      : GDC QA
 Description		: Custom Filtering on the Mutation Frequency App
 Test-Case     : PEAR-732
 
-tags: gdc-data-portal-v2, mutation-frequency, regression
+tags: gdc-data-portal-v2, mutation-frequency, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/demo_mode.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/demo_mode.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description     : Mutation Frequency Demo Mode
 Test-Case       : PEAR-914
 
-tags: gdc-data-portal-v2, mutation-frequency, regression
+tags: gdc-data-portal-v2, mutation-frequency, regression, gitlab
 
 ## Navigate to Mutation Frequency Demo
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/filter_check.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/filter_check.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Filtering on the Mutation Frequency App
 Test-Case      : PEAR-898, PEAR-916
 
-tags: gdc-data-portal-v2, mutation-frequency, regression
+tags: gdc-data-portal-v2, mutation-frequency, regression, gitlab
 
 ## Navigate to Mutation Frequency App
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/is_cancer_gene_census.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/is_cancer_gene_census.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Turn Off Is Cancer Gene Census
 Test-Case      : PEAR-898, PEAR-916
 
-tags: gdc-data-portal-v2, regression, mutation-frequency, is-cancer-census-off
+tags: gdc-data-portal-v2, regression, gitlab, mutation-frequency, is-cancer-census-off
 
 ## Navigate to Mutation Frequency App
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/save_edit_gene_set.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/save_edit_gene_set.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Save/Edit Gene Button
 Test-Case      : PEAR-2236
 
-tags: gdc-data-portal-v2, regression, mutation-frequency
+tags: gdc-data-portal-v2, regression, gitlab, mutation-frequency
 
 ## Navigate to Mutation Frequency App
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/save_edit_mutation_set.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/save_edit_mutation_set.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Save/Edit Mutation Button
 Test-Case      : PEAR-2236
 
-tags: gdc-data-portal-v2, regression, mutation-frequency
+tags: gdc-data-portal-v2, regression, gitlab, mutation-frequency
 
 ## Navigate to Mutation Frequency App
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/saving_cohort_gene_mutation.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/saving_cohort_gene_mutation.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Save a cohort with genes, mutations, and both filters
 Test-Case      : PEAR-1510
 
-tags: gdc-data-portal-v2, mutation-frequency, regression
+tags: gdc-data-portal-v2, mutation-frequency, regression, gitlab
 
 ## Navigate to Mutation Frequency App
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/table_tsv_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/table_tsv_download.spec
@@ -5,7 +5,7 @@ Owner		      : GDC QA
 Description		: Download Table TSV on Genes and Mutations Tab
 Test-Case     : PEAR-909, PEAR-911
 
-tags: gdc-data-portal-v2, mutation-frequency, regression
+tags: gdc-data-portal-v2, mutation-frequency, regression, gitlab
 
 ## Navigate to Mutation Frequency App
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_frequency/tables.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Validate Table Details
 Test-Case      : PEAR-899, PEAR-905
 
-tags: gdc-data-portal-v2, mutation-frequency, regression
+tags: gdc-data-portal-v2, mutation-frequency, regression, gitlab
 
 ## Navigate to Mutation Frequency App
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_summary/cancer_distribution.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_summary/cancer_distribution.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description : Validate Cancer Distribution Table and Downloads
 Test-Case   : PEAR-2367
 
-tags: gdc-data-portal-v2, regression, mutation-summary
+tags: gdc-data-portal-v2, regression, gitlab, mutation-summary
 
 ## Navigate to Mutation Summary Page: chr1:g.114716126C>T
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_summary/consequences.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_summary/consequences.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Validate Consequences Table and Downloads
 Test-Case       : PEAR-2367
 
-tags: gdc-data-portal-v2, regression, mutation-summary
+tags: gdc-data-portal-v2, regression, gitlab, mutation-summary
 
 ## Navigate to Mutation Summary Page: chr3:g.179218303G>A
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/project_summary/validate_header_options.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/project_summary/validate_header_options.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate All Buttons in Project Summary Header
 Test-Case           : PEAR-2202
 
-tags: gdc-data-portal-v2, regression, project-summary, clinical-biospecimen-download
+tags: gdc-data-portal-v2, regression, gitlab, project-summary, clinical-biospecimen-download
 
 ## Navigate to Projects Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/project_summary/validate_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/project_summary/validate_tables.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		    : Validate Various Tables
 Test-Case           : PEAR-2202
 
-tags: gdc-data-portal-v2, regression, project-summary
+tags: gdc-data-portal-v2, regression, gitlab, project-summary
 
 ## Navigate to Projects Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/projects/create_project_cohort.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/projects/create_project_cohort.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Create, Save, Delete Cohort on the Project Page
 Test-Case      : PEAR-1291
 
-tags: gdc-data-portal-v2, regression, projects, cohort
+tags: gdc-data-portal-v2, regression, gitlab, projects, cohort
 
 ## Navigate to Projects Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/projects/filter_cards.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/projects/filter_cards.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Filter Card Check
 Test-Case      : PEAR-1286
 
-tags: gdc-data-portal-v2, regression, projects
+tags: gdc-data-portal-v2, regression, gitlab, projects
 
 ## Navigate to Projects Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/projects/table_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/projects/table_download.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : JSON, TSV Downloads on the project page
 Test-Case      : PEAR-1290
 
-tags: gdc-data-portal-v2, regression, projects, download, smoke-test
+tags: gdc-data-portal-v2, regression, gitlab, projects, download, smoke-test
 
 ## Navigate to Projects Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/repository/add_a_file_filter.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/add_a_file_filter.spec
@@ -4,12 +4,9 @@ Version			: 1.0
 Owner		    : GDC QA
 Description		: Test Repository Filters
 
-tags: gdc-data-portal-v2, repository, repository_filters, smoke-test
+tags: gdc-data-portal-v2, repository, repository_filters, smoke-test, regression, gitlab
 
 ## Repository Filters
-
-tags: regression, smoke
-
 * On GDC Data Portal V2 app
 * Navigate to "Downloads" from "Header" "section"
 

--- a/holmes-py/specs/gdc_data_portal_v2/repository/add_all_remove_all_files.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/add_all_remove_all_files.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Test Repository Add All Files and Remove All Files buttons
 Test-Case      : PEAR-461, PEAR-473
 
-tags: gdc-data-portal-v2, repository, regression
+tags: gdc-data-portal-v2, repository, regression, gitlab
 
 ## Navigate to Repository Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/repository/add_remove_files_from_table.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/add_remove_files_from_table.spec
@@ -5,7 +5,7 @@ Owner		       : GDC QA
 Description		 : Repository Add and Remove Individual Files From the Table
 Test-Case      : PEAR-466, PEAR-471
 
-tags: gdc-data-portal-v2, repository, regression, smoke
+tags: gdc-data-portal-v2, repository, regression, gitlab
 
 ## Navigate to Repository Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/repository/custom_filter_removal.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/custom_filter_removal.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Validate custom filters that have been removed are not present
 Test-case       : PEAR-2269
 
-tags: gdc-data-portal-v2, repository, regression
+tags: gdc-data-portal-v2, repository, regression, gitlab
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/repository/slide_image_viewer.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/slide_image_viewer.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Slide Image Viewer
 Test-Case       : PEAR-479
 
-tags: gdc-data-portal-v2, repository, regression, slide-image-viewer
+tags: gdc-data-portal-v2, repository, regression, gitlab, slide-image-viewer
 
 ## Navigate to Slide Image Viewer
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/repository/table_download.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/table_download.spec
@@ -4,7 +4,7 @@ Version			  : 1.2
 Owner		      : GDC QA
 Description		: JSON, TSV, Manifest, Metadata, Sample Sheet Downloads
 
-tags: gdc-data-portal-v2, repository, json-tsv-file-download, download, regression
+tags: gdc-data-portal-v2, repository, json-tsv-file-download, download, regression, gitlab
 
 ## Navigate to Cohort Builder and Select Filters
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/repository/undo_add_remove.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/repository/undo_add_remove.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Undo Adding and Removing Files
 Test-Case       : PEAR-462, PEAR-468
 
-tags: gdc-data-portal-v2, repository, regression
+tags: gdc-data-portal-v2, repository, regression, gitlab
 
 ## Navigate to Repository Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/set_operations/cohort_analysis.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/set_operations/cohort_analysis.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Set Operations - Cohort Main Page
 Test-Case       : PEAR-1230
 
-tags: gdc-data-portal-v2, set-operations, regression
+tags: gdc-data-portal-v2, set-operations, regression, gitlab
 
 ## Navigate to Cohort Builder
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/set_operations/demo.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/set_operations/demo.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description	    : Set Operations - Demo Mode
 Test-Case       : PEAR-1229
 
-tags: gdc-data-portal-v2, set-operations, regression
+tags: gdc-data-portal-v2, set-operations, regression, gitlab
 
 ## Navigate to Set Operations
 * Navigate to "Analysis" from "Header" "section"

--- a/holmes-py/specs/gdc_data_portal_v2/set_operations/gene_set_analysis.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/set_operations/gene_set_analysis.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Set Operations - Gene Set Main Page
 Test-Case       : PEAR-1230
 
-tags: gdc-data-portal-v2, set-operations, regression
+tags: gdc-data-portal-v2, set-operations, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/set_operations/mutation_set_analysis.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/set_operations/mutation_set_analysis.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Set Operations - Mutation Set Main Page
 Test-Case       : PEAR-1230
 
-tags: gdc-data-portal-v2, set-operations, regression
+tags: gdc-data-portal-v2, set-operations, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/set_operations/same_name.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/set_operations/same_name.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Selecting different sets and cohorts with the same name
 Test-Case       : PEAR-1231, PEAR-1230
 
-tags: gdc-data-portal-v2, set-operations, regression
+tags: gdc-data-portal-v2, set-operations, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/set_operations/selection_screen.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/set_operations/selection_screen.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Set Operations - Selection Screen
 Test-Case       : PEAR-1231
 
-tags: gdc-data-portal-v2, set-operations, regression
+tags: gdc-data-portal-v2, set-operations, regression, gitlab
 
 ## Navigate to Manage Sets
 * On GDC Data Portal V2 app

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -67,12 +67,13 @@ class AnalysisCenterPage(BasePage):
 
     def get_analysis_tool_cases_count(self, tool_name):
         """Returns case count on given analysis tool"""
-        self.wait_for_loading_spinners_to_detach()
+        # self.wait_for_loading_spinners_to_detach()
+        # self.wait_for_loading_spinners_to_detach()
         locator = AnalysisCenterLocators.TEXT_CASES_COUNT_ON_TOOL_CARD(tool_name)
         # If we get " " or " Cases" on return, that means the analysis card is still loading information. We wait until
         # it fully loads or 10 seconds elapses before returning text.
         retry_counter = 0
-        while ((self.get_text(locator) == " ") or (self.get_text(locator) == " Cases")):
+        while ((self.get_text(locator) == " ") or (self.get_text(locator) == "") or (self.get_text(locator) == " Cases")):
             time.sleep(1)
             retry_counter = retry_counter + 1
             if retry_counter >= 10:

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -67,8 +67,8 @@ class AnalysisCenterPage(BasePage):
 
     def get_analysis_tool_cases_count(self, tool_name):
         """Returns case count on given analysis tool"""
-        # self.wait_for_loading_spinners_to_detach()
-        # self.wait_for_loading_spinners_to_detach()
+        self.wait_for_loading_spinners_to_detach()
+        self.wait_for_loading_spinners_to_detach()
         locator = AnalysisCenterLocators.TEXT_CASES_COUNT_ON_TOOL_CARD(tool_name)
         # If we get " " or " Cases" on return, that means the analysis card is still loading information. We wait until
         # it fully loads or 10 seconds elapses before returning text.


### PR DESCRIPTION
## Description
- Created new tag for Gitlab tests
- Added extra checks in analysis center to reduce flaky tests

I was able to run all Gitlab tests and have them pass: https://gitlab.datacommons.io/nci-gdc/front-end/gdc-frontend-framework/-/jobs/1004010
I have a follow up ticket to reduce the flaky tests in the repo to make the run above more consistent

To test:
vpn2: prod-green
`gauge run specs/gdc_data_portal_v2/cohort_builder/filter_by_gene_set.spec specs/gdc_data_portal_v2/cohort_builder/filter_by_mutation_set.spec`
