### PR TITLE
DEV-4156 - /cohorts response wrongly identifies two properties as nonexistent (part 1 - ignoring old gene/ssm id)

### DIFF
--- a/packages/core/src/fieldConstants.ts
+++ b/packages/core/src/fieldConstants.ts
@@ -1,0 +1,11 @@
+export const FIELD_CONSTANTS = {
+  GENE_IDX_GENE_ID: "genes.gene_id",
+  SSM_IDX_SSM_ID: "ssms.ssm_id",
+};
+
+// These fields have been deprecated from being added to cohorts because they don't exist in the case_centric
+// index. However, we don't want to flag existing cohorts with these fields as being invalid
+export const COHORT_FIELD_EXCEPTIONS = [
+  FIELD_CONSTANTS.GENE_IDX_GENE_ID,
+  FIELD_CONSTANTS.SSM_IDX_SSM_ID,
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./dataAccess";
 export * from "./ts-utils";
 export * from "./constants";
 export * from "./deprecatedFields";
+export * from "./fieldConstants";
 export * from "./features/gdcapi";
 export * from "./features/gdcapi/filters";
 export * from "./features/gdcapi/gdcgraphql";

--- a/packages/portal-proto/src/features/cohortBuilder/hooks.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/hooks.ts
@@ -72,16 +72,14 @@ export const useSetupInitialCohorts = (): boolean => {
           modified_datetime: data.modified_datetime,
           saved: true,
           modified: false,
-          nonexistent_fields: data?.nonexistent_fields,
+          nonexistent_fields: (data?.nonexistent_fields || []).filter(
+            (field) => !COHORT_FIELD_EXCEPTIONS.includes(field),
+          ),
         };
-
-        const nonexistent_fields = (data?.nonexistent_fields || []).filter(
-          (field) => !COHORT_FIELD_EXCEPTIONS.includes(field),
-        );
 
         if (
           !cohortWarnings.includes(cohortData.id) &&
-          nonexistent_fields.length > 0
+          cohortData?.nonexistent_fields.length > 0
         ) {
           coreDispatch(addCohortWarning(cohortData.id));
         }

--- a/packages/portal-proto/src/features/cohortBuilder/hooks.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/hooks.ts
@@ -75,7 +75,7 @@ export const useSetupInitialCohorts = (): boolean => {
           nonexistent_fields: data?.nonexistent_fields,
         };
 
-        const nonexistent_fields = data?.nonexistent_fields.filter(
+        const nonexistent_fields = (data?.nonexistent_fields || []).filter(
           (field) => !COHORT_FIELD_EXCEPTIONS.includes(field),
         );
 

--- a/packages/portal-proto/src/features/cohortBuilder/hooks.ts
+++ b/packages/portal-proto/src/features/cohortBuilder/hooks.ts
@@ -28,6 +28,7 @@ import {
   FacetDefinitionType,
   addCohortWarning,
   selectAllCohortsWithWarnings,
+  COHORT_FIELD_EXCEPTIONS,
 } from "@gff/core";
 import { FacetCardDefinition } from "@gff/portal-components";
 import { useEnumFacets } from "@/features/facets/hooks";
@@ -74,9 +75,13 @@ export const useSetupInitialCohorts = (): boolean => {
           nonexistent_fields: data?.nonexistent_fields,
         };
 
+        const nonexistent_fields = data?.nonexistent_fields.filter(
+          (field) => !COHORT_FIELD_EXCEPTIONS.includes(field),
+        );
+
         if (
           !cohortWarnings.includes(cohortData.id) &&
-          cohortData?.nonexistent_fields
+          nonexistent_fields.length > 0
         ) {
           coreDispatch(addCohortWarning(cohortData.id));
         }


### PR DESCRIPTION
## Description
I have another branch for changing to the new fields but that change is pretty large and this one is very self-contained so I created a separate PR  

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
