### PR TITLE
PEAR-2663: Image downloads, 404 and font errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30020,7 +30020,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/packages/portal-proto/src/features/charts/utils.ts
+++ b/packages/portal-proto/src/features/charts/utils.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from "react";
+import { RefObject } from "react";
 
 const EXTRA_PADDING = 100;
 
@@ -36,7 +36,7 @@ const isFontRule = (rule: CSSRule): rule is CSSFontFaceRule => {
  * @returns Blob containing the new SVG content
  */
 const createSVG = async (
-  ref: MutableRefObject<HTMLElement>,
+  ref: RefObject<HTMLElement>,
   sizeFromSvg = true,
 ): Promise<Blob> => {
   const svgElement = document.createElementNS(
@@ -52,19 +52,28 @@ const createSVG = async (
 
   const styleTag = document.createElement("style");
   const styles = [];
-  // Copy styles from page into SVG
+
   for (const sheet of document.styleSheets) {
+    // Skip cross-origin stylesheets to prevent SecurityError
+    if (sheet.href && new URL(sheet.href).origin !== window.location.origin) {
+      continue;
+    }
+
     try {
       for (const rule of sheet.cssRules) {
         // For fonts we need to retrieve the font file, encode it to a data url and then embed back in svg
         if (isFontRule(rule)) {
-          const fontUrl = rule.style
+          const rawFontUrl = rule.style
             .getPropertyValue("src")
             .split("(")[1]
             .split(")")[0]
             .replace(/"|'/g, "");
-          if (fontUrl.includes("latin")) {
-            const fontFile = await fetch(fontUrl);
+
+          if (rawFontUrl.includes("latin")) {
+            const baseUrl = sheet.href ? sheet.href : window.location.href;
+            const absoluteFontUrl = new URL(rawFontUrl, baseUrl).href;
+            const fontFile = await fetch(absoluteFontUrl);
+
             const blob = await fontFile.blob();
             const base64 = await blobToBase64(blob);
             styles.push(
@@ -76,7 +85,7 @@ const createSVG = async (
         }
       }
     } catch (e) {
-      console.warn(e, sheet.href);
+      console.warn("Could not process stylesheet:", sheet.href, e);
     }
   }
   styleTag.innerHTML = styles.join("\n");
@@ -117,7 +126,7 @@ const createSVG = async (
  * @param filename - name of file to save to, extension should be included e.g. chart1.svg
  */
 export const handleDownloadSVG = async (
-  ref: MutableRefObject<HTMLElement>,
+  ref: RefObject<HTMLElement>,
   filename: string,
   sizeFromSvg = true,
 ): Promise<void> => {
@@ -135,7 +144,7 @@ export const handleDownloadSVG = async (
  * @param sizeFromSvg - whether to calculate the size based on just the chart SVG or the whole element
  */
 export const handleDownloadPNG = async (
-  ref: MutableRefObject<HTMLElement>,
+  ref: RefObject<HTMLElement>,
   filename: string,
   sizeFromSvg = true,
 ): Promise<void> => {

--- a/packages/portal-proto/src/features/cohortComparison/CohortCard/CohortTable.tsx
+++ b/packages/portal-proto/src/features/cohortComparison/CohortCard/CohortTable.tsx
@@ -35,7 +35,7 @@ const CohortTable = ({
               data-testid="text-first-cohort-cohort-comparison"
             >
               <td
-                className={`${cellClass} font-bold text-primary-dark whitespace-pre`}
+                className={`${cellClass} font-bold text-primary-dark break-words`}
                 data-testid="text-cohort-name-cohort-comparison"
               >
                 {cohorts.primary_cohort?.name}
@@ -52,7 +52,7 @@ const CohortTable = ({
               data-testid="text-second-cohort-cohort-comparison"
             >
               <td
-                className={`${cellClass} font-bold text-[#BD5800] whitespace-pre`}
+                className={`${cellClass} font-bold text-[#BD5800] break-words`}
                 data-testid="text-cohort-name-cohort-comparison"
               >
                 {cohorts.comparison_cohort?.name}


### PR DESCRIPTION
## Description
1. Addressed Next.js 16 Turbopack changes by resolving relative font paths against the compiled stylesheet's URL (sheet.href) rather than the active page URL.
2. Skipped fetching of the external stylesheets being blocked by CORS issue. Noticed it in console logs.

## verified that the download works locally now.
## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
