### PR TITLE
update proteinpaint-client to version 2.191.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7263,9 +7263,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.191.2",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.191.2.tgz",
-      "integrity": "sha512-28R1K9WsXIukkEx0Red95OGu06iGU3OGquiuWkyWjPa8CCE1abgPGJPzAaRt5jNGQ4aHffxgg+MNGA2CgW/qeg==",
+      "version": "2.191.4",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.191.4.tgz",
+      "integrity": "sha512-OgFZ0PAz+FDcbaCDxTV4ThmcIGDaNl00jan8jkgFPAqkiR5mbPml18zgE3n/l4Utw/0CEr3pBRMxzIZjMCiRww==",
       "license": "SEE LICENSE IN ./LICENSE"
     },
     "node_modules/@standard-schema/spec": {
@@ -29318,7 +29318,7 @@
         "@mantine/hooks": "8.3.9",
         "@mantine/notifications": "8.3.9",
         "@react-spring/web": "^10.0.3",
-        "@sjcrh/proteinpaint-client": "2.191.2",
+        "@sjcrh/proteinpaint-client": "2.191.4",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",

--- a/packages/portal-proto/next.config.js
+++ b/packages/portal-proto/next.config.js
@@ -76,6 +76,7 @@ module.exports = {
   },
   output: "standalone",
   basePath,
+  allowedDevOrigins: ["localhost.gdc.cancer.gov"],
   experimental: {
     esmExternals: true,
   },

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -30,7 +30,7 @@
     "@mantine/hooks": "8.3.9",
     "@mantine/notifications": "8.3.9",
     "@react-spring/web": "^10.0.3",
-    "@sjcrh/proteinpaint-client": "2.191.2",
+    "@sjcrh/proteinpaint-client": "2.191.4",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
@@ -174,6 +174,7 @@ interface Mds3Arg {
     | boolean
     | {
         hardcodeCnvOnly?: boolean;
+        snvIndelOnly?: true;
       };
   geneSymbol?: string;
   tracks?: Track[];
@@ -226,7 +227,7 @@ function getLollipopTrack(
       ssm_id: props.ssm_id,
     };
   } else {
-    arg.geneSearch4GDCmds3 = true;
+    arg.geneSearch4GDCmds3 = { snvIndelOnly: true };
   }
 
   return arg;

--- a/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.unit.test.tsx
@@ -72,7 +72,7 @@ test("SSM lolliplot arguments", () => {
     attributes: [{ from: "sample_id", to: "cases.case_id", convert: true }],
     callback: runpparg.allow2selectSamples?.callback,
   });
-  expect(runpparg.geneSearch4GDCmds3).toEqual(true);
+  expect(runpparg.geneSearch4GDCmds3).toEqual({ snvIndelOnly: true });
   isDemoMode = true;
   rerender(
     <MantineProvider


### PR DESCRIPTION
## Description

ProteinPaint Fixes:
- do not show CNV in this tool

This PR branch also adds `allowedDevOrigins: ["localhost.gdc.cancer.gov"]` to `portal-proto/next.config.js`.

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
