### PR TITLE
PEAR-2698 - cDAVE, Mutation Frequency - loading frame and hints overlap content when scrolling

### DIFF
--- a/packages/portal-proto/src/components/InputEntityList/InputEntityList.tsx
+++ b/packages/portal-proto/src/components/InputEntityList/InputEntityList.tsx
@@ -314,6 +314,7 @@ const InputEntityList: React.FC<InputEntityListProps> = ({
               events={{ hover: true, focus: true, touch: false }}
               withArrow
               withinPortal={false}
+              zIndex={302}
             >
               <ActionIcon
                 data-testid="tooltip-accepted-identifier-info"
@@ -325,7 +326,7 @@ const InputEntityList: React.FC<InputEntityListProps> = ({
             </Tooltip>
           </div>
           <div className="relative">
-            <LoadingOverlay visible={state.isFetching} />
+            <LoadingOverlay visible={state.isFetching} zIndex={301} />
             <Textarea
               data-testid="textbox-enter-identifiers"
               ref={inputRef}

--- a/packages/portal-proto/src/components/Summary/SummaryHeader.tsx
+++ b/packages/portal-proto/src/components/Summary/SummaryHeader.tsx
@@ -87,7 +87,7 @@ export const SummaryHeader = ({
       "bg-primary-vivid py-4 px-4 w-full flex flex-col shadow-lg gap-4 transition-transform duration-500 ease-in-out";
 
     const positionClasses = isModal
-      ? "sticky top-0 rounded-t-sm z-20"
+      ? "sticky top-0 rounded-t-sm z-320"
       : "sticky z-10";
 
     const transformClasses =

--- a/packages/portal-proto/src/components/Table/TableHeader.tsx
+++ b/packages/portal-proto/src/components/Table/TableHeader.tsx
@@ -25,6 +25,7 @@ interface TableHeaderProps<TData> {
   table: Table<TData>;
   columnOrder: string[];
   setColumnOrder: (order: string[]) => void;
+  baseZIndex?: number;
   customBreakpoint?: number;
 }
 
@@ -49,12 +50,15 @@ const TooltipWrapper: React.FC<{
   children: React.ReactNode;
   tooltip: string;
   searchFocused: boolean;
-}> = ({ children, tooltip, searchFocused }) => (
+  baseZIndex: number;
+}> = ({ children, tooltip, searchFocused, baseZIndex }) => (
   <Popover
     opened={searchFocused}
     position="bottom-start"
     offset={0}
     width="target"
+    withinPortal={false}
+    zIndex={baseZIndex + 1} // needs to be higher z-index when in a modal
   >
     <Popover.Target>{children}</Popover.Target>
     <Popover.Dropdown className="p-2 bg-white border rounded-t-none shadow-md border-base-lighter text-nci-gray text-sm overflow-wrap break-all rounded-b font-content">
@@ -72,11 +76,13 @@ const SearchInput: React.FC<{
   onBlur: () => void;
   placeholder?: string;
   tooltip?: string;
+  baseZIndex?: number;
 }> = ({
   searchTerm,
   placeholder,
   tooltip,
   searchFocused,
+  baseZIndex,
   onClear,
   onChange,
   onFocus,
@@ -85,7 +91,11 @@ const SearchInput: React.FC<{
   const TooltipContainer = tooltip ? TooltipWrapper : React.Fragment;
 
   return (
-    <TooltipContainer tooltip={tooltip} searchFocused={searchFocused}>
+    <TooltipContainer
+      tooltip={tooltip}
+      searchFocused={searchFocused}
+      baseZIndex={baseZIndex}
+    >
       <TextInput
         leftSection={<SearchIcon size={24} aria-hidden="true" />}
         data-testid="textbox-table-search-bar"
@@ -124,6 +134,7 @@ function TableHeader<TData>({
   table,
   columnOrder,
   setColumnOrder,
+  baseZIndex,
   customBreakpoint,
 }: TableHeaderProps<TData>) {
   const [searchTerm, setSearchTerm] = useState(search?.defaultSearchTerm ?? "");
@@ -164,6 +175,7 @@ function TableHeader<TData>({
           placeholder={search?.placeholder}
           tooltip={search?.tooltip}
           searchFocused={searchFocused}
+          baseZIndex={baseZIndex}
           onClear={handleClearClick}
           onChange={handleInputChange}
           onFocus={() => setSearchFocused(true)}

--- a/packages/portal-proto/src/components/Table/VerticalTable.tsx
+++ b/packages/portal-proto/src/components/Table/VerticalTable.tsx
@@ -66,6 +66,7 @@ export const TableXPositionContext = createContext<{
  * @param expanded  - The expanded.
  * @param setExpanded - A function that sets the expanded.
  * @param getRowId  - A function that returns the row id.
+ * @param baseZIndex  - The base z index.
  * @param customDataTestID - optional locator for test automation
  * @param customBreakpoint - custom breakpoint for header responsive behavior
  * @category Table
@@ -99,6 +100,7 @@ function VerticalTable<TData>({
   expanded,
   setExpanded,
   getRowId = getDefaultRowId,
+  baseZIndex = 0,
   customDataTestID,
   customAriaLabel,
   customBreakpoint,
@@ -223,6 +225,7 @@ function VerticalTable<TData>({
           table={table}
           columnOrder={columnOrder}
           setColumnOrder={setColumnOrder}
+          baseZIndex={baseZIndex}
           customBreakpoint={customBreakpoint}
         />
       )}

--- a/packages/portal-proto/src/components/Table/types.ts
+++ b/packages/portal-proto/src/components/Table/types.ts
@@ -93,6 +93,7 @@ export interface PaginationOptions {
  * @property expanded - optional state variable to denote expand state of a row
  * @property setExpanded - optional handle for onExpandedChange
  * @property getRowId - optional function is used to derive a unique ID for any given row
+ * @property baseZIndex - optional used to properly set z-index of table elements (e.g. tooltips)
  * @property customDataTestID - optional locator for test automation
  * @property customBreakpoint - custom breakpoint for header responsive behavior
  * @category Table
@@ -253,6 +254,10 @@ export interface TableProps<TData> {
    * optional function is used to derive a unique ID for any given row
    */
   getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string;
+  /**
+   * optional used to properly set z-index of table elements (e.g. tooltips)
+   */
+  baseZIndex?: number;
   customDataTestID?: string;
   customAriaLabel?: string;
   customBreakpoint?: number;

--- a/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
+++ b/packages/portal-proto/src/features/GenomicTables/SomaticMutationsTable/SMTableContainer.tsx
@@ -574,6 +574,7 @@ export const SMTableContainer: React.FC<SMTableContainerProps> = ({
             expanded={expanded}
             setExpanded={handleExpand}
             getRowId={getRowId}
+            baseZIndex={isModal ? 300 : 0}
           />
         </>
       )}

--- a/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.tsx
+++ b/packages/portal-proto/src/features/cDave/CDaveCard/ClinicalSurvivalPlot.tsx
@@ -121,7 +121,11 @@ const ClinicalSurvivalPlot: React.FC<ClinicalSurvivalPlotProps> = ({
     </div>
   ) : (
     <div className="relative">
-      <LoadingOverlay data-testid="loading-spinner" visible={isFetching} />
+      <LoadingOverlay
+        data-testid="loading-spinner"
+        visible={isFetching}
+        zIndex={1}
+      />
       <ExternalDownloadStateSurvivalPlot
         data={data}
         height={150}

--- a/packages/portal-proto/src/features/cases/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/cases/AnnotationsTable.tsx
@@ -302,6 +302,7 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
           enabled: true,
           tooltip: "e.g. TCGA-ZX-AA5X, c8449103-afb0-4e43-ac04-c4ef54a8cdb0",
         }}
+        baseZIndex={300}
         status={statusBooleansToDataStatus(isFetching, isSuccess, isError)}
         pagination={{
           label: "annotation",

--- a/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
+++ b/packages/portal-proto/src/features/cases/CasesView/CasesView.tsx
@@ -547,6 +547,7 @@ export const ContextualCasesView: React.FC = () => {
         columnOrder={columnOrder}
         setColumnOrder={setColumnOrder}
         getRowId={getRowId}
+        baseZIndex={300}
       />
     </div>
   );

--- a/packages/portal-proto/src/features/cases/FilesTable.tsx
+++ b/packages/portal-proto/src/features/cases/FilesTable.tsx
@@ -374,6 +374,7 @@ const FilesTable = ({ caseId }: FilesTableProps) => {
           tooltip:
             "e.g. HCM-CSHL-0062-C18.json, 4b5f5ba0-3010-4449-99d4-7bd7a6d73422",
         }}
+        baseZIndex={300}
         sorting={sorting}
         setSorting={setSorting}
         setColumnOrder={setColumnOrder}

--- a/packages/portal-proto/src/features/files/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/files/AnnotationsTable.tsx
@@ -340,6 +340,7 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
           enabled: true,
           tooltip: "e.g. TCGA-ZX-AA5X, c8449103-afb0-4e43-ac04-c4ef54a8cdb0",
         }}
+        baseZIndex={300}
         pagination={{
           ...pagination,
           label: "annotation",

--- a/packages/portal-proto/src/features/files/AssociatedCB.tsx
+++ b/packages/portal-proto/src/features/files/AssociatedCB.tsx
@@ -172,6 +172,7 @@ const AssociatedCB = ({
       }
       tableTitle={<HeaderTitle>Associated Cases/Biospecimens</HeaderTitle>}
       handleChange={handleChange}
+      baseZIndex={300}
     />
   );
 };

--- a/packages/portal-proto/src/features/projects/AnnotationsTable.tsx
+++ b/packages/portal-proto/src/features/projects/AnnotationsTable.tsx
@@ -353,6 +353,7 @@ const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
           enabled: true,
           tooltip: "e.g. TCGA-ZX-AA5X, c8449103-afb0-4e43-ac04-c4ef54a8cdb0",
         }}
+        baseZIndex={300}
         status={statusBooleansToDataStatus(isFetching, isSuccess, isError)}
         pagination={{
           label: "annotation",

--- a/packages/portal-proto/src/features/projects/PrimarySiteTable.tsx
+++ b/packages/portal-proto/src/features/projects/PrimarySiteTable.tsx
@@ -234,6 +234,7 @@ const PrimarySiteTable: React.FC<PrimarySiteTableProps> = ({
       }}
       showControls={true}
       handleChange={handleChange}
+      baseZIndex={300}
       getRowId={getRowId}
     />
   );


### PR DESCRIPTION
## Description
I put back the baseZIndex prop that was removed in https://github.com/NCI-GDC/gdc-frontend-framework/pull/1696. The `Popover` component has a default z index of 300 so that was causing it to overlap with elements when it wasn't in a modal. I'm going to write a ticket to create a proper z index hierarchy but I wanted to get this fixed without touching the whole site first. 

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
