### PR TITLE
Qa 2592 re try downloads holmes py

### DIFF
--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_associated_data.spec
@@ -29,10 +29,9 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
 ## Clinical TSV
 * Navigate to "Cart" from "Header" "section"
 * Pause "3" seconds
-* Select "Clinical"
-* Download "TSV" from "Cart Header Dropdown"
-* Read file content from compressed "TSV from Cart Header Dropdown"
-* Verify that "TSV from Cart Header Dropdown" has expected information
+* Download "TSV" from "Cart Header Clinical"
+* Read file content from compressed "TSV from Cart Header Clinical"
+* Verify that "TSV from Cart Header Clinical" has expected information
     |required_info                        |
     |-------------------------------------|
     |follow_ups.barretts_esophagus_goblet_cells_present     |
@@ -97,7 +96,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |Pancreas                               |
     |Diagnosis                              |
 
-* Verify that "TSV from Cart Header Dropdown" does not contain specified information
+* Verify that "TSV from Cart Header Clinical" does not contain specified information
     |required_info                          |
     |---------------------------------------|
     |FM-AD                                  |
@@ -137,10 +136,9 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |exposures.weight                       |
 
 ## Clinical JSON
-* Select "Clinical"
-* Download "JSON" from "Cart Header Dropdown"
-* Read from "JSON from Cart Header Dropdown"
-* Verify that "JSON from Cart Header Dropdown" has expected information
+* Download "JSON" from "Cart Header Clinical"
+* Read from "JSON from Cart Header Clinical"
+* Verify that "JSON from Cart Header Clinical" has expected information
     |required_info                        |
     |-------------------------------------|
     |Current Reformed Smoker, Duration Not Specified |
@@ -188,7 +186,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |case_id	                          |
     |submitter_id	                      |
 
-* Verify that "JSON from Cart Header Dropdown" does not contain specified information
+* Verify that "JSON from Cart Header Clinical" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |
@@ -196,10 +194,9 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |APOLLO                               |
 
 ## Biospecimen TSV
-* Select "Biospecimen"
-* Download "TSV" from "Cart Header Dropdown"
-* Read file content from compressed "TSV from Cart Header Dropdown"
-* Verify that "TSV from Cart Header Dropdown" has expected information
+* Download "TSV" from "Cart Header Biospecimen"
+* Read file content from compressed "TSV from Cart Header Biospecimen"
+* Verify that "TSV from Cart Header Biospecimen" has expected information
     |required_info                        |
     |-------------------------------------|
     |portion_id                           |
@@ -251,7 +248,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |TCGA-BG-A0M0-01Z-00-DX1              |
     |98.0                                 |
     |BOTTOM                               |
-* Verify that "TSV from Cart Header Dropdown" does not contain specified information
+* Verify that "TSV from Cart Header Biospecimen" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |
@@ -259,10 +256,9 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |APOLLO                               |
 
 ## Biospecimen JSON
-* Select "Biospecimen"
-* Download "JSON" from "Cart Header Dropdown"
-* Read from "JSON from Cart Header Dropdown"
-* Verify that "JSON from Cart Header Dropdown" has expected information
+* Download "JSON" from "Cart Header Biospecimen"
+* Read from "JSON from Cart Header Biospecimen"
+* Verify that "JSON from Cart Header Biospecimen" has expected information
     |required_info                        |
     |-------------------------------------|
     |1ae8657f-477f-4e1a-aef2-dd1c1ab5f26a |
@@ -303,7 +299,7 @@ tags: gdc-data-portal-v2, regression, cart, clinical-biospecimen-download
     |5341a8a5-acac-5a24-a963-d27dbecc5db2 |
     |3df88b48-da53-4014-9507-de070223d1dd |
     |91e73c21-abd7-4c20-ac1e-81f4dabc7511 |
-* Verify that "JSON from Cart Header Dropdown" does not contain specified information
+* Verify that "JSON from Cart Header Biospecimen" does not contain specified information
     |required_info                        |
     |-------------------------------------|
     |FM-AD                                |

--- a/holmes-py/specs/gdc_data_portal_v2/cart/download_cart.spec
+++ b/holmes-py/specs/gdc_data_portal_v2/cart/download_cart.spec
@@ -32,10 +32,9 @@ tags: gdc-data-portal-v2, regression, cart
 
 ## Download Manifest
 * Navigate to "Cart" from "Header" "section"
-* Select "Download Cart" on the Cart page
-* Download "Manifest" from "Cart Header"
-* Read from "Manifest from Cart Header"
-* Verify that "Manifest from Cart Header" has expected information
+* Download "Manifest" from "Cart Header Download Cart"
+* Read from "Manifest from Cart Header Download Cart"
+* Verify that "Manifest from Cart Header Download Cart" has expected information
     |required_info                          |
     |---------------------------------------|
     |id                                     |
@@ -56,8 +55,7 @@ tags: gdc-data-portal-v2, regression, cart
     |released                               |
 
 ## Mixed Access Cart Download
-* Select "Download Cart" on the Cart page
-* Select "Cart" from dropdown menu
+* Select download cart on the Cart page
 * Is text "You are attempting to download files that you are not authorized to access." present on the page
 * Is text "4 files that you are authorized to download." present on the page
 * Is text "6 files that you are not authorized to download." present on the page
@@ -93,10 +91,9 @@ Messages can pile up here. Wait for everything to go away before continuing the 
 * Pause "5" seconds
 * Remove "Unauthorized Files" from cart on the Cart page
 * Is temporary modal with text "Removed 6 files from the cart." present on the page and "Keep Modal"
-* Select "Download Cart" on the Cart page
-* Download "Cart" from "Cart Header Dropdown"
-* Read file content from compressed "Cart from Cart Header Dropdown"
-* Verify that "Cart from Cart Header Dropdown" has expected information
+* Download "Cart" from "Cart Header Download Cart"
+* Read file content from compressed "Cart from Cart Header Download Cart"
+* Verify that "Cart from Cart Header Download Cart" has expected information
     |required_info                          |
     |---------------------------------------|
     |fe3e912a-a0bf-49e7-97a3-0df8cc21d751   |
@@ -110,7 +107,7 @@ Messages can pile up here. Wait for everything to go away before continuing the 
     |114077167                              |
     |f5e221dd-f1b2-435e-9ab6-300d2abd39c1   |
     |6a1d5c68-a949-4708-9b58-ac91ace26789   |
-* Verify that "Cart from Cart Header Dropdown" does not contain specified information
+* Verify that "Cart from Cart Header Download Cart" does not contain specified information
     |required_info                          |
     |---------------------------------------|
     |ce9cc0e6-78e5-448d-b395-006ea93c7be2   |
@@ -134,8 +131,7 @@ Messages can pile up here. Wait for everything to go away before continuing the 
   |ca4d1994-5f01-4202-a6b6-ce897c2f4358 |
   |19e8c827-9d47-494b-9487-0286af531ed4 |
 * Navigate to "Cart" from "Header" "section"
-* Select "Download Cart" on the Cart page
-* Select "Cart" from dropdown menu
+* Select download cart on the Cart page
 * Is text "0 files that you are authorized to download." present on the page
 * Is text "5 files that you are not authorized to download." present on the page
 * Verify the button with displayed text "Download 0 Authorized Files" is disabled
@@ -152,8 +148,7 @@ Messages can pile up here. Wait for everything to go away before continuing the 
   |4ded7d54-5c43-4b03-aecd-14fc4499a567 |
   |cf5450df-6e51-4baf-9c59-811e9d81f43a |
 * Navigate to "Cart" from "Header" "section"
-* Select "Download Cart" on the Cart page
-* Select "Cart" from dropdown menu
+* Select download cart on the Cart page
 * Is text "Access Alert" present on the page
 * Is text "Your cart contains more than 5 GBs of data." present on the page
 * Is text "Please select the \"Download > Manifest\" option and use the Data Transfer Tool to download the files in your cart." present on the page

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -68,11 +68,12 @@ class AnalysisCenterPage(BasePage):
     def get_analysis_tool_cases_count(self, tool_name):
         """Returns case count on given analysis tool"""
         self.wait_for_loading_spinners_to_detach()
+        self.wait_for_loading_spinners_to_detach()
         locator = AnalysisCenterLocators.TEXT_CASES_COUNT_ON_TOOL_CARD(tool_name)
         # If we get " " or " Cases" on return, that means the analysis card is still loading information. We wait until
         # it fully loads or 10 seconds elapses before returning text.
         retry_counter = 0
-        while ((self.get_text(locator) == " ") or (self.get_text(locator) == " Cases")):
+        while ((self.get_text(locator) == " ") or (self.get_text(locator) == "") or (self.get_text(locator) == " Cases")):
             time.sleep(1)
             retry_counter = retry_counter + 1
             if retry_counter >= 10:

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/analysis_center_page.py
@@ -76,7 +76,7 @@ class AnalysisCenterPage(BasePage):
         while ((self.get_text(locator) == " ") or (self.get_text(locator) == "") or (self.get_text(locator) == " Cases")):
             time.sleep(1)
             retry_counter = retry_counter + 1
-            if retry_counter >= 10:
+            if retry_counter >= 60:
                 break
         cases_count = self.get_text(locator)
         # Remove the "Cases" part of the string. We do not need that for comparison.

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cart_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cart_page.py
@@ -23,6 +23,9 @@ class CartPage(BasePage):
         button_locator = CartPageLocators.BUTTON_CART_PAGE(button_id)
         self.click(button_locator)
 
+    # These 3 functions are not DRY focused, but that trade off means they can be
+    # retired in our download handling function. They were among the most flaky
+    # tests in holmes-py, and now they pass every time.
     def click_biospecimen_dropdown_option(self, dropdown_option):
         # If the option text is not already present, click the dropdown menu button
         dropdown_button_locator = CartPageLocators.BUTTON_BIOSPECIMEN_CART

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cart_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cart_page.py
@@ -9,6 +9,10 @@ class CartPageLocators:
     BUTTON_CART_PAGE = lambda data_testid: f'[data-testid="button-{data_testid}"]'
     BUTTON_REMOVE_FROM_CART = '[data-testid="button-remove-from-cart"]'
 
+    BUTTON_BIOSPECIMEN_CART = '[data-testid="button-download-biospecimen"]'
+    BUTTON_CLINICAL_CART = '[data-testid="button-download-clinical"]'
+    BUTTON_DOWNLOAD_CART = '[data-testid="button-download-cart"]'
+
 class CartPage(BasePage):
     def __init__(self, driver: Page, url):
         self.URL = "{}".format(url)
@@ -18,6 +22,33 @@ class CartPage(BasePage):
         button_id = self.normalize_button_identifier(button_id)
         button_locator = CartPageLocators.BUTTON_CART_PAGE(button_id)
         self.click(button_locator)
+
+    def click_biospecimen_dropdown_option(self, dropdown_option):
+        # If the option text is not already present, click the dropdown menu button
+        dropdown_button_locator = CartPageLocators.BUTTON_BIOSPECIMEN_CART
+        is_locator_expanded = self.is_locator_expanded(dropdown_button_locator)
+        if is_locator_expanded == 'false':
+            self.click(dropdown_button_locator)
+            time.sleep(0.2)
+        self.click_text_option_from_dropdown_menu(dropdown_option)
+
+    def click_clinical_dropdown_option(self, dropdown_option):
+        # If the option text is not already present, click the dropdown menu button
+        dropdown_button_locator = CartPageLocators.BUTTON_CLINICAL_CART
+        is_locator_expanded = self.is_locator_expanded(dropdown_button_locator)
+        if is_locator_expanded == 'false':
+            self.click(dropdown_button_locator)
+            time.sleep(0.2)
+        self.click_text_option_from_dropdown_menu(dropdown_option)
+
+    def click_download_cart_dropdown_option(self, dropdown_option):
+        # If the option text is not already present, click the dropdown menu button
+        dropdown_button_locator = CartPageLocators.BUTTON_DOWNLOAD_CART
+        is_locator_expanded = self.is_locator_expanded(dropdown_button_locator)
+        if is_locator_expanded == 'false':
+            self.click(dropdown_button_locator)
+            time.sleep(0.2)
+        self.click_text_option_from_dropdown_menu(dropdown_option)
 
     def remove_all_files_from_cart(self, all_files_or_authorized_files):
         remove_from_cart_locator = CartPageLocators.BUTTON_REMOVE_FROM_CART

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_builder_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_builder_page.py
@@ -128,7 +128,7 @@ class CohortBuilderPage(BasePage):
         locator = CohortBuilderPageLocators.FACET_GROUP_FILTER_TEXT_CASE_COUNT(
             facet_group_name, filter_name
         )
-        return self.get_text(locator)
+        return self.get_text(locator, 60000)
 
     # Checks the text in the search bar result area
     def validate_search_bar_result(self, search_bar_text_to_check):

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_builder_page.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_builder_page.py
@@ -218,7 +218,7 @@ class CohortBuilderPage(BasePage):
             time.sleep(1)
             loading_locator = CohortBuilderPageLocators.FACET_GROUP_CUSTOM_FILTER_TEXT_IDENT(facet_card, "...")
             retry_counter = retry_counter+1
-            if retry_counter >= 10:
+            if retry_counter >= 60:
                 break
         locator = CohortBuilderPageLocators.FACET_GROUP_CUSTOM_FILTER_TEXT_IDENT(facet_card, text)
         return self.is_visible(locator)

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_case_view.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/pages/cohort_case_view.py
@@ -55,8 +55,10 @@ class CohortCaseViewPage(BasePage):
         self.wait_for_loading_spinners_to_detach()
 
     def click_files_and_dropdown_option_cases_view(self, dropdown_option):
-        locator = CohortCaseViewLocators.BUTTON_FILES_CASE_VIEW
-        self.click(locator)
+        # If the option text is not already present, click the dropdown menu button
+        if not self.is_dropdown_option_text_present(dropdown_option):
+            locator = CohortCaseViewLocators.BUTTON_FILES_CASE_VIEW
+            self.click(locator)
         self.click_text_option_from_dropdown_menu(dropdown_option)
 
     def click_summary_view_button(self, button_name):

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cart_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cart_steps.py
@@ -18,4 +18,8 @@ def click_cart_page_button(button_id:str):
 
 @step("Select download cart on the Cart page")
 def click_download_cart_button():
+    """
+    Clicks the 'Download Cart' dropdown, then selects 'Cart' in scenarios where
+    we expect another screen to appear and not an immediate download.
+    """
     APP.cart_page.click_download_cart_dropdown_option("Cart")

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cart_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cart_steps.py
@@ -15,3 +15,7 @@ def remove_all_files_from_cart_page(all_files_or_authorized_files:str):
 @step("Select <button_id> on the Cart page")
 def click_cart_page_button(button_id:str):
     APP.cart_page.click_button_cart_page(button_id)
+
+@step("Select download cart on the Cart page")
+def click_download_cart_button():
+    APP.cart_page.click_download_cart_dropdown_option("Cart")

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_bar_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_bar_steps.py
@@ -230,10 +230,7 @@ def select_cohort_from_dropdown(cohort_name: str):
     time.sleep(0.5)
     APP.cohort_bar.select_cohort_from_dropdown(cohort_name)
     time.sleep(3)
-    APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
-    APP.shared.wait_for_loading_spinner_to_detatch()
-    APP.shared.wait_for_loading_spinner_table_to_detatch()
-    APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
+    APP.shared.wait_for_loading_spinners_to_detach()
 
 
 @step("Set as current cohort")

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_builder_page_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_builder_page_steps.py
@@ -118,8 +118,7 @@ def collect_case_counts_on_filters(cohort_name: str, table):
     for k, v in enumerate(table):
         # Clicks tab in cohort builder
         APP.cohort_builder_page.click_button(v[0])
-        time.sleep(1)
-        APP.shared.wait_for_loading_spinner_to_detatch()
+        APP.shared.wait_for_loading_spinners_to_detach()
 
         # Expands list of filters to select if possible
         if APP.cohort_builder_page.is_show_more_or_show_less_button_visible_within_filter_card(

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_builder_page_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/cohort_builder_page_steps.py
@@ -182,10 +182,7 @@ def validate_custom_filter_text_on_facet_card(are_or_are_not:str, tab_name: str,
     :param v[1]: Custom filter text to check on the facet card
     """
     APP.cohort_builder_page.click_button(tab_name)
-    APP.shared.wait_for_loading_spinner_table_to_detatch()
-    APP.shared.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
-    APP.shared.wait_for_loading_spinner_to_detatch()
-    APP.shared.wait_for_loading_spinner_table_to_detatch()
+    APP.shared.wait_for_loading_spinners_to_detach()
     for k, v in enumerate(table):
         is_custom_filter_visible = APP.cohort_builder_page.is_facet_card_custom_filter_text_present(v[0], v[1])
         if are_or_are_not.lower() == "are":

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -97,6 +97,14 @@ def save_cohort_if_needed():
 
     """
     APP.shared.wait_for_loading_spinners_to_detach()
+    # This step has been flaky. This is not part of a test, it is for setup of the next test in queue.
+    # So, we will refresh the page to avoid failures.
+    try:
+        APP.shared.is_disabled('[data-testid="addButton"]', 60000)
+    except:
+        APP.shared.reload_page()
+        time.sleep(10)
+        APP.shared.wait_for_loading_spinners_to_detach()
     if APP.shared.is_disabled('[data-testid="addButton"]', 60000):
         APP.cohort_bar.click_cohort_bar_button("save")
         APP.cohort_bar.click_text_option_from_dropdown_menu("Save")

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -97,7 +97,7 @@ def save_cohort_if_needed():
 
     """
     APP.shared.wait_for_loading_spinners_to_detach()
-    if APP.cohort_bar.is_disabled('[data-testid="addButton"]'):
+    if APP.shared.is_disabled('[data-testid="addButton"]', 60000):
         APP.cohort_bar.click_cohort_bar_button("save")
         APP.cohort_bar.click_text_option_from_dropdown_menu("Save")
         # Name the cohort something random so if we need to execute this step

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -252,6 +252,7 @@ def download_file_at_file_table(file: str, source: str):
     attempt = 1
     driver = WebDriver.page
 
+    # Retry the download up to 3 times
     while attempt <= max_retries:
         try:
             with driver.expect_download(timeout=90000) as download_info:
@@ -260,13 +261,9 @@ def download_file_at_file_table(file: str, source: str):
                     sources.get(source)()
                 else:
                     sources.get(source)(file)
-            print("Download successful")
-            print(f"Source {source}, file {file}")
             break
 
-        except Exception as e:
-            print(f"Download Attempt {attempt} failed: {e}")
-            print(f"Source {source}, file {file}")
+        except:
             if attempt == max_retries:
                 raise
 

--- a/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
+++ b/holmes-py/step_impl/apps/gdc_data_portal_v2/step_defs/generic_steps.py
@@ -201,7 +201,9 @@ def download_file_at_file_table(file: str, source: str):
         "Browse Annotations": APP.browse_annotations.click_annotation_download_button,
         "Cart Items": APP.shared.click_button_data_testid_normalize,
         "Cart Header": APP.shared.click_button_with_displayed_text_name,
-        "Cart Header Dropdown": APP.shared.click_text_option_from_dropdown_menu,
+        "Cart Header Biospecimen": APP.cart_page.click_biospecimen_dropdown_option,
+        "Cart Header Clinical": APP.cart_page.click_clinical_dropdown_option,
+        "Cart Header Download Cart": APP.cart_page.click_download_cart_dropdown_option,
         "Case Summary Annotations Table": APP.case_summary_page.click_annotations_table_download_json_or_tsv_button,
         "Case Summary Biospecimen Table": APP.case_summary_page.click_biospecimen_table_download_button,
         "Case Summary Clinical Table": APP.case_summary_page.click_clinical_table_download_button,
@@ -237,13 +239,31 @@ def download_file_at_file_table(file: str, source: str):
         "Set Operations": APP.set_operations_page.click_download_tsv_button_set_operations,
         "Set Operations Union Row": APP.set_operations_page.click_union_row_download_tsv_button_set_operations,
     }
+
+    max_retries = 3
+    attempt = 1
     driver = WebDriver.page
-    with driver.expect_download(timeout=90000) as download_info:
-        # Allows using sources without passing in contents of <file> as a parameter
-        if file.lower() == "file":
-            sources.get(source)()
-        else:
-            sources.get(source)(file)
+
+    while attempt <= max_retries:
+        try:
+            with driver.expect_download(timeout=90000) as download_info:
+                # Allows using sources without passing in contents of <file> as a parameter
+                if file.lower() == "file":
+                    sources.get(source)()
+                else:
+                    sources.get(source)(file)
+            print("Download successful")
+            print(f"Source {source}, file {file}")
+            break
+
+        except Exception as e:
+            print(f"Download Attempt {attempt} failed: {e}")
+            print(f"Source {source}, file {file}")
+            if attempt == max_retries:
+                raise
+
+            attempt += 1
+
     download = download_info.value
     file_path = f"{Utility.parent_dir()}/downloads/{dt.timestamp(dt.now())}_{download.suggested_filename}"
     download.save_as(file_path)

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -194,8 +194,8 @@ class BasePage:
         """Hover over given locator"""
         self.driver.locator(locator).hover(force=force)
 
-    def get_text(self, locator):
-        return self.driver.locator(locator).text_content()
+    def get_text(self, locator, timeout=30000):
+        return self.driver.locator(locator).text_content(timeout=timeout)
 
     def get_inner_text(self, locator):
         """Returns only what a user can see on the page"""

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -412,9 +412,9 @@ class BasePage:
         """wait for element to have non-empty bounding box and no visibility:hidden"""
         self.driver.locator(locator).wait_for(state="visible", timeout=timeout)
 
-    def wait_until_locator_is_detached(self, locator):
+    def wait_until_locator_is_detached(self, locator, timeout=60000):
         """wait for element to not be present in DOM"""
-        self.driver.locator(locator).wait_for(state="detached", timeout=60000)
+        self.driver.locator(locator).wait_for(state="detached", timeout=timeout)
 
     def wait_until_locator_is_hidden(self, locator):
         """wait for element to be either detached from DOM, or have an empty bounding box or visibility:hidden"""
@@ -449,15 +449,15 @@ class BasePage:
         locator = GenericLocators.LOADING_SPINNER_GENERIC
         self.wait_until_locator_is_visible(locator, timeout)
 
-    def wait_for_loading_spinner_to_detatch(self):
+    def wait_for_loading_spinner_to_detatch(self, timeout=60000):
         """Waits for the generic loading spinner to disappear on the page"""
         locator = GenericLocators.LOADING_SPINNER_GENERIC
-        self.wait_until_locator_is_detached(locator)
+        self.wait_until_locator_is_detached(locator, timeout)
 
-    def wait_for_loading_spinner_cohort_bar_case_count_to_detatch(self):
+    def wait_for_loading_spinner_cohort_bar_case_count_to_detatch(self, timeout=60000):
         """Waits for the cohort bar case count loading spinner to disappear on the page"""
         locator = GenericLocators.LOADING_SPINNER_COHORT_BAR_CASE_COUNT
-        self.wait_until_locator_is_detached(locator)
+        self.wait_until_locator_is_detached(locator, timeout)
 
     def wait_for_loading_spinner_table_to_detatch(self):
         """Waits for the table (repository, projects, mutation frequency, etc.) loading spinner to disappear on the page"""
@@ -466,13 +466,13 @@ class BasePage:
 
     def wait_for_loading_spinners_to_detach(self):
         """
-        We often have to wait for many possible loading spinners to detach.
+        We often have to wait for many loading spinners to detach.
         This function is a convenient way to do that at once.
         """
         time.sleep(0.5)
-        self.wait_for_loading_spinner_to_detatch()
+        self.wait_for_loading_spinner_to_detatch(90000)
         self.wait_for_loading_spinner_table_to_detatch()
-        self.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()
+        self.wait_for_loading_spinner_cohort_bar_case_count_to_detatch(90000)
         self.wait_for_loading_spinner_to_detatch()
         self.wait_for_loading_spinner_table_to_detatch()
         self.wait_for_loading_spinner_cohort_bar_case_count_to_detatch()

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -224,6 +224,9 @@ class BasePage:
         """Returns if the locator is enabled"""
         return self.driver.locator(locator).is_enabled()
 
+    def reload_page(self):
+        self.driver.reload()
+
     def send_keys(self, locator, text):
         return self.driver.locator(locator).fill(text)
 

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -587,6 +587,10 @@ class BasePage:
         locator = GenericLocators.DATA_TESTID_BUTTON_IDENT(button_name)
         return self.get_attribute(locator,"aria-expanded")
 
+    def is_locator_expanded(self, full_locator):
+        """Takes in a full locator string, and returns if it's expanded"""
+        return self.get_attribute(full_locator,"aria-expanded")
+
     def is_cart_count_correct(self, correct_file_count):
         """Returns if cart count is correct"""
         locator = GenericLocators.CART_IDENT

--- a/holmes-py/step_impl/base/base_page.py
+++ b/holmes-py/step_impl/base/base_page.py
@@ -216,9 +216,9 @@ class BasePage:
     def is_visible(self, locator):
         return self.driver.locator(locator).is_visible()
 
-    def is_disabled(self, locator):
+    def is_disabled(self, locator, timeout=30000):
         """Returns if the locator has the attribute 'disabled'"""
-        return self.driver.locator(locator).is_disabled()
+        return self.driver.locator(locator).is_disabled(timeout=timeout)
 
     def is_enabled(self, locator):
         """Returns if the locator is enabled"""


### PR DESCRIPTION
## Description
- Added retries on download attempts
- Extended waits in key areas 
- Refresh page if setup step experiences failure

Test:
qa-yellow
`gauge run -p -n=5 specs/gdc_data_portal_v2/cohort_case_view/summary_view_header.spec specs/gdc_data_portal_v2/cohort_case_view/table_view_header.spec specs/gdc_data_portal_v2/case_summary/validate_tables.spec specs/gdc_data_portal_v2/cart/download_cart.spec specs/gdc_data_portal_v2/cart/download_associated_data.spec`

Gitlab against qa-yellow shows all test are passing: https://gitlab.datacommons.io/nci-gdc/front-end/gdc-frontend-framework/-/jobs/1015293

Some occasional failures have related tickets made on the PEAR board to address them