### PR TITLE
Qa 2591 new tab tests change assertion

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/cart/miscellaneous_scenarios.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/miscellaneous_scenarios.spec
@@ -22,10 +22,10 @@ tags: gdc-data-portal-v2, regression, cart
 * Is text "Download Files in your Cart directly from the Web Browser." present on the page
 * Is text "Download  GDC Reference Files for use in your genomic data analysis." present on the page
 * These links on the "Cart" should take the user to correct page in a new tab
-  |button_text                                |text_on_expected_page                                    |
+  |button_text                                |url_expected_on_new_tab                                  |
   |-------------------------------------------|---------------------------------------------------------|
-  |GDC Data Transfer Tool                     |The GDC Data Transfer Tool (DTT) provides an optimized   |
-  |GDC Reference Files                        |Reference files used by the GDC data harmonization       |
+  |GDC Data Transfer Tool                     |https://gdc.cancer.gov/access-data/gdc-data-transfer-tool|
+  |GDC Reference Files                        |https://gdc.cancer.gov/about-data/gdc-data-processing/gdc-reference-files|
 
 ## No Files in Cart Message
 * Remove "All Files" from cart on the Cart page

--- a/holmes-py/specs/gdc_data_portal_v2/footer/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/footer/link_checking.spec
@@ -16,25 +16,26 @@ tags: gdc-data-portal-v2, regression, footer, navigation
 
 ## Validate Navigation Links - different tab
 * These links on the "Footer" should take the user to correct page in a new tab
-  |button_text                                |text_on_expected_page                                          |
+  |button_text                                |url_expected_on_new_tab                                        |
   |-------------------------------------------|---------------------------------------------------------------|
-  |Data Portal                                |A repository and computational platform for cancer researchers |
-  |Website                                    |The NCI's Genomic Data Commons                                 |
-  |API                                        |The GDC Application Programming Interface (API)                |
-  |Data Transfer Tool                         |The GDC Data Transfer Tool (DTT) provides an optimized         |
-  |Documentation                              |can find detailed information on GDC processes and tools       |
-  |Data Submission Portal                     |The GDC Data Submission Portal is a web-based system           |
-  |Publications                               |To request a publication page that meets the above criteria    |
-  |Support                                    |please contact the GDC Help Desk                               |
-  |Listserv                                   |This screen allows you to subscribe or unsubscribe to the      |
-  |Accessibility                              |Section 508 requires that all individuals with disabilities    |
-  |Disclaimer                                 |NCI urges users to consult with a qualified physician          |
-  |FOIA                                       |provides individuals with a right to access to records         |
-  |HHS Vulnerability Disclosure               |If you make a good faith effort to comply with this policy     |
-  |U.S. Department of Health and Human Services|200 Independence Avenue, S.W.                                 |
-  |National Institutes of Health              |9000 Rockville Pike Bethesda, Maryland 20892                   |
-  |National Cancer Institute                  |National Cancer Institute                                      |
-  |USA.gov                                    |USA.gov helps you locate a                                     |
+  |Data Portal                                |https://portal.gdc.cancer.gov/                                 |
+  |Website                                    |https://gdc.cancer.gov/                                        |
+  |API                                        |https://gdc.cancer.gov/developers/gdc-application-programming-interface-api|
+  |Data Transfer Tool                         |https://gdc.cancer.gov/access-data/gdc-data-transfer-tool      |
+  |Documentation                              |https://docs.gdc.cancer.gov/                                   |
+  |Data Submission Portal                     |https://portal.gdc.cancer.gov/submission/                      |
+  |Publications                               |https://gdc.cancer.gov/about-data/publications                 |
+  |Site Home                                  |https://portal.gdc.cancer.gov/                                 |
+  |Support                                    |https://gdc.cancer.gov/support                                 |
+  |Listserv                                   |https://list.nih.gov/cgi-bin/wa.exe?SUBED1=gdc-users-l&A=1     |
+  |Accessibility                              |https://www.cancer.gov/policies/accessibility                  |
+  |Disclaimer                                 |https://www.cancer.gov/policies/disclaimer                     |
+  |FOIA                                       |https://www.nih.gov/institutes-nih/nih-office-director/office-communications-public-liaison/freedom-information-act-office|
+  |HHS Vulnerability Disclosure               |https://www.hhs.gov/vulnerability-disclosure-policy/           |
+  |U.S. Department of Health and Human Services|https://www.hhs.gov/                                          |
+  |National Institutes of Health              |https://www.nih.gov/                                           |
+  |National Cancer Institute                  |https://www.cancer.gov/                                        |
+  |USA.gov                                    |https://www.usa.gov/                                           |
 
 ## Validate Navigation Links - same tab
 * These links should take the user to correct page in the same tab

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -58,8 +58,8 @@ tags: gdc-data-portal-v2, regression, gene-summary, new_tab
 * In table "External References Gene Summary" these selections should take the user to correct page in a new tab
     |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
-    |1    |2      |https://www.ncbi.nlm.nih.gov/gene/5728                               |
+    |1    |2      |http*://www.ncbi.nlm.nih.gov/gene/5728                               |
     |2    |2      |http*://www.uniprot.org/uniprot**/P60484                             |
-    |4    |2      |https://omim.org/entry/601728                                        |
-    |6    |2      |https://civicdb.org/features/41/summary                              |
-    |7    |2      |https://www.genecards.org/cgi-bin/carddisp.pl?gene=PTEN              |
+    |4    |2      |http*://omim.org/entry/601728                                        |
+    |6    |2      |http*://civicdb.org/features/41/summary                              |
+    |7    |2      |http*://www.genecards.org/cgi-bin/carddisp.pl?gene=PTEN              |

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -56,9 +56,11 @@ tags: gdc-data-portal-v2, regression, gene-summary
     |41                                     |6    |2      |
     |PTEN                                   |7    |2      |
 * In table "External References Gene Summary" these selections should take the user to correct page in a new tab
-    |row  |column |expected_text                                                        |
+    |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
-    |2    |2      |This isoform has been chosen as the canonical sequence.              |
-    |3    |2      |phosphatase and tensin homolog                                       |
-    |6    |2      |PTEN is a multi-functional tumor suppressor that is very commonly    |
-    |7    |2      |PTEN (Phosphatase And Tensin Homolog) is a Protein Coding gene       |
+    |1    |2      |https://www.ncbi.nlm.nih.gov/gene/5728                               |
+    |2    |2      |https://www.uniprot.org/uniprotkb/P60484/entry                       |
+    |3    |2      |https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9588|
+    |4    |2      |https://omim.org/entry/601728                                        |
+    |6    |2      |https://civicdb.org/features/41/summary                              |
+    |7    |2      |https://www.genecards.org/cgi-bin/carddisp.pl?gene=PTEN              |

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Validate Summary Table and External Reference Table
 Test-Case       : PEAR-2286
 
-tags: gdc-data-portal-v2, regression, gene-summary, new_tab
+tags: gdc-data-portal-v2, regression, gene-summary
 
 ## Navigate to Gene Summary Page: PTEN
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -60,7 +60,6 @@ tags: gdc-data-portal-v2, regression, gene-summary, new_tab
     |-----|-------|---------------------------------------------------------------------|
     |1    |2      |https://www.ncbi.nlm.nih.gov/gene/5728                               |
     |2    |2      |http*://www.uniprot.org/uniprot**/P60484                             |
-    |3    |2      |https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9588|
     |4    |2      |https://omim.org/entry/601728                                        |
     |6    |2      |https://civicdb.org/features/41/summary                              |
     |7    |2      |https://www.genecards.org/cgi-bin/carddisp.pl?gene=PTEN              |

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Validate Summary Table and External Reference Table
 Test-Case       : PEAR-2286
 
-tags: gdc-data-portal-v2, regression, gene-summary
+tags: gdc-data-portal-v2, regression, gene-summary, new_tab
 
 ## Navigate to Gene Summary Page: PTEN
 * On GDC Data Portal V2 app
@@ -59,7 +59,7 @@ tags: gdc-data-portal-v2, regression, gene-summary
     |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
     |1    |2      |https://www.ncbi.nlm.nih.gov/gene/5728                               |
-    |2    |2      |https://www.uniprot.org/uniprotkb/P60484                             |
+    |2    |2      |http*://www.uniprot.org/uniprotkb/P60484                             |
     |3    |2      |https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9588|
     |4    |2      |https://omim.org/entry/601728                                        |
     |6    |2      |https://civicdb.org/features/41/summary                              |

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -59,7 +59,7 @@ tags: gdc-data-portal-v2, regression, gene-summary, new_tab
     |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
     |1    |2      |https://www.ncbi.nlm.nih.gov/gene/5728                               |
-    |2    |2      |http*://www.uniprot.org/uniprotkb/P60484                             |
+    |2    |2      |http*://www.uniprot.org/uniprot**/P60484                             |
     |3    |2      |https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9588|
     |4    |2      |https://omim.org/entry/601728                                        |
     |6    |2      |https://civicdb.org/features/41/summary                              |

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -59,7 +59,7 @@ tags: gdc-data-portal-v2, regression, gene-summary
     |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
     |1    |2      |https://www.ncbi.nlm.nih.gov/gene/5728                               |
-    |2    |2      |https://www.uniprot.org/uniprotkb/P60484/entry                       |
+    |2    |2      |https://www.uniprot.org/uniprotkb/P60484                             |
     |3    |2      |https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9588|
     |4    |2      |https://omim.org/entry/601728                                        |
     |6    |2      |https://civicdb.org/features/41/summary                              |

--- a/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/gene_summary/summary_external_references_tables.spec
@@ -62,4 +62,3 @@ tags: gdc-data-portal-v2, regression, gene-summary, new_tab
     |2    |2      |http*://www.uniprot.org/uniprot**/P60484                             |
     |4    |2      |http*://omim.org/entry/601728                                        |
     |6    |2      |http*://civicdb.org/features/41/summary                              |
-    |7    |2      |http*://www.genecards.org/cgi-bin/carddisp.pl?gene=PTEN              |

--- a/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
@@ -13,24 +13,24 @@ tags: gdc-data-portal-v2, regression, header, navigation
 
 ## Validate Navigation Links - different tab
 * These links on the "Header" should take the user to correct page in a new tab
-  |button_text                                |text_on_expected_page                                          |
+  |button_text                                |url_expected_on_new_tab                                        |
   |-------------------------------------------|---------------------------------------------------------------|
-  |Video Guides                               |In this GDC 2.0 Video Tutorial, obtain an overview of          |
-  |Obtaining Access to Controlled Data        |In order to obtain access to controlled data available in the  |
+  |Video Guides                               |https://docs.gdc.cancer.gov/Data_Portal/Users_Guide/Video_Tutorials/|
+  |Obtaining Access to Controlled Data        |https://gdc.cancer.gov/access-data/obtaining-access-controlled-data|
 
 ## Validate Apps Links
 * These Apps links should take the user to correct page in new tab
-  |button_text                                |text_on_expected_page                                          |
+  |button_text                                |url_expected_on_new_tab                                        |
   |-------------------------------------------|---------------------------------------------------------------|
-  |Website                                    |The GDC supports several cancer genome programs at the NCI     |
-  |API                                        |The GDC Application Programming Interface (API)                |
-  |Data Transfer Tool                         |The GDC Data Transfer Tool (DTT) provides                      |
-  |Documentation                              |A place where researchers, data submitters and developers can  |
-  |Data Submission Portal                     |The GDC Data Submission Portal is a web-based system           |
-  |Publications                               |The GDC provides access to information and supplementary files from publications|
+  |Website                                    |https://gdc.cancer.gov/?utm_source=dataportal&utm_medium=apps  |
+  |API                                        |https://gdc.cancer.gov/developers/gdc-application-programming-interface-api?utm_source=dataportal&utm_medium=apps   |
+  |Data Transfer Tool                         |https://gdc.cancer.gov/access-data/gdc-data-transfer-tool?utm_source=dataportal&utm_medium=apps|
+  |Documentation                              |https://docs.gdc.cancer.gov/?utm_source=dataportal&utm_medium=apps|
+  |Data Submission Portal                     |https://portal.gdc.cancer.gov/submission/login?next=%2Fsubmission%2Fundefined|
+  |Publications                               |https://gdc.cancer.gov/about-data/publications?utm_source=dataportal&utm_medium=apps|
 * Navigate to "Manage Sets" from "Header" "section"
 * These Apps links should take the user to correct page in the same tab
-  |button_text                                |text_on_expected_page                                          |
+  |button_text                                |url_expected_on_new_tab                                        |
   |-------------------------------------------|---------------------------------------------------------------|
   |Data Portal                                |A repository and computational platform for cancer             |
 

--- a/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Header - Links
 Test-case       : PEAR-2518
 
-tags: gdc-data-portal-v2, regression, header, navigation
+tags: gdc-data-portal-v2, regression, header, navigation, new_tab
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/header/link_checking.spec
@@ -5,7 +5,7 @@ Owner		        : GDC QA
 Description		  : Test Header - Links
 Test-case       : PEAR-2518
 
-tags: gdc-data-portal-v2, regression, header, navigation, new_tab
+tags: gdc-data-portal-v2, regression, header, navigation
 
 ## Navigate to Home Page
 * On GDC Data Portal V2 app

--- a/holmes-py/specs/gdc_data_portal_v2/home_page/navigation.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/home_page/navigation.spec
@@ -12,11 +12,11 @@ tags: gdc-data-portal-v2, regression, home-page, navigation
 
 ## Validate Navigation Buttons - different tab
 * These links on the "Home Page" should take the user to correct page in a new tab
-  |button_text                                |text_on_expected_page                                  |
+  |button_text                                |url_expected_on_new_tab                                |
   |-------------------------------------------|-------------------------------------------------------|
-  |Learn More About Our Harmonization Process |GDC for processing genomic data                        |
-  |Contact Us                                 |For assistance with GDC query                          |
-  |Data Release                               |A complete list of files for DR27.0                    |
+  |Learn More About Our Harmonization Process |https://gdc.cancer.gov/about-data/gdc-data-processing  |
+  |Contact Us                                 |https://gdc.cancer.gov/support                         |
+  |Data Release                               |https://docs.gdc.cancer.gov/Data/Release_Notes/Data_Release_Notes/|
 
 ## Validate Navigation Buttons - same tab
 * These links should take the user to correct page in the same tab

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Validate Summary Table and External Reference Table
 Test-Case       : PEAR-2367
 
-tags: gdc-data-portal-v2, regression, mutation-summary
+tags: gdc-data-portal-v2, regression, mutation-summary, new_tab
 
 ## Navigate to Mutation Summary Page: chr7:g.140753336A>T
 * On GDC Data Portal V2 app
@@ -49,5 +49,5 @@ tags: gdc-data-portal-v2, regression, mutation-summary
     |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
     |1    |2      |https://www.ncbi.nlm.nih.gov/snp/rs113488022                         |
-    |2    |2      |https://cancer.sanger.ac.uk/cosmic/                                  |
+    |2    |2      |http*://cancer.sanger.ac.uk/cosmic/                                  |
     |3    |2      |https://civicdb.org/variants/12                                      |

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
@@ -49,5 +49,5 @@ tags: gdc-data-portal-v2, regression, mutation-summary
     |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
     |1    |2      |https://www.ncbi.nlm.nih.gov/snp/rs113488022                         |
-    |2    |2      |https://cancer.sanger.ac.uk/cosmic/login                             |
+    |2    |2      |https://cancer.sanger.ac.uk/cosmic/                                  |
     |3    |2      |https://civicdb.org/variants/12                                      |

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
@@ -46,8 +46,8 @@ tags: gdc-data-portal-v2, regression, mutation-summary
     |12                                     |3    |2      |
 
 * In table "External References Mutation Summary" these selections should take the user to correct page in a new tab
-    |row  |column |expected_text                                                        |
+    |row  |column |url_expected_on_new_tab                                              |
     |-----|-------|---------------------------------------------------------------------|
-    |1    |2      |All alleles are reported in the Forward orientation.                 |
-    |2    |2      |In order to access COSMIC data                                       |
-    |3    |2      |1                                                                    |
+    |1    |2      |https://www.ncbi.nlm.nih.gov/snp/rs113488022                         |
+    |2    |2      |https://cancer.sanger.ac.uk/cosmic/login                             |
+    |3    |2      |https://civicdb.org/variants/12                                      |

--- a/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/mutation_summary/summary_external_references_tables.spec
@@ -5,7 +5,7 @@ Owner		    : GDC QA
 Description		: Validate Summary Table and External Reference Table
 Test-Case       : PEAR-2367
 
-tags: gdc-data-portal-v2, regression, mutation-summary, new_tab
+tags: gdc-data-portal-v2, regression, mutation-summary
 
 ## Navigate to Mutation Summary Page: chr7:g.140753336A>T
 * On GDC Data Portal V2 app

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -68,11 +68,12 @@ class AnalysisCenterPage(BasePage):
     def get_analysis_tool_cases_count(self, tool_name):
         """Returns case count on given analysis tool"""
         self.wait_for_loading_spinners_to_detach()
+        self.wait_for_loading_spinners_to_detach()
         locator = AnalysisCenterLocators.TEXT_CASES_COUNT_ON_TOOL_CARD(tool_name)
         # If we get " " or " Cases" on return, that means the analysis card is still loading information. We wait until
         # it fully loads or 10 seconds elapses before returning text.
         retry_counter = 0
-        while ((self.get_text(locator) == " ") or (self.get_text(locator) == " Cases")):
+        while ((self.get_text(locator) == " ") or (self.get_text(locator) == "") or (self.get_text(locator) == " Cases")):
             time.sleep(1)
             retry_counter = retry_counter + 1
             if retry_counter >= 10:

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -1264,7 +1264,12 @@ def name_cohort(cohort_name: str):
 def click_nav_item_check_text_in_new_tab(page_name: str, table):
     """
     Performs an action to open a new tab.
-    Then, checks for expected text on the new tab to indicate it opened correctly.
+    Then, checks url in new tab to assert it opened correctly.
+
+    :param page_name: What area of the data portal is the button located. See list of options
+    located in function 'perform_action_handle_new_tab'.
+    :param v[0]: Name of button to click.
+    :param v[1]: Expected URL in new tab.
     """
 
     # Banners can interfere with this test. Dismiss any banner before beginning.
@@ -1272,12 +1277,11 @@ def click_nav_item_check_text_in_new_tab(page_name: str, table):
         APP.shared.click_button_with_displayed_text_name("Dismiss")
     for k, v in enumerate(table):
         new_tab = APP.shared.perform_action_handle_new_tab(page_name, v[0])
-        is_text_visible = APP.shared.is_text_visible_on_new_tab(new_tab, v[1])
+        is_url_correct = APP.shared.is_url_correct_on_new_tab(new_tab, v[1])
         new_tab.close()
-        time.sleep(0.4)
         assert (
-            is_text_visible
-        ), f"After click on '{v[0]}', the expected text '{v[1]}' in NOT present"
+            is_url_correct
+        ), f"After click on '{v[0]}', the expected url '{v[1]}' in NOT present"
 
 
 @step(
@@ -1286,22 +1290,22 @@ def click_nav_item_check_text_in_new_tab(page_name: str, table):
 def click_table_by_row_column_check_text_in_new_tab(table_name: str, table):
     """
     click_table_by_row_column_check_text_in_new_tab clicks in a table to open a new tab,
-    and validates the text present in the new tab.
+    and checks url in new tab to assert it opened correctly.
 
     :param table_name: Specifies what table to click on.
     :param v[0]: Row number to click.
     :param v[1]: Column number to click.
-    :param v[2]: Text to check.
+    :param v[2]: Expected URL in new tab.
     """
     # Banners can interfere with this test. Dismiss any banner before beginning.
     if APP.shared.is_text_present("Dismiss"):
         APP.shared.click_button_with_displayed_text_name("Dismiss")
     for k, v in enumerate(table):
         new_tab = APP.shared.click_in_table_handle_new_tab(table_name, v[0], v[1])
-        is_text_visible = APP.shared.is_text_visible_on_new_tab(new_tab, v[2])
+        is_url_correct = APP.shared.is_url_correct_on_new_tab(new_tab, v[2])
         assert (
-            is_text_visible
-        ), f"After click in table '{table_name}', row: '{v[0]}' and column: '{v[1]}' the expected text '{v[2]}' in NOT present"
+            is_url_correct
+        ), f"After click in table '{table_name}', row: '{v[0]}' and column: '{v[1]}' the expected url '{v[2]}' in NOT present"
         new_tab.close()
         time.sleep(0.4)
 

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/header_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/header_steps.py
@@ -14,17 +14,17 @@ def start_app():
 def click_apps_link_new_tab(table):
     """
     Clicks open the Apps Menu in upper-right corner of header, and clicks on specified link in menu.
-    Then, checks for expected text on the new tab to indicate it opened correctly.
+    Then, checks url in new tab to assert it opened correctly.
     """
     for k, v in enumerate(table):
         APP.header_section.click_apps_menu()
         new_tab = APP.shared.perform_action_handle_new_tab("Header", v[0])
-        is_text_visible = APP.shared.is_text_visible_on_new_tab(new_tab, v[1])
+        is_url_correct = APP.shared.is_url_correct_on_new_tab(new_tab, v[1])
         new_tab.close()
         time.sleep(0.4)
         assert (
-            is_text_visible
-        ), f"After click on '{v[0]}', the expected text '{v[1]}' in NOT present"
+            is_url_correct
+        ), f"After click on '{v[0]}', the expected URL '{v[1]}' in NOT present"
 
 @step("These Apps links should take the user to correct page in the same tab <table>")
 def click_apps_link_same_tab(table):

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -1002,7 +1002,6 @@ class BasePage:
         :param url_to_check: The url to validate is on the new tab.
         """
         try:
-            print(new_tab.url)
             url_to_check = url_to_check + "**"
             new_tab.wait_for_url(url_to_check,timeout=90000)
         except:

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -994,19 +994,17 @@ class BasePage:
         WebDriver.set_tab_viewport_size(new_tab)
         return new_tab
 
-    def is_text_visible_on_new_tab(self, new_tab, text_to_check):
+    def is_url_correct_on_new_tab(self, new_tab, url_to_check):
         """
-        is_text_visible_on_new_tab checks for text on a given tab page.
+        is_url_correct_on_new_tab checks for url on given tab page.
 
         :param new_tab: The tab page to be checked.
-        :param text_to_check: The <p> text to be searched for.
+        :param url_to_check: The url to validate is on the new tab.
         """
-        # Some sites check to see if you are a human before the page loads. This mouse event is an action
-        # that triggers the rest of the page loading.
-        new_tab.mouse.up()
-        expected_text_locator = GenericLocators.TEXT_IN_PARAGRAPH(text_to_check)
         try:
-            new_tab.locator(expected_text_locator).wait_for(state="visible",timeout=75000)
+            print(new_tab.url)
+            url_to_check = url_to_check + "**"
+            new_tab.wait_for_url(url_to_check,timeout=90000)
         except:
             return False
         return True


### PR DESCRIPTION
## Description
- Updated new tab tests to assert URLs. This allows every test to pass in Gitlab

Validation: 
- Link in gitlab to show every test can pass now: https://gitlab.datacommons.io/nci-gdc/front-end/gdc-frontend-framework/-/jobs/1010610