### PR TITLE
Fix for UUID issue in qa-int

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 .DS_Store
 docs/
 .nx
+packages/*/next-env.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -30017,14 +30017,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -31229,15 +31228,6 @@
         "node": ">=14.17"
       }
     },
-    "packages/core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "packages/enclave-portal": {
       "version": "2.19.0",
       "license": "Apache-2",
@@ -31575,15 +31565,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "packages/portal-proto/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "packages/sapien": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "glob": "^11.0.0",
     "globby": "^11.0.4",
     "@napi-rs/magic-string": "0.3.4",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "uuid": "^8.3.2"
   },
   "engines": {
     "node": "^24.14.0",

--- a/packages/enclave-portal/tsconfig.json
+++ b/packages/enclave-portal/tsconfig.json
@@ -8,7 +8,7 @@
     "noEmit": true,
     "incremental": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/packages/portal-proto/global.d.ts
+++ b/packages/portal-proto/global.d.ts
@@ -1,0 +1,6 @@
+declare module "*.svg" {
+  import { FC, SVGProps } from "react";
+  import { ImageProps } from "next/image";
+  const content: FC<SVGProps<SVGElement> & Pick<ImageProps, "layout">>;
+  export default content;
+}

--- a/packages/portal-proto/next-env.d.ts
+++ b/packages/portal-proto/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/portal-proto/src/components/CollapsibleList.tsx
+++ b/packages/portal-proto/src/components/CollapsibleList.tsx
@@ -1,6 +1,5 @@
 import React, { JSX, useState } from "react";
 import { CaretDownIcon, CaretUpIcon } from "@/utils/icons";
-
 import { v4 as uuidv4 } from "uuid";
 
 export const CollapsibleList = ({

--- a/packages/portal-proto/tsconfig.json
+++ b/packages/portal-proto/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/packages/portal-proto/tsconfig.json
+++ b/packages/portal-proto/tsconfig.json
@@ -34,7 +34,8 @@
     "**/*.ts",
     "**/*.tsx",
     "src/components/ItemTypes.js",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "global.d.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description
Hoist uuid to the top. currently, core and portal-proto has its own uuid. Since we are not copying core's node module in docker, it's failing. Now it's at the root level.

## Checklist
- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
