### PR TITLE
update proteinpaint-client to 2.181.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7432,9 +7432,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.180.1",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.180.1.tgz",
-      "integrity": "sha512-JnORD81YxYu//qElji38DwZxoHN9surF48eKaf+OZjhbDg2crebRnQKRw+KITt5YXlyVsbl41QyJJI0qocibPQ==",
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.181.0.tgz",
+      "integrity": "sha512-Bwe2RFG4LfCkVN+61YIcVUwHdNU5J6UH8aYBlrbajR+1n2AwwEuYoLF2HjK9TF9uT/Y+IR/D9RwQuxY1psrcyQ==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -31607,7 +31607,7 @@
         "@mantine/hooks": "8.3.9",
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^10.0.3",
-        "@sjcrh/proteinpaint-client": "2.180.1",
+        "@sjcrh/proteinpaint-client": "2.181.0",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/next-env.d.ts
+++ b/packages/portal-proto/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/portal-proto/next-env.d.ts
+++ b/packages/portal-proto/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/hooks": "8.3.9",
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^10.0.3",
-    "@sjcrh/proteinpaint-client": "2.180.1",
+    "@sjcrh/proteinpaint-client": "2.181.0",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes:
- https://gdc-ctds.atlassian.net/browse/SV-2735
- https://gdc-ctds.atlassian.net/browse/SV-2753
- https://gdc-ctds.atlassian.net/browse/SV-2754
- https://gdc-ctds.atlassian.net/browse/SV-2765
- https://gdc-ctds.atlassian.net/browse/SV-2770
- https://gdc-ctds.atlassian.net/browse/SV-2780

PP changelog
- fix the launching of genome browser lollipop from a disco plot label click
- always set the tooltip top position instead of bottom to make it more reliable when an embedder's body position=relative
- improved logic when hiding a tooltip after the first clickable element is blurred
- prevent the unexpected closure of the parent GenesetEdit menu while clicking on a child MSigDb menu
- list the correct samples when selecting a violin area with a numeric overlay
- filter and sort GDC diagnoses entries to prioritize diagnosis_is_primary_disease entries
- hide CNV legend for GDC ssm lollipop

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
