### PR TITLE
Qa 2674 remove pillow from automation

### DIFF
--- a/holmes-py/docker-requirements.txt
+++ b/holmes-py/docker-requirements.txt
@@ -67,5 +67,5 @@ setuptools==78.1.1
     # Added this to fix a SNYK security flag
 typing-extensions==4.15.0
     # via pyee
-virtualenv==20.35.4
+virtualenv==20.36.1
     # via pre-commit

--- a/holmes-py/docker-requirements.txt
+++ b/holmes-py/docker-requirements.txt
@@ -26,8 +26,6 @@ mouseinfo==0.1.3
     # via pyautogui
 nodeenv==1.9.1
     # via pre-commit
-pillow==12.2.0
-    # via -r requirements.in
 platformdirs==4.5.0
     # via virtualenv
 playwright==1.53.0
@@ -69,5 +67,5 @@ setuptools==78.1.1
     # Added this to fix a SNYK security flag
 typing-extensions==4.15.0
     # via pyee
-virtualenv==20.36.1
+virtualenv==20.35.4
     # via pre-commit

--- a/holmes-py/requirements.in
+++ b/holmes-py/requirements.in
@@ -1,10 +1,11 @@
 pre-commit
 filelock==3.20.3
 getgauge==0.4.11
-playwright==1.53.0
+playwright==1.59.0
 protobuf==5.29.6
 grpcio==1.71.0
 pyautogui==0.9.54
 # May have to add setuptools manually to requirements.txt after running
 # 'pip-compile requirements.in'
 setuptools==78.1.1
+virtualenv==20.36.1

--- a/holmes-py/requirements.in
+++ b/holmes-py/requirements.in
@@ -1,12 +1,10 @@
 pre-commit
 filelock==3.20.3
 getgauge==0.4.11
-playwright==1.59.0
+playwright==1.53.0
 protobuf==5.29.6
 grpcio==1.71.0
-pillow==12.2.0
 pyautogui==0.9.54
 # May have to add setuptools manually to requirements.txt after running
 # 'pip-compile requirements.in'
 setuptools==78.1.1
-virtualenv==20.36.1

--- a/holmes-py/requirements.txt
+++ b/holmes-py/requirements.txt
@@ -32,11 +32,9 @@ mouseinfo==0.1.3
     # via pyautogui
 nodeenv==1.9.1
     # via pre-commit
-pillow==12.2.0
-    # via -r requirements.in
 platformdirs==4.5.0
     # via virtualenv
-playwright==1.59.0
+playwright==1.53.0
     # via -r requirements.in
 pre-commit==3.5.0
     # via -r requirements.in
@@ -81,5 +79,5 @@ setuptools==78.1.1
     # Added this to fix a SNYK security flag
 typing-extensions==4.15.0
     # via pyee
-virtualenv==20.36.1
+virtualenv==20.35.4
     # via pre-commit

--- a/holmes-py/requirements.txt
+++ b/holmes-py/requirements.txt
@@ -34,7 +34,7 @@ nodeenv==1.9.1
     # via pre-commit
 platformdirs==4.5.0
     # via virtualenv
-playwright==1.53.0
+playwright==1.59.0
     # via -r requirements.in
 pre-commit==3.5.0
     # via -r requirements.in
@@ -79,5 +79,5 @@ setuptools==78.1.1
     # Added this to fix a SNYK security flag
 typing-extensions==4.15.0
     # via pyee
-virtualenv==20.35.4
+virtualenv==20.36.1
     # via pre-commit


### PR DESCRIPTION
## Description
- Removed Pillow to resolve vulnerabilities 

Proof:
1. I built it locally and was able to run automation. The tests ran and report generated came back normal. 
2. I ran a git lab pipeline with the changes. Image was able to build and tests could execute normally. 