### PR TITLE
update proteinpaint-client to 2.202.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7182,9 +7182,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.199.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.199.0.tgz",
-      "integrity": "sha512-TJcuwnfiSNK1HMI8EIhyX5UciX5eh8vBPhRtKRwXg7ixN6J2lpd41+CMFPRBDDZRr2nkEI+suL3q8Wn+1OFxEw==",
+      "version": "2.202.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.202.0.tgz",
+      "integrity": "sha512-7w7PyO6UkKHefPQRMmkwf2VHt7YmEFP5xV4T05J5vImMZLnsl/p/D4A9pzMVRnI8ytRiLH+DoiZOKZNNxrdZhw==",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "semver": "^7.8.5"
@@ -29346,7 +29346,7 @@
         "@nci-gdc/sapien": "^2.20.0",
         "@nci-gdc/survivalplot": "^2.20.0",
         "@react-spring/web": "^10.0.3",
-        "@sjcrh/proteinpaint-client": "2.199.0",
+        "@sjcrh/proteinpaint-client": "2.202.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -34,7 +34,7 @@
     "@nci-gdc/sapien": "^2.20.0",
     "@nci-gdc/survivalplot": "^2.20.0",
     "@react-spring/web": "^10.0.3",
-    "@sjcrh/proteinpaint-client": "2.199.0",
+    "@sjcrh/proteinpaint-client": "2.202.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
## Description

### General improvements
- For age at diagnosis variable, the ui consistently shows values by unit of year and no longer by unit of day https://github.com/stjude/proteinpaint/pull/4810 
- Streamline pp backend gdc support and de-specialcasing: https://github.com/stjude/proteinpaint/pull/4798,
https://github.com/stjude/sjpp/pull/1460
- Guard against enabling dev feature toggles on production https://github.com/stjude/proteinpaint/pull/4814 
- Improve dataset validation on server launch https://github.com/stjude/proteinpaint/pull/4817 
- In correlation plot, stop unrelated actions (like closing sandbox of 2nd plot) from aborting in-flight 1st plot requests (https://github.com/stjude/proteinpaint/pull/4822, https://github.com/stjude/proteinpaint/pull/4824)
- Removed dependency Npm library image-size with vulnerability https://github.com/stjude/proteinpaint/pull/4833/ Openseadragon https://github.com/stjude/proteinpaint/pull/4826 
- Bolster e2e test
- Add purposeful fail cases to e2e tests https://github.com/stjude/sjpp/pull/1484 
- BAM track: GDC BAM slice download will not save 403 error text as a .bam file https://gdc-ctds.atlassian.net/browse/FEAT-924  https://github.com/stjude/proteinpaint/pull/4834

- Single-cell RNAseq new app
Prework for caching cell type fraction per sample https://github.com/stjude/proteinpaint/pull/4825 
- Correlation tool: Survival e2e tests (https://github.com/stjude/sjpp/pull/1472 , https://github.com/stjude/sjpp/pull/1488. https://github.com/stjude/proteinpaint/commit/d2747ecfa42f99a60d218e7ff05439f600a5cc5e 
- Convert clientside plots from js to typescript to inherit ComponentApi
  - Boxplot, scatter https://github.com/stjude/proteinpaint/pull/4830 
  - violin https://github.com/stjude/proteinpaint/pull/4847 
  - barchart https://github.com/stjude/proteinpaint/pull/4835 
  - Regression  https://github.com/stjude/proteinpaint/pull/4845
- Cox regression
  - Moved to a route https://github.com/stjude/proteinpaint/pull/4807
  - Show nonlinearity result for cubic spline https://github.com/stjude/proteinpaint/pull/4806 
  - When age at diagnosis is used as continuous variable, compute by unit of year but not day https://github.com/stjude/proteinpaint/pull/4809 
  - Auto fill Overall Survival term to outcome https://github.com/stjude/proteinpaint/pull/4818 https://github.com/stjude/sjpp/pull/1475 
  - Ui fix to move forest plot axis to top header, remove hardcoded “5 year followup” in user message from coefficient table https://github.com/stjude/proteinpaint/pull/4819 
  - e2e test
     - https://github.com/stjude/sjpp/pull/1469 
     - https://github.com/stjude/sjpp/pull/1470 
     - https://github.com/stjude/sjpp/pull/1476 
  - hide "Replace" on the cox outcome pill when the dataset has only one usable outcome term https://github.com/stjude/proteinpaint/pull/4823 
- Mutation variable allows selecting samples with specific mutation in addition to mutation class, works for single and multiple gene 
  - https://github.com/stjude/proteinpaint/pull/4829 
  - https://github.com/stjude/proteinpaint/pull/4832
  - https://github.com/stjude/proteinpaint/pull/4833/
- sv/fusion variable allow filtering by breakpoint positions
  - https://github.com/stjude/proteinpaint/pull/4841 
  - https://github.com/stjude/proteinpaint/pull/4849



## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
