### PR TITLE
update proteinpaint-client 2.207.1-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7182,9 +7182,9 @@
       }
     },
     "node_modules/@sjcrh/proteinpaint-client": {
-      "version": "2.202.0",
-      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.202.0.tgz",
-      "integrity": "sha512-7w7PyO6UkKHefPQRMmkwf2VHt7YmEFP5xV4T05J5vImMZLnsl/p/D4A9pzMVRnI8ytRiLH+DoiZOKZNNxrdZhw==",
+      "version": "2.207.1-0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-client/-/proteinpaint-client-2.207.1-0.tgz",
+      "integrity": "sha512-HPuyko6zycgQgp9KC9Mql9M+hYQ9xHgTDkew3ymxJVC+fsNXEVJquZmhsE7+J5AsjJmV0pbv14dAn0cc8adhgQ==",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "semver": "^7.8.5"
@@ -29346,7 +29346,7 @@
         "@nci-gdc/sapien": "^2.20.0",
         "@nci-gdc/survivalplot": "^2.20.0",
         "@react-spring/web": "^10.0.3",
-        "@sjcrh/proteinpaint-client": "2.202.0",
+        "@sjcrh/proteinpaint-client": "2.207.1-0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-table": "^8.9.3",
         "dayjs": "^1.11.13",

--- a/packages/portal-proto/package.json
+++ b/packages/portal-proto/package.json
@@ -34,7 +34,7 @@
     "@nci-gdc/sapien": "^2.20.0",
     "@nci-gdc/survivalplot": "^2.20.0",
     "@react-spring/web": "^10.0.3",
-    "@sjcrh/proteinpaint-client": "2.202.0",
+    "@sjcrh/proteinpaint-client": "2.207.1-0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-table": "^8.9.3",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
## Description

GDC-related features and fixes:
- GDC BAM slice download will not save 403 error text as a .bam file
- OncoMatrix row-label editing is re-enabled. for geneVariant rows, allow per-row tw.q customizaton
- Prototyped GDC differential expression tool, including hierarchical clustering in volcano plot, GSEA

## Checklist

- [ ] Added proper unit tests
- [ ] Left proper TODO messages for any remaining tasks
- [ ] Scanned for web accessibility with **aXe**, and mitigated or documented
      flagged issues

## Screenshots/Screen Recordings (if Appropriate)
