### PR TITLE
update proteinpaint-client to 2.182.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7523,9 +7523,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.181.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.181.0.tgz",
-      "integrity": "sha512-Bwe2RFG4LfCkVN+61YIcVUwHdNU5J6UH8aYBlrbajR+1n2AwwEuYoLF2HjK9TF9uT/Y+IR/D9RwQuxY1psrcyQ==",
+      "version": "2.182.1",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.182.1.tgz",
+      "integrity": "sha512-kG0sNXSGkfY+UdAnM8rqCI+nhM5g+QQ6RoaOoY4SS1OsqYeNECAApciP9cSGkLo28LBrvzyNeblPikAvCWhA5Q==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@so-ric/colorspace": {
@@ -31365,7 +31365,7 @@
         "@mantine/hooks": "8.3.9",
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^10.0.3",
-        "@sjcrh/proteinpaint-client": "2.181.0",
+        "@sjcrh/proteinpaint-client": "2.182.1",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",
         "filesize": "^8.0.7",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/hooks": "8.3.9",
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^10.0.3",
-    "@sjcrh/proteinpaint-client": "2.181.0",
+    "@sjcrh/proteinpaint-client": "2.182.1",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",
     "filesize": "^8.0.7",


### PR DESCRIPTION
## Description

Fixes
- https://gdc-ctds.atlassian.net/browse/SV-2763
- https://gdc-ctds.atlassian.net/browse/SV-2785
- https://gdc-ctds.atlassian.net/browse/SV-2714 (partial)

Relevant PP change log:
- restore option to replace survival series colors via legend click menu
- darken willdtype gray color to pass Section 508 contrast requirement
- show the persisted top mutated genes message in matrix plot when starting with no cohort filter and after switching cohorts
- improve the message wording when non-primary diagnoses data is not rendered for a sample or case
- correctly handle undefined item.tvs in filterSamples4assayAvailability


## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
