### PR TITLE
supply a GDC_API argument in IDCViewerWrapper; update proteinpaint-cl…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7148,9 +7148,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.197.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.197.0.tgz",
-      "integrity": "sha512-L3KGcuBjj83ubz1fyQRafPQYX0kgJbjiaZaIBIHCC08gKTh73VBSHSSyveZeGwgxmTmmIfHTzQOEOBm/GT2zHQ==",
+      "version": "2.198.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.198.0.tgz",
+      "integrity": "sha512-cBzlDOThADb7IocaLQNHkL9+BbFoF1RSmF55R5uaBylC7Pwp+FNMtgeBBJKonCr6Mp+gxhoKkK4L4NfumRwn3A==",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "semver": "^7.8.5"
@@ -28766,7 +28766,7 @@
         "@nci-gdc/sapien": "^2.20.0",
         "@nci-gdc/survivalplot": "^2.20.0",
         "@react-spring/web": "^10.0.3",
-        "@sjcrh/proteinpaint-client": "2.197.0",
+        "@sjcrh/proteinpaint-client": "2.198.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -34,7 +34,7 @@
     "@nci-gdc/sapien": "^2.20.0",
     "@nci-gdc/survivalplot": "^2.20.0",
     "@react-spring/web": "^10.0.3",
-    "@sjcrh/proteinpaint-client": "2.197.0",
+    "@sjcrh/proteinpaint-client": "2.198.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",

--- a/packages/portal-proto/src/features/proteinpaint/IDCViewerWrapper.unit.test.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/IDCViewerWrapper.unit.test.tsx
@@ -12,7 +12,8 @@ jest.mock("@gff/core", () => ({
   buildCohortGqlOperator: jest.fn(() => filter),
   useAddCohortMutation: jest.fn(() => [() => null, { isSuccess: true }]),
   useFetchUserDetailsQuery: jest.fn(() => userDetails),
-  PROTEINPAINT_API: "host:port/basepath",
+  PROTEINPAINT_API: "protocol://host:port/basepath",
+  GDC_API: "protocol://host/basepath",
 }));
 
 jest.mock("@/hooks/useIsDemoApp", () => ({
@@ -50,6 +51,7 @@ test("IDCViewerWrapperPP arguments", () => {
   expect(runpparg.holder instanceof HTMLElement).toBe(true);
   expect(runpparg.launchIdc).toEqual(true);
   expect(runpparg.filter0).toEqual(filter);
+  expect(typeof runpparg.GDC_API).toEqual("string");
   isDemoMode = true;
   rerender(
     <MantineProvider

--- a/packages/portal-proto/src/features/proteinpaint/IDCViewerWrapperPP.tsx
+++ b/packages/portal-proto/src/features/proteinpaint/IDCViewerWrapperPP.tsx
@@ -4,7 +4,8 @@ import { runproteinpaint } from "@sjcrh/proteinpaint-client";
 import {
   useCoreSelector,
   selectCurrentCohortFilters,
-  PROTEINPAINT_API,
+  PROTEINPAINT_API, // declared in portal-proto/.env.* files
+  GDC_API, // declared in portal-proto/.env.* files
   useFetchUserDetailsQuery,
   buildCohortGqlOperator,
 } from "@gff/core";
@@ -85,6 +86,7 @@ interface IdcUiArg {
   launchIdc: true;
   genome?: string;
   filter0: any;
+  GDC_API?: string;
 }
 
 interface PpApi {
@@ -98,6 +100,7 @@ function getIdcUi(props: PpProps, filter0: any) {
     host: props.basepath || (basepath as string),
     filter0: filter0 || null,
     launchIdc: true,
+    GDC_API,
   };
   return arg;
 }

--- a/packages/portal-proto/src/features/proteinpaint/dev.sh
+++ b/packages/portal-proto/src/features/proteinpaint/dev.sh
@@ -15,7 +15,7 @@ else
 	# !!! NOTE: turbopack used to find the @sjrch/proteintpaint under node_mmodules, but has stopped working !!!
 	# a temporary fix is to do the following:
 	# 1. run `npm run dev` from the sjpp or proteinpaint repo/directory
-	# 2. on client rebundling, run `cp -r dist ~/dev/gdc-frontend-framework/node_modules/"@sjcrh"/proteinpaint-client/`
+	# 2. on rebundling from the client dir, run `cp -r dist ~/dev/gdc-frontend-framework/node_modules/"@sjcrh"/proteinpaint-client/`
 	#
 	npm unlink ../proteinpaint/client # change back to `npm link` when fixed
 	# An issue with npm link and workspaces: the non-linked @sjcrh/proteinpaint-client package


### PR DESCRIPTION
…ient to 2.198.0

## Description



Fixes client-side:
- accept a GDC_API argument for IDCViewer to avoid CORS error in qa-int/prod when requesting /cases data

Fixes server-side (from ppgdc tag 2.198.0-be8e2192c)
- Reorg GDC termdb dictionary init to use the ds.termdb.dictionary.build() hook, moving the builder from server/src into the ppgdc dataset
- Move dataset launch-time case-sample caching into a uniform ds.preInit.cacheSamples() hook: mds3 init now dispatches caching generically (dropping the ds.label=='GDC' hardcode in mds3.init.nonblocking.js), so each API-based dataset owns its own caching (GDC's gdc.initCache relocated to the ppgdc dataset)
- Route GDC dictionary term data through the ds.cohort.termdb.dictionary.get() hook, removing the GDC-specific getSampleData_dictionaryTerms_v2s path (and its variant2samples fallback) from shared server code

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
